### PR TITLE
feat: merge herd-pro into herd — unified v0.9.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "herd"
-version = "0.5.0"
+version = "0.9.0"
 edition = "2021"
 authors = ["Swift Innovative Technologies"]
 description = "Intelligent Ollama router with GPU awareness"
@@ -11,7 +11,7 @@ categories = ["command-line-utilities", "network-programming"]
 
 [dependencies]
 tokio = { version = "1", features = ["full"] }
-axum = "0.7"
+axum = { version = "0.7", features = ["ws"] }
 tower = { version = "0.4", features = ["full"] }
 tower-http = { version = "0.5", features = ["trace", "cors"] }
 reqwest = { version = "0.11", features = ["json", "stream"] }
@@ -29,6 +29,7 @@ chrono = "0.4"
 dirs = "5.0"
 uuid = { version = "1", features = ["v4"] }
 self_update = { version = "0.42", features = ["archive-zip", "archive-tar", "compression-flate2", "compression-zip-deflate"] }
+rusqlite = { version = "0.31", features = ["bundled"] }
 
 [dev-dependencies]
 tokio-test = "0.4"

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Herd Roadmap
 
-**Updated:** March 9, 2026
+**Updated:** April 5, 2026
 
 ## Vision
 
@@ -55,13 +55,39 @@ No cloud dependency. No API keys exposed. Full local control.
 - Hot models warmer — `hot_models: [...]` per backend; background warmer pings every 4 min with `keep_alive: "-1"` for pre-load and OOM recovery
 - Removes `ModelHoming` and `default_model` — superseded by `hot_models` + proxy injection
 
-### v0.5.0+ — Scale & Ecosystem (Q3 2026)
+### v0.5.0 — Task Classification ✅
+
+- Keyword-based task tier classification middleware
+- Automatic model selection by complexity tier (heavy/standard/lightweight)
+- `X-Herd-Tier` response header on classified requests
+- Analytics logging with `tier` and `classified_by` fields
+- Off by default — zero overhead when disabled
+
+### v0.9.0 — Herd Pro Merge (Unified Release) ✅
+
+> **Herd Pro features merged into the public repo. Herd Pro is now archived.**
+
+- Agent session management (create, list, resume, delete with message history and TTL)
+- Built-in tool calling (read_file, write_file, list_files, run_command)
+- Permission engine — regex-based deny patterns for file and shell access
+- JSONL audit logging for tool calls and permission denials
+- WebSocket streaming for real-time agent events
+- Node registration — herd-tune scripts for auto-enrolling Ollama nodes
+- Fleet management — SQLite node registry, health polling, dashboard Fleet tab
+- Enrollment key authentication for node registration
+- Dashboard: Sessions, Fleet, and Settings (config editor) tabs
+- Config editor API (`GET/PUT /admin/config`) with secret redaction
+
+### v1.0.0+ — Scale & Ecosystem (Future)
 
 - Multi-node discovery (mDNS / static fleet config)
 - TLS termination
 - Rate limiting per client / API key
 - Plugin system for custom routing strategies
 - Distributed health consensus
+- Budget caps and cost tracking
+- Routing profiles (named presets)
+- Multi-model consensus routing
 
 ## Get Involved
 

--- a/dashboard.html
+++ b/dashboard.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Herd Dashboard</title>
+    <title>Herd Pro Dashboard</title>
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
     <style>
         * { box-sizing: border-box; margin: 0; padding: 0; }
@@ -198,6 +198,96 @@
         .latency-value { font-size: 24px; font-weight: 700; color: #fbbf24; }
         .latency-label { font-size: 12px; color: #64748b; margin-top: 4px; }
 
+        /* Sessions */
+        .sessions-header-stats {
+            display: flex; gap: 16px; align-items: center; flex-wrap: wrap;
+        }
+        .sessions-header-stats .meta-item { font-size: 12px; }
+
+        .session-card { cursor: pointer; }
+        .session-card .card-header { margin-bottom: 8px; }
+        .session-model { font-size: 14px; color: #818cf8; font-weight: 600; }
+        .session-meta { display: flex; gap: 8px; flex-wrap: wrap; }
+        .session-status { padding: 2px 8px; border-radius: 8px; font-size: 11px; font-weight: 600; text-transform: uppercase; }
+        .session-status.active { background: rgba(34, 197, 94, 0.15); color: #4ade80; }
+        .session-status.processing { background: rgba(251, 191, 36, 0.15); color: #fbbf24; }
+        .session-status.error { background: rgba(239, 68, 68, 0.15); color: #ef4444; }
+
+        .session-card.error {
+            border-color: rgba(239, 68, 68, 0.4);
+            box-shadow: 0 0 12px rgba(239, 68, 68, 0.08);
+        }
+        .session-card.error .card-name::after {
+            content: 'ERROR';
+            display: inline-block;
+            background: rgba(239, 68, 68, 0.2); color: #ef4444;
+            font-size: 9px; font-weight: 700; padding: 1px 6px;
+            border-radius: 4px; margin-left: 8px; vertical-align: middle; letter-spacing: 0.5px;
+        }
+        .session-card.processing { border-color: rgba(251, 191, 36, 0.4); }
+        .session-card.processing .card-name::after {
+            content: '';
+            display: inline-block; width: 8px; height: 8px; border-radius: 50%;
+            background: #fbbf24; margin-left: 8px; vertical-align: middle;
+            animation: processing-pulse 1.5s ease-in-out infinite;
+        }
+        @keyframes processing-pulse {
+            0%, 100% { opacity: 1; box-shadow: 0 0 0 0 rgba(251, 191, 36, 0.4); }
+            50% { opacity: 0.5; box-shadow: 0 0 8px 2px rgba(251, 191, 36, 0.3); }
+        }
+
+        /* Session Messages */
+        .msg { padding: 10px 14px; border-radius: 10px; margin-bottom: 8px; font-size: 13px; line-height: 1.5; }
+        .msg.system { background: rgba(99, 102, 241, 0.1); border-left: 3px solid #818cf8; }
+        .msg.user { background: rgba(255, 255, 255, 0.04); border-left: 3px solid #64748b; }
+        .msg.assistant { background: rgba(34, 197, 94, 0.08); border-left: 3px solid #4ade80; }
+        .msg.tool { background: rgba(251, 191, 36, 0.08); border-left: 3px solid #fbbf24; font-family: monospace; font-size: 12px; }
+        .msg-role { font-size: 11px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.5px; margin-bottom: 4px; color: #94a3b8; }
+        .msg-content { white-space: pre-wrap; word-break: break-word; max-height: 200px; overflow-y: auto; }
+        .msg-tool-calls { margin-top: 6px; font-size: 12px; color: #818cf8; }
+
+        .msg.tool.permission-denied {
+            background: rgba(239, 68, 68, 0.1);
+            border-left: 3px solid #ef4444;
+        }
+        .msg.tool.permission-denied .msg-role { color: #ef4444; }
+        .msg.tool.permission-denied::before {
+            content: 'DENIED';
+            display: inline-block;
+            background: rgba(239, 68, 68, 0.2); color: #ef4444;
+            font-size: 10px; font-weight: 700; padding: 1px 6px;
+            border-radius: 4px; margin-bottom: 6px; letter-spacing: 0.5px;
+        }
+
+        /* Session Send Message */
+        .session-send-row {
+            display: flex; gap: 8px; margin-top: 16px; padding-top: 16px;
+            border-top: 1px solid rgba(255,255,255,0.06);
+        }
+        .session-send-row input {
+            flex: 1; padding: 8px 12px; border-radius: 8px; border: 1px solid rgba(255,255,255,0.1);
+            background: rgba(255,255,255,0.04); color: #e2e8f0; font-size: 13px; outline: none;
+        }
+        .session-send-row input:focus { border-color: rgba(99,102,241,0.5); }
+        .session-send-row button {
+            padding: 8px 16px; border-radius: 8px; font-size: 13px; font-weight: 600;
+            background: rgba(99,102,241,0.2); color: #818cf8; border: 1px solid rgba(99,102,241,0.4);
+            cursor: pointer; transition: background 0.2s;
+        }
+        .session-send-row button:hover { background: rgba(99,102,241,0.3); }
+
+        /* Empty Sessions */
+        .sessions-empty { text-align: center; padding: 48px 24px; color: #64748b; }
+        .sessions-empty-icon { font-size: 36px; margin-bottom: 12px; opacity: 0.5; }
+        .sessions-empty-title { font-size: 16px; font-weight: 600; color: #94a3b8; margin-bottom: 8px; }
+        .sessions-empty-text { font-size: 13px; line-height: 1.6; max-width: 420px; margin: 0 auto; }
+        .sessions-empty-code {
+            display: inline-block; margin-top: 12px;
+            background: rgba(255,255,255,0.04); border: 1px solid rgba(255,255,255,0.08);
+            border-radius: 6px; padding: 8px 14px;
+            font-family: monospace; font-size: 12px; color: #818cf8; text-align: left;
+        }
+
         /* Footer */
         .footer {
             margin-top: 24px; padding-top: 16px;
@@ -205,6 +295,7 @@
             display: flex; justify-content: space-between;
             font-size: 12px; color: #475569;
         }
+        .footer-refresh { color: #64748b; }
 
         /* Modal */
         .modal-overlay {
@@ -236,13 +327,19 @@
         .modal-actions .btn-submit:hover { background: rgba(99, 102, 241, 0.3); }
 
         /* Toast */
-        .toast {
-            position: fixed; bottom: 24px; right: 24px; padding: 10px 18px; border-radius: 8px;
-            font-size: 13px; font-weight: 500; z-index: 200; opacity: 0; transition: opacity 0.3s;
+        .toast-container {
+            position: fixed; top: 24px; left: 50%; transform: translateX(-50%);
+            z-index: 300; display: flex; flex-direction: column; gap: 8px;
+            align-items: center; pointer-events: none;
         }
-        .toast.show { opacity: 1; }
-        .toast.success { background: rgba(34, 197, 94, 0.15); color: #4ade80; border: 1px solid rgba(34, 197, 94, 0.3); }
-        .toast.error { background: rgba(239, 68, 68, 0.15); color: #ef4444; border: 1px solid rgba(239, 68, 68, 0.3); }
+        .toast-item {
+            padding: 10px 24px; border-radius: 8px; font-size: 13px; font-weight: 500;
+            pointer-events: auto; transform: translateY(-20px); opacity: 0;
+            transition: transform 0.3s ease, opacity 0.3s ease; max-width: 500px;
+        }
+        .toast-item.show { transform: translateY(0); opacity: 1; }
+        .toast-item.success { background: rgba(34, 197, 94, 0.15); color: #4ade80; border: 1px solid rgba(34, 197, 94, 0.3); }
+        .toast-item.error { background: rgba(239, 68, 68, 0.15); color: #ef4444; border: 1px solid rgba(239, 68, 68, 0.3); }
 
         /* Empty state */
         .empty-state {
@@ -343,13 +440,105 @@
             .container { padding: 16px; }
             .stat-value { font-size: 22px; }
         }
+
+        /* Fleet Management */
+        .fleet-add-node {
+            margin-bottom: 24px; padding: 20px;
+            background: linear-gradient(135deg, #1a1a2e 0%, #16213e 100%);
+            border: 1px solid rgba(255,255,255,0.06); border-radius: 12px;
+        }
+        .fleet-add-node h3 { font-size: 16px; font-weight: 600; color: #e2e8f0; margin-bottom: 8px; }
+        .fleet-add-node p { font-size: 13px; color: #94a3b8; line-height: 1.6; }
+        .script-download-buttons { display: flex; gap: 12px; margin: 16px 0; }
+        .script-download-buttons .btn { text-decoration: none; display: inline-block; }
+        .btn-primary {
+            background: rgba(99, 102, 241, 0.2); color: #818cf8; border: 1px solid rgba(99, 102, 241, 0.4);
+            padding: 8px 18px; border-radius: 8px; font-size: 13px; font-weight: 600; cursor: pointer;
+            transition: all 0.2s;
+        }
+        .btn-primary:hover { background: rgba(99, 102, 241, 0.3); border-color: rgba(99, 102, 241, 0.6); }
+        .btn-secondary {
+            background: rgba(255,255,255,0.04); color: #94a3b8; border: 1px solid rgba(255,255,255,0.1);
+            padding: 8px 18px; border-radius: 8px; font-size: 13px; font-weight: 600; cursor: pointer;
+            transition: all 0.2s;
+        }
+        .btn-secondary:hover { background: rgba(255,255,255,0.08); border-color: rgba(255,255,255,0.2); }
+        .quick-start details { font-size: 13px; color: #94a3b8; }
+        .quick-start summary {
+            cursor: pointer; font-weight: 600; color: #818cf8; font-size: 13px;
+            padding: 4px 0; user-select: none;
+        }
+        .quick-start summary:hover { color: #a5b4fc; }
+        .instructions-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 20px; margin-top: 12px; }
+        .instructions-grid h4 { font-size: 14px; font-weight: 600; color: #e2e8f0; margin-bottom: 8px; }
+        .instructions-grid ol { padding-left: 18px; line-height: 1.8; }
+        .instructions-grid code {
+            background: rgba(0,0,0,0.3); padding: 2px 6px; border-radius: 4px;
+            font-family: 'SF Mono', 'Fira Code', monospace; font-size: 12px; color: #4ade80;
+        }
+        .fleet-table-container { margin-top: 16px; }
+        .fleet-table-container h3 {
+            font-size: 16px; font-weight: 600; color: #e2e8f0; margin-bottom: 12px;
+        }
+        .fleet-table-container h3 span { color: #64748b; font-weight: 400; }
+        .data-table {
+            width: 100%; border-collapse: collapse; font-size: 13px;
+            background: linear-gradient(135deg, #1a1a2e 0%, #16213e 100%);
+            border: 1px solid rgba(255,255,255,0.06); border-radius: 12px;
+            overflow: hidden;
+        }
+        .data-table th {
+            text-align: left; padding: 10px 14px; color: #64748b; font-weight: 600;
+            border-bottom: 1px solid rgba(255,255,255,0.06); font-size: 12px;
+            text-transform: uppercase; letter-spacing: 0.5px;
+        }
+        .data-table td {
+            padding: 10px 14px; color: #94a3b8;
+            border-bottom: 1px solid rgba(255,255,255,0.03);
+        }
+        .data-table tr:last-child td { border-bottom: none; }
+        .data-table td.empty-state { text-align: center; padding: 40px; color: #64748b; }
+        .status-dot {
+            display: inline-block; width: 8px; height: 8px;
+            border-radius: 50%; margin-right: 6px; vertical-align: middle;
+        }
+        .status-healthy { background: #4ade80; box-shadow: 0 0 6px rgba(74, 222, 128, 0.4); }
+        .status-degraded { background: #fbbf24; box-shadow: 0 0 6px rgba(251, 191, 36, 0.4); }
+        .status-unreachable { background: #ef4444; }
+        .status-disabled { background: #6b7280; }
+        .toggle-switch { position: relative; display: inline-block; width: 36px; height: 20px; vertical-align: middle; }
+        .toggle-switch input { opacity: 0; width: 0; height: 0; }
+        .toggle-slider {
+            position: absolute; cursor: pointer; inset: 0;
+            background: #4b5563; border-radius: 20px; transition: 0.2s;
+        }
+        .toggle-slider:before {
+            content: ''; position: absolute; width: 16px; height: 16px;
+            left: 2px; bottom: 2px; background: white;
+            border-radius: 50%; transition: 0.2s;
+        }
+        .toggle-switch input:checked + .toggle-slider { background: #4ade80; }
+        .toggle-switch input:checked + .toggle-slider:before { transform: translateX(16px); }
+        .inline-input {
+            background: rgba(255,255,255,0.04); border: 1px solid rgba(255,255,255,0.1);
+            color: #e2e8f0; border-radius: 6px; padding: 4px 6px; text-align: center;
+            font-size: 13px; outline: none;
+        }
+        .inline-input:focus { border-color: rgba(99, 102, 241, 0.5); }
+        .row-disabled { opacity: 0.5; }
+        .fleet-actions { display: flex; align-items: center; gap: 8px; }
+        @media (max-width: 768px) {
+            .instructions-grid { grid-template-columns: 1fr; }
+            .data-table { font-size: 12px; }
+            .data-table th, .data-table td { padding: 8px 10px; }
+        }
     </style>
 </head>
 <body>
     <div class="container">
         <!-- Header -->
         <div class="header">
-            <h1><span>&#x1F999;</span> Herd</h1>
+            <h1><span>&#x1F999;</span> Herd Pro</h1>
             <div class="header-right">
                 <div class="header-meta">
                     <span class="strategy-badge" id="strategy">--</span>
@@ -363,7 +552,7 @@
                 </div>
                 <input type="password" id="api-key-input" placeholder="API Key"
                     style="width:120px; padding:4px 8px; background:rgba(255,255,255,0.06); border:1px solid rgba(255,255,255,0.1); border-radius:6px; color:#e2e8f0; font-size:12px;"
-                    onchange="setApiKey(this.value);">
+                    onchange="setApiKey(this.value); refresh(); refreshSessions();">
                 <button class="btn" onclick="openAddModal()">+ Add Node</button>
             </div>
         </div>
@@ -397,8 +586,17 @@
             <div class="tab" data-tab="analytics" onclick="switchTab('analytics')">
                 Analytics
             </div>
+            <div class="tab" data-tab="sessions" onclick="switchTab('sessions')">
+                Sessions <span class="tab-badge" id="sessions-tab-badge">0</span>
+            </div>
             <div class="tab" data-tab="agent-guide" onclick="switchTab('agent-guide')">
                 Agent Guide
+            </div>
+            <div class="tab" data-tab="fleet" onclick="switchTab('fleet')">
+                Fleet <span class="tab-badge" id="fleet-tab-badge">0</span>
+            </div>
+            <div class="tab" data-tab="settings" onclick="switchTab('settings')">
+                Settings
             </div>
         </div>
 
@@ -443,6 +641,16 @@
                     <div class="latency-label">p99 Latency</div>
                 </div>
             </div>
+        </div>
+
+        <!-- Sessions Tab -->
+        <div class="tab-content" id="tab-sessions">
+            <div class="sessions-header-stats" id="sessions-header-stats" style="margin-bottom:16px;">
+                <span class="meta-item" id="session-count">0 active</span>
+                <span class="meta-item" id="session-tool-calls">Tool Calls: <strong>--</strong></span>
+                <span class="meta-item" id="session-denials">Denials: <strong>--</strong></span>
+            </div>
+            <div class="grid" id="sessions-grid"></div>
         </div>
 
         <!-- Agent Guide Tab -->
@@ -512,20 +720,6 @@ Content-Type: application/json
                 </div>
 
                 <div class="guide-section">
-                    <h2>Task Classification (opt-in)</h2>
-                    <p>Automatically routes requests to appropriate models by complexity when no model is specified.</p>
-                    <div class="guide-card">
-                        <h3>How It Works</h3>
-                        <ul>
-                            <li><strong>Trigger:</strong> Send a request without specifying a model</li>
-                            <li><strong>Response:</strong> Includes <code>X-Herd-Tier</code> header showing the assigned tier (<code>heavy</code>, <code>standard</code>, <code>lightweight</code>)</li>
-                            <li><strong>Skipped when:</strong> Request includes a <code>model</code> field or <code>X-Herd-Tags</code> header</li>
-                            <li><strong>Configure:</strong> Tiers and keywords in <code>herd.yaml</code> under <code>task_classifier</code></li>
-                        </ul>
-                    </div>
-                </div>
-
-                <div class="guide-section">
                     <h2>Routing Strategies</h2>
                     <p>The active strategy is shown in the header badge. It determines how Herd picks a backend for your request.</p>
                     <table class="guide-table">
@@ -589,10 +783,265 @@ Content-Type: application/json
             </div>
         </div>
 
+        <!-- Fleet Tab -->
+        <div class="tab-content" id="tab-fleet">
+            <div class="fleet-add-node">
+                <h3>Add Node to Fleet</h3>
+                <p>Run the herd-tune script on any machine with Ollama to auto-detect hardware and register with this Herd Pro instance.</p>
+
+                <div class="script-download-buttons">
+                    <a href="/api/nodes/script?os=windows" class="btn btn-primary" download>
+                        Windows (PowerShell)
+                    </a>
+                    <a href="/api/nodes/script?os=linux" class="btn btn-secondary" download>
+                        Linux (Bash)
+                    </a>
+                </div>
+
+                <div class="quick-start">
+                    <details>
+                        <summary>Quick Start Instructions</summary>
+                        <div class="instructions-grid">
+                            <div>
+                                <h4>Windows</h4>
+                                <ol>
+                                    <li>Download herd-tune.ps1 (button above)</li>
+                                    <li>Open PowerShell as Administrator on your Ollama machine</li>
+                                    <li>Run: <code>.\herd-tune.ps1 -Apply</code></li>
+                                    <li>Done &mdash; your node will appear in the fleet below</li>
+                                </ol>
+                            </div>
+                            <div>
+                                <h4>Linux</h4>
+                                <ol>
+                                    <li>Download herd-tune.sh (button above)</li>
+                                    <li>On your Ollama machine:<br>
+                                        <code>chmod +x herd-tune.sh</code><br>
+                                        <code>sudo ./herd-tune.sh --apply</code></li>
+                                    <li>Done &mdash; your node will appear in the fleet below</li>
+                                </ol>
+                            </div>
+                        </div>
+                    </details>
+                </div>
+            </div>
+
+            <div class="fleet-table-container">
+                <h3>Registered Nodes <span id="fleet-count">(0)</span></h3>
+                <table class="data-table" id="fleet-table">
+                    <thead>
+                        <tr>
+                            <th>Hostname</th>
+                            <th>GPU</th>
+                            <th>VRAM</th>
+                            <th>RAM</th>
+                            <th>Status</th>
+                            <th>Models Loaded</th>
+                            <th>Available</th>
+                            <th>Parallel</th>
+                            <th>Priority</th>
+                            <th>Actions</th>
+                        </tr>
+                    </thead>
+                    <tbody id="fleet-nodes-body">
+                        <tr><td colspan="10" class="empty-state">No nodes registered yet. Download and run herd-tune to add nodes.</td></tr>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+
+        <!-- Settings Tab -->
+        <div class="tab-content" id="tab-settings">
+            <div id="settings-locked" style="display:none; text-align:center; padding:60px 20px;">
+                <h3 style="color:#e2e8f0;">API Key Required</h3>
+                <p style="color:#94a3b8;">Enter your API key above to access settings.</p>
+            </div>
+            <div id="settings-form" style="display:none;">
+                <div id="settings-no-key-warning" style="display:none; background:#78350f; border:1px solid #d97706; border-radius:8px; padding:12px 16px; margin-bottom:20px; color:#fbbf24;">
+                    No API key is set. Admin endpoints are unprotected. Set one below.
+                </div>
+
+                <div style="display:grid; grid-template-columns:1fr 1fr; gap:20px;">
+                    <!-- Server -->
+                    <div class="stat-card">
+                        <h3 style="margin:0 0 16px; color:#e2e8f0; font-size:14px; text-transform:uppercase; letter-spacing:0.05em;">Server</h3>
+                        <label style="display:block; margin-bottom:12px;">
+                            <span style="color:#94a3b8; font-size:12px;">Host</span>
+                            <input type="text" id="cfg-server-host" style="width:100%; margin-top:4px;" placeholder="0.0.0.0">
+                        </label>
+                        <label style="display:block; margin-bottom:12px;">
+                            <span style="color:#94a3b8; font-size:12px;">Port</span>
+                            <input type="number" id="cfg-server-port" style="width:100%; margin-top:4px;" placeholder="40114">
+                        </label>
+                        <label style="display:block; margin-bottom:12px;">
+                            <span style="color:#94a3b8; font-size:12px;">API Key</span>
+                            <input type="password" id="cfg-server-apikey" style="width:100%; margin-top:4px;" placeholder="Leave blank to keep current">
+                        </label>
+                        <label style="display:block; margin-bottom:12px;">
+                            <span style="color:#94a3b8; font-size:12px;">Enrollment Key (for node registration)</span>
+                            <input type="password" id="cfg-server-enrollmentkey" style="width:100%; margin-top:4px;" placeholder="Leave blank to keep current">
+                        </label>
+                        <label style="display:block;">
+                            <span style="color:#94a3b8; font-size:12px;">Rate Limit (req/s, 0 = unlimited)</span>
+                            <input type="number" id="cfg-server-ratelimit" style="width:100%; margin-top:4px;" placeholder="0" min="0">
+                        </label>
+                    </div>
+
+                    <!-- Routing -->
+                    <div class="stat-card">
+                        <h3 style="margin:0 0 16px; color:#e2e8f0; font-size:14px; text-transform:uppercase; letter-spacing:0.05em;">Routing</h3>
+                        <label style="display:block; margin-bottom:12px;">
+                            <span style="color:#94a3b8; font-size:12px;">Strategy</span>
+                            <select id="cfg-routing-strategy" style="width:100%; margin-top:4px; padding:8px; background:#1e293b; color:#e2e8f0; border:1px solid #334155; border-radius:6px;">
+                                <option value="model_aware">Model Aware</option>
+                                <option value="priority">Priority</option>
+                                <option value="least_busy">Least Busy</option>
+                                <option value="weighted_round_robin">Weighted Round Robin</option>
+                            </select>
+                        </label>
+                        <label style="display:block; margin-bottom:12px;">
+                            <span style="color:#94a3b8; font-size:12px;">Timeout</span>
+                            <input type="text" id="cfg-routing-timeout" style="width:100%; margin-top:4px;" placeholder="120s">
+                        </label>
+                        <label style="display:block; margin-bottom:12px;">
+                            <span style="color:#94a3b8; font-size:12px;">Retry Count</span>
+                            <input type="number" id="cfg-routing-retrycount" style="width:100%; margin-top:4px;" min="0">
+                        </label>
+                        <label style="display:block;">
+                            <span style="color:#94a3b8; font-size:12px;">Default Keep Alive</span>
+                            <input type="text" id="cfg-routing-keepalive" style="width:100%; margin-top:4px;" placeholder="5m">
+                        </label>
+                    </div>
+
+                    <!-- Circuit Breaker -->
+                    <div class="stat-card">
+                        <h3 style="margin:0 0 16px; color:#e2e8f0; font-size:14px; text-transform:uppercase; letter-spacing:0.05em;">Circuit Breaker</h3>
+                        <label style="display:block; margin-bottom:12px;">
+                            <span style="color:#94a3b8; font-size:12px;">Failure Threshold</span>
+                            <input type="number" id="cfg-cb-threshold" style="width:100%; margin-top:4px;" min="1">
+                        </label>
+                        <label style="display:block; margin-bottom:12px;">
+                            <span style="color:#94a3b8; font-size:12px;">Timeout</span>
+                            <input type="text" id="cfg-cb-timeout" style="width:100%; margin-top:4px;" placeholder="120s">
+                        </label>
+                        <label style="display:block;">
+                            <span style="color:#94a3b8; font-size:12px;">Recovery Time</span>
+                            <input type="text" id="cfg-cb-recovery" style="width:100%; margin-top:4px;" placeholder="30s">
+                        </label>
+                    </div>
+
+                    <!-- Observability -->
+                    <div class="stat-card">
+                        <h3 style="margin:0 0 16px; color:#e2e8f0; font-size:14px; text-transform:uppercase; letter-spacing:0.05em;">Observability</h3>
+                        <label style="display:flex; align-items:center; gap:8px; margin-bottom:12px; color:#e2e8f0;">
+                            <input type="checkbox" id="cfg-obs-metrics"> Metrics endpoint
+                        </label>
+                        <label style="display:flex; align-items:center; gap:8px; margin-bottom:12px; color:#e2e8f0;">
+                            <input type="checkbox" id="cfg-obs-adminapi"> Admin API
+                        </label>
+                        <label style="display:flex; align-items:center; gap:8px; margin-bottom:12px; color:#e2e8f0;">
+                            <input type="checkbox" id="cfg-obs-tracing"> Tracing
+                        </label>
+                        <label style="display:block; margin-bottom:12px;">
+                            <span style="color:#94a3b8; font-size:12px;">Log Retention (days)</span>
+                            <input type="number" id="cfg-obs-retention" style="width:100%; margin-top:4px;" min="1">
+                        </label>
+                        <label style="display:block; margin-bottom:12px;">
+                            <span style="color:#94a3b8; font-size:12px;">Max Log Size (MB)</span>
+                            <input type="number" id="cfg-obs-maxsize" style="width:100%; margin-top:4px;" min="0">
+                        </label>
+                        <label style="display:block;">
+                            <span style="color:#94a3b8; font-size:12px;">Max Log Files</span>
+                            <input type="number" id="cfg-obs-maxfiles" style="width:100%; margin-top:4px;" min="1">
+                        </label>
+                    </div>
+
+                    <!-- Agent -->
+                    <div class="stat-card">
+                        <h3 style="margin:0 0 16px; color:#e2e8f0; font-size:14px; text-transform:uppercase; letter-spacing:0.05em;">Agent</h3>
+                        <label style="display:flex; align-items:center; gap:8px; margin-bottom:12px; color:#e2e8f0;">
+                            <input type="checkbox" id="cfg-agent-enabled"> Enabled
+                        </label>
+                        <label style="display:block; margin-bottom:12px;">
+                            <span style="color:#94a3b8; font-size:12px;">Max Sessions</span>
+                            <input type="number" id="cfg-agent-maxsessions" style="width:100%; margin-top:4px;" min="1">
+                        </label>
+                        <label style="display:block; margin-bottom:12px;">
+                            <span style="color:#94a3b8; font-size:12px;">Max Tool Rounds</span>
+                            <input type="number" id="cfg-agent-maxrounds" style="width:100%; margin-top:4px;" min="1">
+                        </label>
+                        <label style="display:block; margin-bottom:12px;">
+                            <span style="color:#94a3b8; font-size:12px;">Session TTL (minutes)</span>
+                            <input type="number" id="cfg-agent-ttl" style="width:100%; margin-top:4px;" min="1">
+                        </label>
+                        <label style="display:block;">
+                            <span style="color:#94a3b8; font-size:12px;">Default Model</span>
+                            <input type="text" id="cfg-agent-model" style="width:100%; margin-top:4px;" placeholder="e.g. llama3:8b">
+                        </label>
+                    </div>
+
+                    <!-- Model Warmer -->
+                    <div class="stat-card">
+                        <h3 style="margin:0 0 16px; color:#e2e8f0; font-size:14px; text-transform:uppercase; letter-spacing:0.05em;">Model Warmer</h3>
+                        <label style="display:block; margin-bottom:12px;">
+                            <span style="color:#94a3b8; font-size:12px;">Interval (seconds, min 10)</span>
+                            <input type="number" id="cfg-warmer-interval" style="width:100%; margin-top:4px;" min="10">
+                        </label>
+                    </div>
+                </div>
+
+                <!-- Backends Config -->
+                <div class="stat-card" style="margin-top:20px;">
+                    <div style="display:flex; justify-content:space-between; align-items:center; margin-bottom:16px;">
+                        <h3 style="margin:0; color:#e2e8f0; font-size:14px; text-transform:uppercase; letter-spacing:0.05em;">Backends</h3>
+                        <button class="btn btn-primary btn-sm" onclick="addSettingsBackend()">+ Add Backend</button>
+                    </div>
+                    <table class="data-table" id="settings-backends-table">
+                        <thead>
+                            <tr>
+                                <th>Name</th>
+                                <th>URL</th>
+                                <th>Priority</th>
+                                <th>Hot Models</th>
+                                <th>Tags</th>
+                                <th>Actions</th>
+                            </tr>
+                        </thead>
+                        <tbody id="settings-backends-body"></tbody>
+                    </table>
+                </div>
+
+                <div style="margin-top:20px; display:flex; gap:12px; justify-content:flex-end;">
+                    <button class="btn btn-secondary" onclick="loadConfig()">Reset</button>
+                    <button class="btn btn-primary" onclick="saveConfig()">Save &amp; Reload</button>
+                </div>
+                <p style="color:#64748b; font-size:12px; margin-top:8px; text-align:right;">
+                    Some settings (host, port, api_key, rate_limit) require a restart to take effect.
+                </p>
+            </div>
+        </div>
+
+        <!-- Session Detail Modal -->
+        <div class="modal-overlay" id="session-modal-overlay">
+            <div class="modal" style="width:700px;max-height:80vh;display:flex;flex-direction:column;">
+                <h2 id="session-modal-title">Session</h2>
+                <div id="session-messages" style="margin-top:16px;flex:1;overflow-y:auto;"></div>
+                <div class="session-send-row">
+                    <input type="text" id="session-send-input" placeholder="Send a message..." onkeydown="if(event.key==='Enter')sendSessionMessage()">
+                    <button onclick="sendSessionMessage()">Send</button>
+                </div>
+                <div class="modal-actions">
+                    <button class="btn-cancel" onclick="closeSessionModal()">Close</button>
+                    <button class="btn btn-danger btn-sm" id="session-delete-btn">Delete Session</button>
+                </div>
+            </div>
+        </div>
+
         <!-- Footer -->
         <div class="footer">
             <span id="last-update">Updating...</span>
-            <span id="version-info">Herd v0.4.1</span>
+            <span class="footer-refresh" id="refresh-countdown">Refreshing in 5s</span>
+            <span id="version-info">Herd Pro v0.1.0</span>
         </div>
     </div>
 
@@ -641,13 +1090,16 @@ Content-Type: application/json
         </div>
     </div>
 
-    <!-- Toast -->
-    <div class="toast" id="toast"></div>
+    <!-- Toast container -->
+    <div class="toast-container" id="toast-container"></div>
 
     <script>
         let timelineChart, modelChart, backendChart;
+        let currentSessionId = null;
         let refreshCountdown = 5;
-        let countdownTimer;
+        let countdownInterval = null;
+        let fleetNodes = [];
+        let fleetRefreshInterval = null;
 
         // -- Tab System --
         function switchTab(name) {
@@ -664,13 +1116,55 @@ Content-Type: application/json
                     backendChart?.resize();
                 }, 50);
             }
+            // Fleet tab: start/stop auto-refresh
+            if (name === 'fleet') {
+                startFleetRefresh();
+            } else {
+                stopFleetRefresh();
+            }
+            // Settings tab: load config
+            if (name === 'settings') {
+                loadConfig();
+            }
         }
 
         // Restore last tab
         const savedTab = sessionStorage.getItem('herd-tab');
         if (savedTab) switchTab(savedTab);
 
-        // -- API Key Auth --
+        // -- Helpers --
+        function formatIdle(seconds) {
+            if (seconds < 60) return `${seconds}s`;
+            if (seconds < 3600) return `${Math.floor(seconds / 60)}m ${seconds % 60}s`;
+            return `${Math.floor(seconds / 3600)}h ${Math.floor((seconds % 3600) / 60)}m`;
+        }
+
+        function formatMs(ms) {
+            if (ms < 1000) return `${ms}ms`;
+            return `${(ms / 1000).toFixed(1)}s`;
+        }
+
+        function timeAgo(seconds) {
+            if (seconds < 60) return `${seconds}s ago`;
+            if (seconds < 3600) return `${Math.floor(seconds / 60)}m ago`;
+            if (seconds < 86400) return `${Math.floor(seconds / 3600)}h ago`;
+            return `${Math.floor(seconds / 86400)}d ago`;
+        }
+
+        function gpuClass(pct) {
+            if (pct < 50) return 'low';
+            if (pct < 80) return 'medium';
+            return 'high';
+        }
+
+        function truncate(str, len) {
+            return str.length > len ? str.substring(0, len) + '...' : str;
+        }
+
+        function escapeHtml(str) {
+            return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+        }
+
         function getApiKey() {
             return localStorage.getItem('herd-api-key') || '';
         }
@@ -692,33 +1186,21 @@ Content-Type: application/json
             return fetch(url, options);
         }
 
-        // -- Helpers --
-        function formatIdle(seconds) {
-            if (seconds < 60) return `${seconds}s`;
-            if (seconds < 3600) return `${Math.floor(seconds / 60)}m ${seconds % 60}s`;
-            return `${Math.floor(seconds / 3600)}h ${Math.floor((seconds % 3600) / 60)}m`;
-        }
-
-        function formatMs(ms) {
-            if (ms < 1000) return `${ms}ms`;
-            return `${(ms / 1000).toFixed(1)}s`;
-        }
-
-        function gpuClass(pct) {
-            if (pct < 50) return 'low';
-            if (pct < 80) return 'medium';
-            return 'high';
-        }
-
-        function truncate(str, len) {
-            return str.length > len ? str.substring(0, len) + '...' : str;
-        }
-
+        // -- Toast --
         function showToast(msg, type = 'success') {
-            const t = document.getElementById('toast');
-            t.textContent = msg;
-            t.className = `toast show ${type}`;
-            setTimeout(() => t.className = 'toast', 3000);
+            const container = document.getElementById('toast-container');
+            const el = document.createElement('div');
+            el.className = `toast-item ${type}`;
+            el.textContent = msg;
+            container.appendChild(el);
+            requestAnimationFrame(() => {
+                requestAnimationFrame(() => el.classList.add('show'));
+            });
+            setTimeout(() => {
+                el.classList.remove('show');
+                el.addEventListener('transitionend', () => el.remove(), { once: true });
+                setTimeout(() => { if (el.parentNode) el.remove(); }, 400);
+            }, 5000);
         }
 
         // -- Modal --
@@ -772,7 +1254,7 @@ Content-Type: application/json
             const listEl = document.getElementById('model-list');
             listEl.innerHTML = '<div style="font-size:12px; color:#64748b; padding:8px;">Loading models...</div>';
             try {
-                const res = await authFetch(`/admin/backends/${name}/models`);
+                const res = await fetch(`/admin/backends/${name}/models`);
                 const data = await res.json();
                 const models = data.models || [];
                 if (models.length === 0) {
@@ -809,7 +1291,7 @@ Content-Type: application/json
         async function deleteModel(backend, model) {
             if (!confirm(`Delete ${model} from ${backend}?`)) return;
             try {
-                const res = await authFetch(`/admin/backends/${backend}/models/${encodeURIComponent(model)}`, { method: 'DELETE' });
+                const res = await fetch(`/admin/backends/${backend}/models/${encodeURIComponent(model)}`, { method: 'DELETE' });
                 if (res.ok) {
                     showToast(`Deleted ${model}`);
                     loadBackendModels(backend);
@@ -840,7 +1322,7 @@ Content-Type: application/json
             barEl.style.width = '0%';
 
             try {
-                const res = await authFetch(`/admin/backends/${name}/pull`, {
+                const res = await fetch(`/admin/backends/${name}/pull`, {
                     method: 'POST',
                     headers: {'Content-Type': 'application/json'},
                     body: JSON.stringify({name: model}),
@@ -910,7 +1392,7 @@ Content-Type: application/json
                     const body = { name, url, priority };
                     if (modelFilter) body.model_filter = modelFilter;
                     const res = await authFetch('/admin/backends', {
-                        method: 'POST', headers: {'Content-Type': 'application/json'}, body: JSON.stringify(body)
+                        method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body)
                     });
                     if (!res.ok) { const t = await res.text(); throw new Error(t); }
                     showToast(`Added ${name}`);
@@ -920,7 +1402,7 @@ Content-Type: application/json
                     if (vramMb) body.vram_override_mb = vramMb;
                     const originalName = document.getElementById('modal-original-name').value;
                     const res = await authFetch(`/admin/backends/${originalName}`, {
-                        method: 'PUT', headers: {'Content-Type': 'application/json'}, body: JSON.stringify(body)
+                        method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body)
                     });
                     if (!res.ok) { const t = await res.text(); throw new Error(t); }
                     showToast(`Updated ${originalName}`);
@@ -966,13 +1448,13 @@ Content-Type: application/json
                         <div class="gpu-bar-label"><span>VRAM</span><span>${usedGB}/${totalGB} GB</span></div>
                         <div class="gpu-bar-track"><div class="gpu-bar-fill ${gpuClass(pct)}" style="width:${pct}%"></div></div>
                     </div>
-                    <div class="gpu-stats"><span class="gpu-stat">${g.temperature.toFixed(0)}°C</span></div>
+                    <div class="gpu-stats"><span class="gpu-stat">${g.temperature.toFixed(0)}\u00B0C</span></div>
                 `;
             }
 
             let tagsHtml = '';
             if (b.tags && b.tags.length > 0) {
-                tagsHtml = `<div class="tags-row">${b.tags.map(t => `<span class="tag">${t}</span>`).join('')}</div>`;
+                tagsHtml = `<div class="tags-row">${b.tags.map(t => `<span class="tag">${escapeHtml(t)}</span>`).join('')}</div>`;
             }
 
             let idleHtml = '';
@@ -991,13 +1473,13 @@ Content-Type: application/json
             return `
                 <div class="card ${isOnline ? '' : 'offline'}">
                     <div class="card-header">
-                        <span class="card-name">${b.name}</span>
+                        <span class="card-name">${escapeHtml(b.name)}</span>
                         <div class="card-actions">
                             <button class="btn btn-sm" onclick="openEditModal('${b.name}')">Edit</button>
                             <button class="btn btn-sm btn-danger" onclick="removeBackend('${b.name}')">&#x2715;</button>
                         </div>
                     </div>
-                    <div class="card-url">${urlDisplay}</div>
+                    <div class="card-url">${escapeHtml(urlDisplay)}</div>
                     ${tagsHtml}
                     <div class="meta">
                         <span class="meta-item">P: <strong>${b.priority}</strong></span>
@@ -1063,7 +1545,8 @@ Content-Type: application/json
             });
         }
 
-        async function updateCharts() {
+        // -- Update Stats & Charts from Analytics --
+        async function updateAnalytics() {
             try {
                 const res = await fetch('/analytics?hours=24');
                 const data = await res.json();
@@ -1114,6 +1597,7 @@ Content-Type: application/json
             }
         }
 
+        // -- Check for Update --
         async function checkUpdate() {
             try {
                 const res = await fetch('/update');
@@ -1124,8 +1608,10 @@ Content-Type: application/json
                     badge.style.display = 'inline-block';
                     badge.onclick = () => window.open(data.download_url, '_blank');
                 }
-                document.getElementById('version-info').textContent = `Herd v${data.current}`;
-            } catch (e) {}
+                document.getElementById('version-info').textContent = `Herd Pro v${data.current}`;
+            } catch (e) {
+                console.error('Update check failed:', e);
+            }
         }
 
         // -- Main Refresh --
@@ -1137,9 +1623,11 @@ Content-Type: application/json
                     fetch('/gpu').catch(() => null),
                 ]);
                 const data = await statusRes.json();
-                const all = [...(data.healthy_backends || []), ...(data.unhealthy_backends || [])];
+                const healthy = data.healthy_backends || [];
+                const unhealthy = data.unhealthy_backends || [];
+                const all = [...healthy, ...unhealthy];
                 const timeout = data.idle_timeout_minutes || 30;
-                const healthyCount = (data.healthy_backends || []).length;
+                const healthyCount = healthy.length;
 
                 // GPU map
                 let gpuMap = {};
@@ -1172,31 +1660,480 @@ Content-Type: application/json
             }
         }
 
-        // Countdown timer
+        // -- Session Rendering --
+        function renderSessionCard(s) {
+            const age = Math.floor((Date.now() / 1000) - s.created_at);
+            const statusClass = (s.status === 'error' || s.status === 'processing') ? ` ${s.status}` : '';
+            return `
+                <div class="card session-card${statusClass}" onclick="openSessionDetail('${s.id}')">
+                    <div class="card-header">
+                        <span class="card-name">${s.id.substring(0, 8)}\u2026</span>
+                        <span class="session-status ${s.status}">${s.status}</span>
+                    </div>
+                    <div class="session-model">${escapeHtml(s.model)}</div>
+                    <div class="session-meta" style="margin-top:8px;">
+                        <span class="meta-item">Messages: <strong>${s.message_count}</strong></span>
+                        <span class="meta-item"><strong>${timeAgo(age)}</strong></span>
+                    </div>
+                </div>
+            `;
+        }
+
+        async function refreshSessions() {
+            try {
+                const res = await authFetch('/agent/sessions');
+                if (res.status === 404 || res.status === 405) {
+                    document.querySelector('[data-tab="sessions"]').style.display = 'none';
+                    return;
+                }
+                const sessions = await res.json();
+                const grid = document.getElementById('sessions-grid');
+                const countEl = document.getElementById('session-count');
+                const badge = document.getElementById('sessions-tab-badge');
+
+                const activeCount = sessions.filter(s => s.status === 'active' || s.status === 'processing').length;
+                countEl.innerHTML = `${activeCount} active / ${sessions.length} total`;
+                badge.textContent = activeCount;
+
+                if (sessions.length === 0) {
+                    grid.innerHTML = `
+                        <div class="sessions-empty" style="grid-column: 1 / -1;">
+                            <div class="sessions-empty-icon">&#x1F916;</div>
+                            <div class="sessions-empty-title">No active sessions</div>
+                            <div class="sessions-empty-text">
+                                Agent sessions are created via the API. Send a POST request to start a conversation:
+                                <code class="sessions-empty-code">curl -X POST /agent/sessions \\
+  -H "Content-Type: application/json" \\
+  -d '{"model": "your-model"}'</code>
+                            </div>
+                        </div>
+                    `;
+                } else {
+                    grid.innerHTML = sessions.map(renderSessionCard).join('');
+                }
+
+                // Fetch agent analytics for header stats
+                try {
+                    const agentRes = await authFetch('/analytics/agent');
+                    if (agentRes.ok) {
+                        const agentData = await agentRes.json();
+                        const toolCalls = agentData.total_tool_calls ?? agentData.tool_calls ?? '--';
+                        const denials = agentData.permission_denials ?? agentData.denials ?? '--';
+                        document.getElementById('session-tool-calls').innerHTML = `Tool Calls: <strong>${toolCalls}</strong>`;
+                        document.getElementById('session-denials').innerHTML = `Denials: <strong>${denials}</strong>`;
+                    }
+                } catch (_) { /* agent analytics endpoint may not exist */ }
+
+            } catch (e) {
+                // Agent API likely not enabled, hide tab
+            }
+        }
+
+        // -- Session Detail --
+        function renderMessage(m) {
+            let extra = '';
+            if (m.tool_calls && m.tool_calls.length > 0) {
+                extra = '<div class="msg-tool-calls">Tools: ' +
+                    m.tool_calls.map(tc => `<strong>${escapeHtml(tc.name)}</strong>`).join(', ') + '</div>';
+            }
+            const content = m.content.length > 2000 ? m.content.substring(0, 2000) + '\u2026' : m.content;
+            const isDenied = m.role === 'tool' && /denied|permission denied/i.test(m.content);
+            const deniedClass = isDenied ? ' permission-denied' : '';
+            return `
+                <div class="msg ${m.role}${deniedClass}">
+                    <div class="msg-role">${escapeHtml(m.role)}${m.tool_call_id ? ' (' + escapeHtml(m.tool_call_id) + ')' : ''}</div>
+                    <div class="msg-content">${escapeHtml(content)}</div>
+                    ${extra}
+                </div>
+            `;
+        }
+
+        async function openSessionDetail(id) {
+            currentSessionId = id;
+            try {
+                const res = await authFetch(`/agent/sessions/${id}`);
+                if (!res.ok) { showToast('Session not found', 'error'); return; }
+                const session = await res.json();
+                document.getElementById('session-modal-title').textContent =
+                    `Session ${id.substring(0, 8)}\u2026 (${session.model})`;
+                document.getElementById('session-messages').innerHTML =
+                    session.messages.map(renderMessage).join('');
+                document.getElementById('session-send-input').value = '';
+                document.getElementById('session-delete-btn').onclick = async () => {
+                    if (!confirm('Delete this session?')) return;
+                    try {
+                        const delRes = await authFetch(`/agent/sessions/${id}`, { method: 'DELETE' });
+                        if (!delRes.ok) throw new Error(`Delete failed (${delRes.status})`);
+                        closeSessionModal();
+                        refreshSessions();
+                        showToast('Session deleted');
+                    } catch (delErr) {
+                        showToast(`Failed to delete session: ${delErr.message}`, 'error');
+                    }
+                };
+                document.getElementById('session-modal-overlay').classList.add('active');
+            } catch (e) {
+                showToast(`Error: ${e.message}`, 'error');
+            }
+        }
+
+        async function sendSessionMessage() {
+            if (!currentSessionId) return;
+            const input = document.getElementById('session-send-input');
+            const message = input.value.trim();
+            if (!message) return;
+            input.value = '';
+            try {
+                const res = await authFetch(`/agent/sessions/${currentSessionId}/messages`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ content: message })
+                });
+                if (!res.ok) throw new Error(`Send failed (${res.status})`);
+                showToast('Message sent');
+                // Refresh the modal content
+                openSessionDetail(currentSessionId);
+            } catch (e) {
+                showToast(`Failed to send: ${e.message}`, 'error');
+            }
+        }
+
+        function closeSessionModal() {
+            document.getElementById('session-modal-overlay').classList.remove('active');
+            currentSessionId = null;
+        }
+
+        // -- Fleet Management --
+
+        async function fetchFleetNodes() {
+            try {
+                const resp = await fetch('/api/nodes');
+                if (!resp.ok) return;
+                const data = await resp.json();
+                fleetNodes = data.nodes || [];
+                renderFleetTable();
+            } catch (e) {
+                console.error('Failed to fetch fleet nodes:', e);
+            }
+        }
+
+        function renderFleetTable() {
+            const tbody = document.getElementById('fleet-nodes-body');
+            const countEl = document.getElementById('fleet-count');
+            const badgeEl = document.getElementById('fleet-tab-badge');
+            if (!tbody) return;
+
+            countEl.textContent = `(${fleetNodes.length})`;
+            badgeEl.textContent = fleetNodes.length;
+
+            if (fleetNodes.length === 0) {
+                tbody.innerHTML = '<tr><td colspan="10" class="empty-state">No nodes registered yet. Download and run herd-tune to add nodes.</td></tr>';
+                return;
+            }
+
+            tbody.innerHTML = fleetNodes.map(node => {
+                const statusClass = node.status === 'healthy' ? 'status-healthy' :
+                                   node.status === 'degraded' ? 'status-degraded' :
+                                   node.status === 'disabled' ? 'status-disabled' : 'status-unreachable';
+                const statusDot = `<span class="status-dot ${statusClass}"></span>`;
+                const modelsLoaded = (node.models_loaded || []).join(', ') || '\u2014';
+                const vramGB = node.vram_mb ? (node.vram_mb / 1024).toFixed(1) + ' GB' : '\u2014';
+                const ramGB = node.ram_mb ? (node.ram_mb / 1024).toFixed(1) + ' GB' : '\u2014';
+                const enabledToggle = `<label class="toggle-switch">
+                    <input type="checkbox" ${node.enabled ? 'checked' : ''} onchange="toggleNodeEnabled('${node.id}', this.checked)">
+                    <span class="toggle-slider"></span>
+                </label>`;
+
+                return `<tr class="${!node.enabled ? 'row-disabled' : ''}">
+                    <td><strong>${escapeHtml(node.hostname || '')}</strong><br><small style="color:#64748b;">${escapeHtml(node.ollama_url || '')}</small></td>
+                    <td>${escapeHtml(node.gpu || '\u2014')}</td>
+                    <td>${vramGB}</td>
+                    <td>${ramGB}</td>
+                    <td>${statusDot} ${escapeHtml(node.status || 'unknown')}</td>
+                    <td><small>${escapeHtml(modelsLoaded)}</small></td>
+                    <td>${node.models_available || 0}</td>
+                    <td>${node.max_concurrent || 0}</td>
+                    <td>
+                        <input type="number" class="inline-input" value="${node.priority || 50}" min="1" max="100"
+                            onchange="updateNodePriority('${node.id}', this.value)" style="width:60px">
+                    </td>
+                    <td>
+                        <div class="fleet-actions">
+                            ${enabledToggle}
+                            <button class="btn btn-sm btn-danger" onclick="removeNode('${node.id}', '${escapeHtml(node.hostname || '')}')">&#x2715;</button>
+                        </div>
+                    </td>
+                </tr>`;
+            }).join('');
+        }
+
+        async function toggleNodeEnabled(id, enabled) {
+            try {
+                await authFetch(`/api/nodes/${id}`, {
+                    method: 'PUT',
+                    headers: {'Content-Type': 'application/json'},
+                    body: JSON.stringify({ enabled })
+                });
+                fetchFleetNodes();
+            } catch (e) {
+                console.error('Failed to toggle node:', e);
+                showToast('Failed to toggle node', 'error');
+            }
+        }
+
+        async function updateNodePriority(id, priority) {
+            try {
+                await authFetch(`/api/nodes/${id}`, {
+                    method: 'PUT',
+                    headers: {'Content-Type': 'application/json'},
+                    body: JSON.stringify({ priority: parseInt(priority) })
+                });
+            } catch (e) {
+                console.error('Failed to update priority:', e);
+                showToast('Failed to update priority', 'error');
+            }
+        }
+
+        async function removeNode(id, hostname) {
+            if (!confirm(`Remove node "${hostname}" from fleet?`)) return;
+            try {
+                await authFetch(`/api/nodes/${id}`, { method: 'DELETE' });
+                showToast(`Removed ${hostname}`);
+                fetchFleetNodes();
+            } catch (e) {
+                console.error('Failed to remove node:', e);
+                showToast('Failed to remove node', 'error');
+            }
+        }
+
+        function startFleetRefresh() {
+            fetchFleetNodes();
+            if (fleetRefreshInterval) clearInterval(fleetRefreshInterval);
+            fleetRefreshInterval = setInterval(fetchFleetNodes, 5000);
+        }
+
+        function stopFleetRefresh() {
+            if (fleetRefreshInterval) {
+                clearInterval(fleetRefreshInterval);
+                fleetRefreshInterval = null;
+            }
+        }
+
+        // -- Settings / Config Editor --
+        let settingsBackends = [];
+
+        async function loadConfig() {
+            const resp = await authFetch('/admin/config');
+            if (resp.status === 401) {
+                document.getElementById('settings-locked').style.display = 'block';
+                document.getElementById('settings-form').style.display = 'none';
+                return;
+            }
+            document.getElementById('settings-locked').style.display = 'none';
+            document.getElementById('settings-form').style.display = 'block';
+
+            const config = await resp.json();
+
+            // Server
+            document.getElementById('cfg-server-host').value = config.server?.host || '';
+            document.getElementById('cfg-server-port').value = config.server?.port || 40114;
+            document.getElementById('cfg-server-apikey').value = '';
+            document.getElementById('cfg-server-apikey').placeholder =
+                config.server?.api_key === '********' ? 'Set (leave blank to keep)' : 'Not set';
+            document.getElementById('cfg-server-enrollmentkey').value = '';
+            document.getElementById('cfg-server-enrollmentkey').placeholder =
+                config.server?.enrollment_key === '********' ? 'Set (leave blank to keep)' : 'Auto-generated';
+            document.getElementById('cfg-server-ratelimit').value = config.server?.rate_limit || 0;
+
+            // Show warning if no API key
+            document.getElementById('settings-no-key-warning').style.display =
+                (!config.server?.api_key || config.server?.api_key !== '********') ? 'block' : 'none';
+
+            // Routing
+            document.getElementById('cfg-routing-strategy').value = config.routing?.strategy || 'model_aware';
+            document.getElementById('cfg-routing-timeout').value = config.routing?.timeout || '120s';
+            document.getElementById('cfg-routing-retrycount').value = config.routing?.retry_count ?? 2;
+            document.getElementById('cfg-routing-keepalive').value = config.routing?.default_keep_alive || '5m';
+
+            // Circuit breaker
+            document.getElementById('cfg-cb-threshold').value = config.circuit_breaker?.failure_threshold ?? 5;
+            document.getElementById('cfg-cb-timeout').value = config.circuit_breaker?.timeout || '120s';
+            document.getElementById('cfg-cb-recovery').value = config.circuit_breaker?.recovery_time || '30s';
+
+            // Observability
+            document.getElementById('cfg-obs-metrics').checked = config.observability?.metrics ?? true;
+            document.getElementById('cfg-obs-adminapi').checked = config.observability?.admin_api ?? false;
+            document.getElementById('cfg-obs-tracing').checked = config.observability?.tracing ?? false;
+            document.getElementById('cfg-obs-retention').value = config.observability?.log_retention_days ?? 7;
+            document.getElementById('cfg-obs-maxsize').value = config.observability?.log_max_size_mb ?? 100;
+            document.getElementById('cfg-obs-maxfiles').value = config.observability?.log_max_files ?? 5;
+
+            // Agent
+            document.getElementById('cfg-agent-enabled').checked = config.agent?.enabled ?? false;
+            document.getElementById('cfg-agent-maxsessions').value = config.agent?.max_sessions ?? 100;
+            document.getElementById('cfg-agent-maxrounds').value = config.agent?.max_tool_rounds ?? 10;
+            document.getElementById('cfg-agent-ttl').value = config.agent?.session_ttl_minutes ?? 60;
+            document.getElementById('cfg-agent-model').value = config.agent?.default_model || '';
+
+            // Model warmer
+            document.getElementById('cfg-warmer-interval').value = config.model_warmer?.interval_secs ?? 240;
+
+            // Backends
+            settingsBackends = (config.backends || []).map(b => ({...b}));
+            renderSettingsBackends();
+        }
+
+        function renderSettingsBackends() {
+            const tbody = document.getElementById('settings-backends-body');
+            if (!settingsBackends.length) {
+                tbody.innerHTML = '<tr><td colspan="6" class="empty-state">No backends configured.</td></tr>';
+                return;
+            }
+            tbody.innerHTML = settingsBackends.map((b, i) => `<tr>
+                <td><input type="text" value="${escapeHtml(b.name)}" onchange="settingsBackends[${i}].name=this.value" style="width:100%;"></td>
+                <td><input type="text" value="${escapeHtml(b.url)}" onchange="settingsBackends[${i}].url=this.value" style="width:100%;"></td>
+                <td><input type="number" value="${b.priority}" onchange="settingsBackends[${i}].priority=parseInt(this.value)" style="width:60px;" min="0"></td>
+                <td><input type="text" value="${(b.hot_models||[]).join(', ')}" onchange="settingsBackends[${i}].hot_models=this.value.split(',').map(s=>s.trim()).filter(Boolean)" style="width:100%;"></td>
+                <td><input type="text" value="${(b.tags||[]).join(', ')}" onchange="settingsBackends[${i}].tags=this.value.split(',').map(s=>s.trim()).filter(Boolean)" style="width:100%;"></td>
+                <td><button class="btn btn-danger btn-sm" onclick="settingsBackends.splice(${i},1);renderSettingsBackends()">Remove</button></td>
+            </tr>`).join('');
+        }
+
+        function addSettingsBackend() {
+            settingsBackends.push({ name: '', url: '', priority: 50, hot_models: [], tags: [] });
+            renderSettingsBackends();
+            // Focus the new name field
+            const rows = document.querySelectorAll('#settings-backends-body tr');
+            const lastRow = rows[rows.length - 1];
+            if (lastRow) lastRow.querySelector('input')?.focus();
+        }
+
+        function buildConfigFromForm() {
+            const apiKeyInput = document.getElementById('cfg-server-apikey').value;
+            let apiKey;
+            if (apiKeyInput) {
+                apiKey = apiKeyInput;
+            } else {
+                // Blank = keep existing (send sentinel)
+                apiKey = document.getElementById('cfg-server-apikey').placeholder.startsWith('Set') ? '********' : null;
+            }
+
+            return {
+                server: {
+                    host: document.getElementById('cfg-server-host').value,
+                    port: parseInt(document.getElementById('cfg-server-port').value) || 40114,
+                    api_key: apiKey,
+                    enrollment_key: (() => {
+                        const v = document.getElementById('cfg-server-enrollmentkey').value;
+                        if (v) return v;
+                        return document.getElementById('cfg-server-enrollmentkey').placeholder.startsWith('Set') ? '********' : null;
+                    })(),
+                    rate_limit: parseInt(document.getElementById('cfg-server-ratelimit').value) || 0,
+                },
+                routing: {
+                    strategy: document.getElementById('cfg-routing-strategy').value,
+                    timeout: document.getElementById('cfg-routing-timeout').value,
+                    retry_count: parseInt(document.getElementById('cfg-routing-retrycount').value) || 0,
+                    default_keep_alive: document.getElementById('cfg-routing-keepalive').value,
+                },
+                circuit_breaker: {
+                    failure_threshold: parseInt(document.getElementById('cfg-cb-threshold').value) || 5,
+                    timeout: document.getElementById('cfg-cb-timeout').value,
+                    recovery_time: document.getElementById('cfg-cb-recovery').value,
+                },
+                observability: {
+                    metrics: document.getElementById('cfg-obs-metrics').checked,
+                    admin_api: document.getElementById('cfg-obs-adminapi').checked,
+                    tracing: document.getElementById('cfg-obs-tracing').checked,
+                    log_retention_days: parseInt(document.getElementById('cfg-obs-retention').value) || 7,
+                    log_max_size_mb: parseInt(document.getElementById('cfg-obs-maxsize').value) || 100,
+                    log_max_files: parseInt(document.getElementById('cfg-obs-maxfiles').value) || 5,
+                },
+                agent: {
+                    enabled: document.getElementById('cfg-agent-enabled').checked,
+                    max_sessions: parseInt(document.getElementById('cfg-agent-maxsessions').value) || 100,
+                    max_tool_rounds: parseInt(document.getElementById('cfg-agent-maxrounds').value) || 10,
+                    session_ttl_minutes: parseInt(document.getElementById('cfg-agent-ttl').value) || 60,
+                    default_model: document.getElementById('cfg-agent-model').value || null,
+                    permissions: { deny_file_patterns: [], deny_bash_patterns: [], allow_shell_commands: false },
+                },
+                model_warmer: {
+                    interval_secs: parseInt(document.getElementById('cfg-warmer-interval').value) || 240,
+                },
+                backends: settingsBackends,
+            };
+        }
+
+        async function saveConfig() {
+            const config = buildConfigFromForm();
+            const resp = await authFetch('/admin/config', {
+                method: 'PUT',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify(config),
+            });
+            if (resp.ok) {
+                const result = await resp.json();
+                showToast(result.message || 'Config saved and reloaded');
+                // If user set a new API key, store it in the dashboard
+                const newKey = document.getElementById('cfg-server-apikey').value;
+                if (newKey) {
+                    setApiKey(newKey);
+                    document.getElementById('api-key-input').value = newKey;
+                }
+                loadConfig(); // refresh form
+            } else {
+                const err = await resp.json().catch(() => ({ error: 'Unknown error' }));
+                showToast(err.error || 'Save failed', 'error');
+            }
+        }
+
+        // -- Countdown Timer --
         function startCountdown() {
-            clearInterval(countdownTimer);
-            countdownTimer = setInterval(() => {
+            refreshCountdown = 5;
+            updateCountdownDisplay();
+            if (countdownInterval) clearInterval(countdownInterval);
+            countdownInterval = setInterval(() => {
                 refreshCountdown--;
-                if (refreshCountdown <= 0) refreshCountdown = 5;
+                if (refreshCountdown <= 0) {
+                    refreshCountdown = 5;
+                }
+                updateCountdownDisplay();
             }, 1000);
         }
 
-        // Close modal on escape
-        document.addEventListener('keydown', e => { if (e.key === 'Escape') closeModal(); });
+        function updateCountdownDisplay() {
+            document.getElementById('refresh-countdown').textContent = `Refreshing in ${refreshCountdown}s`;
+        }
+
+        // -- Keyboard & Click Handlers --
+        document.addEventListener('keydown', e => {
+            if (e.key === 'Escape') { closeModal(); closeSessionModal(); }
+        });
         document.getElementById('modal-overlay').addEventListener('click', e => {
             if (e.target === e.currentTarget) closeModal();
         });
+        document.getElementById('session-modal-overlay').addEventListener('click', e => {
+            if (e.target === e.currentTarget) closeSessionModal();
+        });
 
-        // Initialize
+        // -- Initialize --
         initCharts();
+        // Restore API key
         const savedKey = getApiKey();
         if (savedKey) document.getElementById('api-key-input').value = savedKey;
         refresh();
-        updateCharts();
+        updateAnalytics();
         checkUpdate();
+        refreshSessions();
+        fetchFleetNodes(); // initial badge count
         startCountdown();
+
+        // If fleet tab was last active, start its auto-refresh
+        if (savedTab === 'fleet') startFleetRefresh();
+
         setInterval(refresh, 5000);
-        setInterval(updateCharts, 30000);
+        setInterval(updateAnalytics, 30000);
+        setInterval(refreshSessions, 10000);
     </script>
 </body>
 </html>

--- a/docs/specs/herd-tune-spec.md
+++ b/docs/specs/herd-tune-spec.md
@@ -1,0 +1,282 @@
+# Herd-Tune: Node Auto-Registration for Herd Pro
+
+## Overview
+
+Herd Pro needs a frictionless way for operators to add Ollama backend nodes to their fleet. The workflow:
+
+1. Operator opens the Herd Pro dashboard in a browser (from any machine, including the node itself)
+2. Clicks "Add Node" — dashboard offers a download of the appropriate `herd-tune` script (PowerShell for Windows, bash for Linux), pre-configured with this Herd Pro instance's registration endpoint
+3. Operator runs the script on the Ollama node
+4. Script detects local GPU/VRAM/RAM, probes the local Ollama instance, applies recommended `OLLAMA_*` environment variables, and POSTs a registration payload to Herd Pro
+5. Node appears in the dashboard fleet view immediately
+
+No SSH. No file uploads. No manual config editing. The script is the only thing that touches the node. Herd Pro only ever talks to nodes via their Ollama HTTP API.
+
+## Architecture
+
+```
+[Herd Pro Dashboard]
+  │
+  ├── GET /dashboard/add-node          → "Add Node" page with download buttons
+  ├── GET /api/nodes/script?os=windows → Returns herd-tune.ps1 with endpoint baked in
+  ├── GET /api/nodes/script?os=linux   → Returns herd-tune.sh with endpoint baked in
+  │
+  ├── POST /api/nodes/register         → Receives node registration from herd-tune
+  ├── GET /api/nodes                   → List all registered nodes
+  ├── GET /api/nodes/:id               → Single node detail
+  ├── PUT /api/nodes/:id               → Update node (priority, tags, enabled)
+  ├── DELETE /api/nodes/:id            → Remove node from fleet
+  │
+  └── Background: health poller polls each node's Ollama /api/ps every N seconds
+```
+
+## API Endpoints
+
+### POST /api/nodes/register
+
+Called by `herd-tune` after local detection. Registers or updates a node.
+
+**Request:**
+```json
+{
+  "hostname": "citadel",
+  "ollama_url": "http://192.168.1.100:11434",
+  "gpu": "NVIDIA GeForce RTX 5090",
+  "vram_mb": 32768,
+  "ram_mb": 131072,
+  "ollama_version": "0.16.1",
+  "models_available": 42,
+  "models_loaded": ["qwen3:32b", "gemma3:27b"],
+  "recommended_config": {
+    "num_parallel": 8,
+    "max_loaded_models": 4,
+    "max_queue": 1024,
+    "keep_alive": "30m",
+    "flash_attention": true,
+    "kv_cache_type": "q8_0",
+    "context_length": 16384
+  },
+  "config_applied": true,
+  "herd_tune_version": "0.3.0",
+  "os": "windows",
+  "registered_at": "2026-03-29T14:30:00Z"
+}
+```
+
+**Response (201 Created or 200 OK if re-registering):**
+```json
+{
+  "id": "node-uuid-here",
+  "hostname": "citadel",
+  "status": "registered",
+  "message": "Node registered successfully. Health polling started."
+}
+```
+
+**Behavior:**
+- If a node with the same `hostname` already exists, update it (re-registration is idempotent)
+- Start health polling immediately on successful registration
+- Store in SQLite (consistent with Herd Pro's existing data layer)
+
+### GET /api/nodes/script?os={windows|linux}
+
+Returns the `herd-tune` script with the Herd Pro registration endpoint pre-configured.
+
+**Behavior:**
+- Read the script template from an embedded resource or file
+- Replace the placeholder endpoint URL with the actual Herd Pro base URL (derived from the request's Host header or a configured public URL)
+- Set `Content-Disposition: attachment; filename="herd-tune.ps1"` (or `.sh`)
+- Set appropriate `Content-Type`
+
+**Example:** If Herd Pro is running at `http://192.168.1.50:8081`, the downloaded script will have `$HerdProEndpoint = "http://192.168.1.50:8081"` baked in.
+
+### GET /api/nodes
+
+Returns all registered nodes with current health status.
+
+```json
+{
+  "nodes": [
+    {
+      "id": "uuid",
+      "hostname": "citadel",
+      "ollama_url": "http://192.168.1.100:11434",
+      "gpu": "NVIDIA GeForce RTX 5090",
+      "vram_mb": 32768,
+      "ram_mb": 131072,
+      "max_concurrent": 8,
+      "status": "healthy",
+      "models_loaded": ["qwen3:32b"],
+      "models_available": 42,
+      "last_health_check": "2026-03-29T14:35:00Z",
+      "registered_at": "2026-03-29T14:30:00Z",
+      "priority": 1,
+      "enabled": true,
+      "tags": ["local"]
+    }
+  ]
+}
+```
+
+### PUT /api/nodes/:id
+
+Update operator-controlled fields: `priority`, `tags`, `enabled`.
+Hardware fields are only updated via re-registration (re-run `herd-tune`).
+
+### DELETE /api/nodes/:id
+
+Remove a node from the fleet. Stops health polling. In-flight requests to this node should drain gracefully.
+
+## Health Polling
+
+After registration, Herd Pro polls each node on a configurable interval (default 10s):
+
+1. `GET {ollama_url}/api/ps` → loaded models, VRAM usage, context length, expiration
+2. `GET {ollama_url}/api/tags` → available models (less frequent, every 60s)
+3. Track response latency as a routing signal
+
+**Node status states:**
+- `healthy` — responding, models loaded
+- `degraded` — responding but high latency or VRAM pressure
+- `unreachable` — failed health checks (after 3 consecutive failures)
+- `disabled` — operator manually disabled via dashboard
+
+Unreachable nodes are not removed — they stay registered but excluded from routing. They automatically return to `healthy` when they start responding again.
+
+## herd-tune Scripts
+
+### PowerShell (Windows) — herd-tune.ps1
+
+Core logic:
+
+- **Detect** GPU (nvidia-smi, WMI fallback), RAM, local Ollama via API
+- **Calculate** recommended `OLLAMA_*` settings based on VRAM
+- **Apply** (with `-Apply` flag) — set Machine-level env vars + restart Ollama service
+- **Register** — POST payload to `{HerdPro}/api/nodes/register`
+- **Fallback** — if `-HerdPro` not set and no baked endpoint, skip registration, do local detection only
+
+### Bash (Linux) — herd-tune.sh
+
+Same logic, adapted:
+
+- `nvidia-smi` for GPU, `free -m` for RAM
+- `systemctl` for Ollama service management
+- `curl` for registration POST
+
+### Script Template Placeholders
+
+Both scripts have a clearly marked placeholder at the top:
+
+```powershell
+# ── Herd Pro Registration (auto-configured on download) ──
+$HerdProEndpoint = "%%HERD_PRO_ENDPOINT%%"
+```
+
+```bash
+# ── Herd Pro Registration (auto-configured on download) ──
+HERD_PRO_ENDPOINT="%%HERD_PRO_ENDPOINT%%"
+```
+
+The `/api/nodes/script` endpoint replaces `%%HERD_PRO_ENDPOINT%%` with the real URL before serving.
+
+## Dashboard UI — Add Node Flow
+
+### "Add Node" page (`/dashboard/add-node` or section in settings)
+
+**Content:**
+
+1. Brief explanation: "Run the herd-tune script on any machine running Ollama to add it to your fleet."
+
+2. Two download buttons:
+   - **Windows (PowerShell)** → `GET /api/nodes/script?os=windows`
+   - **Linux (Bash)** → `GET /api/nodes/script?os=linux`
+
+3. Quick-start instructions shown inline:
+
+   **Windows:**
+   ```
+   1. Download herd-tune.ps1 (button above)
+   2. Open PowerShell as Administrator on your Ollama machine
+   3. Run:  .\herd-tune.ps1 -Apply
+   4. Done — your node will appear in the fleet below
+   ```
+
+   **Linux:**
+   ```
+   1. Download herd-tune.sh (button above)
+   2. On your Ollama machine:
+      chmod +x herd-tune.sh
+      sudo ./herd-tune.sh --apply
+   3. Done — your node will appear in the fleet below
+   ```
+
+4. **Live fleet table** below the instructions — shows registered nodes updating in real-time (poll `/api/nodes` or use SSE). Operator sees the node appear after running the script.
+
+### Fleet Management (existing dashboard, or new section)
+
+- Table of nodes: hostname, GPU, VRAM, status, loaded models, parallel slots, priority
+- Toggle enabled/disabled per node
+- Edit priority and tags
+- Remove node
+- "Re-tune" button that shows the command to re-run `herd-tune` on that node
+
+## Data Storage
+
+Add a `nodes` table to Herd Pro's SQLite database:
+
+```sql
+CREATE TABLE IF NOT EXISTS nodes (
+    id TEXT PRIMARY KEY,
+    hostname TEXT NOT NULL UNIQUE,
+    ollama_url TEXT NOT NULL,
+    gpu TEXT,
+    vram_mb INTEGER DEFAULT 0,
+    ram_mb INTEGER DEFAULT 0,
+    max_concurrent INTEGER DEFAULT 1,
+    ollama_version TEXT,
+    os TEXT,
+    status TEXT DEFAULT 'healthy',
+    priority INTEGER DEFAULT 10,
+    enabled INTEGER DEFAULT 1,
+    tags TEXT DEFAULT '[]',
+    models_available INTEGER DEFAULT 0,
+    models_loaded TEXT DEFAULT '[]',
+    recommended_config TEXT DEFAULT '{}',
+    config_applied INTEGER DEFAULT 0,
+    last_health_check TEXT,
+    registered_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+);
+```
+
+## Integration with Routing
+
+The node registry replaces the current static backend configuration. Herd Pro's router should:
+
+1. Query the `nodes` table for `enabled = 1 AND status IN ('healthy', 'degraded')`
+2. Use `max_concurrent` to know how many parallel slots each node has
+3. Use health poll data (loaded models, response latency) for model affinity and least-loaded routing
+4. Respect `priority` for tie-breaking
+
+This means the `[[backends]]` section in the TOML/YAML config becomes optional — nodes registered via `herd-tune` are the primary source. Static config backends still work for non-Ollama backends (vLLM, cloud providers) that don't run `herd-tune`.
+
+## Implementation Order
+
+1. **SQLite `nodes` table** — migration in Herd Pro
+2. **POST /api/nodes/register** — accept and store registrations
+3. **GET /api/nodes** — list nodes (dashboard needs this)
+4. **Health poller** — background task polling registered nodes
+5. **Router integration** — read from `nodes` table instead of (or in addition to) static config
+6. **Script templates** — embed herd-tune.ps1 and herd-tune.sh as resources
+7. **GET /api/nodes/script** — serve scripts with endpoint baked in
+8. **Dashboard UI** — add node page, fleet table, management controls
+9. **PUT/DELETE /api/nodes/:id** — management endpoints
+10. **herd-tune scripts** — finalize with registration POST
+
+## Notes
+
+- Scripts ship embedded in the Herd Pro binary/container, not as separate downloads. When the container is built, the scripts are bundled.
+- Registration is idempotent. Running `herd-tune` again on a node updates its entry. This is how you "re-tune" after hardware changes.
+- The dashboard "Add Node" instructions should be visible even with zero nodes registered (first-run experience).
+- Herd Pro's public URL / external address may differ from its container internal address. Consider a `HERD_PRO_PUBLIC_URL` env var for generating correct script endpoints.
+- The scripts should detect the Ollama URL on the local machine and prefer Tailscale IP > LAN IP > localhost for the `ollama_url` field, since Herd Pro needs to reach it from the container network.

--- a/herd.yaml.example
+++ b/herd.yaml.example
@@ -109,3 +109,21 @@ observability:
   log_retention_days: 7          # Auto-prune JSONL request logs older than N days (default: 7)
   log_max_size_mb: 100           # Rotate log file when it exceeds N MB (default: 100, 0 = no limit)
   log_max_files: 5               # Keep up to N rotated log files (default: 5)
+
+# === AGENT ===
+# Built-in agent session management with tool calling and permission controls.
+# Off by default. Requires api_key to be set.
+
+# agent:
+#   enabled: false
+#   max_sessions: 100               # Maximum concurrent agent sessions
+#   max_tool_rounds: 10             # Max tool-call iterations per message
+#   session_ttl_minutes: 60         # Auto-expire idle sessions after this duration
+#   permissions:
+#     allow_shell_commands: false    # Enable run_command tool (default: false)
+#     deny_file_patterns:           # Regex patterns blocking file access
+#       - "\.env$"
+#       - "\.ssh/"
+#     deny_bash_patterns:           # Regex patterns blocking shell commands
+#       - "^rm\\s+-rf"
+#       - "^sudo"

--- a/scripts/herd-tune.ps1
+++ b/scripts/herd-tune.ps1
@@ -1,0 +1,312 @@
+<#
+.SYNOPSIS
+    herd-tune — Detect GPU/VRAM/RAM, configure Ollama, and register with Herd Pro.
+.DESCRIPTION
+    Run on any Windows machine with Ollama installed to auto-detect hardware,
+    apply recommended Ollama environment variables, and register with a Herd Pro instance.
+.PARAMETER Apply
+    Apply recommended OLLAMA_* environment variables and restart the Ollama service.
+    Requires administrator privileges.
+.PARAMETER HerdPro
+    Override the Herd Pro endpoint URL (default: baked in at download time).
+#>
+[CmdletBinding()]
+param(
+    [switch]$Apply,
+    [string]$HerdPro
+)
+
+# ── Herd Pro Registration (auto-configured on download) ──
+$HerdProEndpoint = "%%HERD_PRO_ENDPOINT%%"
+$EnrollmentKey = "%%ENROLLMENT_KEY%%"
+$HerdTuneVersion = "0.8.0"
+
+# -HerdPro parameter overrides the baked-in endpoint.
+# Also check HERD_PRO_URL env var as fallback (useful for containers/CI).
+if ($HerdPro) {
+    $HerdProEndpoint = $HerdPro
+} elseif ($env:HERD_PRO_URL) {
+    $HerdProEndpoint = $env:HERD_PRO_URL
+}
+
+# ── Require admin only when -Apply is used ──
+if ($Apply) {
+    $currentPrincipal = New-Object Security.Principal.WindowsPrincipal([Security.Principal.WindowsIdentity]::GetCurrent())
+    if (-not $currentPrincipal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
+        # Re-launch elevated, forwarding arguments
+        $argList = "-ExecutionPolicy Bypass -File `"$PSCommandPath`" -Apply"
+        if ($HerdProEndpoint -and $HerdProEndpoint -ne '%%HERD_PRO_ENDPOINT%%') {
+            $argList += " -HerdPro `"$HerdProEndpoint`""
+        }
+        Start-Process powershell.exe -Verb RunAs -ArgumentList $argList -Wait
+        exit $LASTEXITCODE
+    }
+}
+
+# ── Detect GPU ──
+function Get-GpuInfo {
+    # Try nvidia-smi first
+    try {
+        $smiOutput = & nvidia-smi --query-gpu=name,memory.total --format=csv,noheader,nounits 2>$null
+        if ($LASTEXITCODE -eq 0 -and $smiOutput) {
+            $parts = $smiOutput.Split(',').Trim()
+            return @{ Name = $parts[0]; VramMb = [int]$parts[1] }
+        }
+    } catch {}
+
+    # WMI fallback
+    try {
+        $gpu = Get-CimInstance -ClassName Win32_VideoController | Sort-Object AdapterRAM -Descending | Select-Object -First 1
+        if ($gpu) {
+            $vram = [math]::Round($gpu.AdapterRAM / 1MB)
+            return @{ Name = $gpu.Name; VramMb = $vram }
+        }
+    } catch {}
+
+    return @{ Name = $null; VramMb = 0 }
+}
+
+# ── Detect RAM ──
+function Get-RamMb {
+    try {
+        $os = Get-CimInstance -ClassName Win32_OperatingSystem
+        return [math]::Round($os.TotalVisibleMemorySize / 1024)
+    } catch {
+        return 0
+    }
+}
+
+# ── Detect Ollama ──
+function Get-OllamaInfo {
+    $ollamaUrl = "http://localhost:11434"
+
+    # Check if Ollama is running
+    try {
+        $version = Invoke-RestMethod -Uri "$ollamaUrl/api/version" -TimeoutSec 5
+        $ollamaVersion = $version.version
+    } catch {
+        Write-Warning "Ollama is not running at $ollamaUrl"
+        return $null
+    }
+
+    # Get loaded models
+    try {
+        $ps = Invoke-RestMethod -Uri "$ollamaUrl/api/ps" -TimeoutSec 5
+        $modelsLoaded = @($ps.models | ForEach-Object { $_.name })
+    } catch {
+        $modelsLoaded = @()
+    }
+
+    # Get available models
+    try {
+        $tags = Invoke-RestMethod -Uri "$ollamaUrl/api/tags" -TimeoutSec 10
+        $modelsAvailable = $tags.models.Count
+    } catch {
+        $modelsAvailable = 0
+    }
+
+    # Determine best reachable URL (prefer LAN IP over localhost)
+    $bestUrl = $ollamaUrl
+    try {
+        $adapters = Get-NetIPAddress -AddressFamily IPv4 | Where-Object {
+            $_.IPAddress -ne '127.0.0.1' -and $_.PrefixOrigin -ne 'WellKnown'
+        } | Sort-Object -Property InterfaceIndex
+        if ($adapters) {
+            $lanIp = $adapters[0].IPAddress
+            $bestUrl = "http://${lanIp}:11434"
+        }
+    } catch {}
+
+    return @{
+        OllamaUrl      = $bestUrl
+        OllamaVersion  = $ollamaVersion
+        ModelsLoaded   = $modelsLoaded
+        ModelsAvailable = $modelsAvailable
+    }
+}
+
+# ── Calculate recommended config ──
+function Get-RecommendedConfig {
+    param([int]$VramMb)
+
+    $config = @{
+        flash_attention = $true
+        kv_cache_type   = "q8_0"
+    }
+
+    if ($VramMb -ge 24576) {
+        # 24GB+ VRAM (RTX 4090, 5090, A5000, etc.)
+        $config.num_parallel    = 8
+        $config.max_loaded_models = 4
+        $config.max_queue       = 1024
+        $config.keep_alive      = "30m"
+        $config.context_length  = 16384
+    } elseif ($VramMb -ge 12288) {
+        # 12-24GB VRAM (RTX 3080, 4070 Ti, etc.)
+        $config.num_parallel    = 4
+        $config.max_loaded_models = 2
+        $config.max_queue       = 512
+        $config.keep_alive      = "15m"
+        $config.context_length  = 8192
+    } elseif ($VramMb -ge 8192) {
+        # 8-12GB VRAM (RTX 3070, 4060, etc.)
+        $config.num_parallel    = 2
+        $config.max_loaded_models = 1
+        $config.max_queue       = 256
+        $config.keep_alive      = "10m"
+        $config.context_length  = 4096
+    } else {
+        # < 8GB VRAM
+        $config.num_parallel    = 1
+        $config.max_loaded_models = 1
+        $config.max_queue       = 128
+        $config.keep_alive      = "5m"
+        $config.context_length  = 2048
+    }
+
+    return $config
+}
+
+# ── Apply Ollama config ──
+function Set-OllamaConfig {
+    param($Config)
+
+    Write-Host "`n=== Applying Ollama Configuration ===" -ForegroundColor Cyan
+
+    $envVars = @{
+        "OLLAMA_NUM_PARALLEL"     = $Config.num_parallel
+        "OLLAMA_MAX_LOADED_MODELS" = $Config.max_loaded_models
+        "OLLAMA_MAX_QUEUE"        = $Config.max_queue
+        "OLLAMA_KEEP_ALIVE"       = $Config.keep_alive
+        "OLLAMA_FLASH_ATTENTION"  = if ($Config.flash_attention) { "1" } else { "0" }
+        "OLLAMA_KV_CACHE_TYPE"    = $Config.kv_cache_type
+        "OLLAMA_CONTEXT_LENGTH"   = $Config.context_length
+    }
+
+    foreach ($kv in $envVars.GetEnumerator()) {
+        [System.Environment]::SetEnvironmentVariable($kv.Key, [string]$kv.Value, "Machine")
+        Write-Host "  Set $($kv.Key) = $($kv.Value)" -ForegroundColor Green
+    }
+
+    # Restart Ollama service
+    Write-Host "`nRestarting Ollama service..." -ForegroundColor Yellow
+    try {
+        Restart-Service -Name "OllamaService" -Force -ErrorAction Stop
+        Start-Sleep -Seconds 3
+        Write-Host "Ollama service restarted." -ForegroundColor Green
+    } catch {
+        Write-Warning "Could not restart Ollama service automatically. Please restart it manually."
+    }
+}
+
+# ── Main ──
+Write-Host @"
+
+  _               _       _
+ | |_  ___ _ _ __| |  ___| |_ _  _ _ _  ___
+ | ' \/ -_) '_/ _`` | |___| _| || | ' \/ -_)
+ |_||_\___|_| \__,_|     \__|\_,_|_||_\___|
+
+  GPU Detection & Ollama Configuration
+  Version $HerdTuneVersion
+
+"@ -ForegroundColor Cyan
+
+# Detect hardware
+Write-Host "=== Hardware Detection ===" -ForegroundColor Cyan
+
+$gpu = Get-GpuInfo
+$ramMb = Get-RamMb
+
+Write-Host "  GPU:  $($gpu.Name ?? 'Not detected')"
+Write-Host "  VRAM: $($gpu.VramMb) MB"
+Write-Host "  RAM:  $ramMb MB"
+
+# Detect Ollama
+Write-Host "`n=== Ollama Detection ===" -ForegroundColor Cyan
+$ollama = Get-OllamaInfo
+if (-not $ollama) {
+    Write-Error "Ollama is not running. Please start Ollama and try again."
+    exit 1
+}
+
+Write-Host "  URL:      $($ollama.OllamaUrl)"
+Write-Host "  Version:  $($ollama.OllamaVersion)"
+Write-Host "  Models:   $($ollama.ModelsAvailable) available, $($ollama.ModelsLoaded.Count) loaded"
+
+# Calculate config
+$config = Get-RecommendedConfig -VramMb $gpu.VramMb
+
+Write-Host "`n=== Recommended Configuration ===" -ForegroundColor Cyan
+$config.GetEnumerator() | ForEach-Object { Write-Host "  $($_.Key): $($_.Value)" }
+
+$configApplied = $false
+if ($Apply) {
+    Set-OllamaConfig -Config $config
+    $configApplied = $true
+} else {
+    Write-Host "`nRun with -Apply to set these environment variables and restart Ollama." -ForegroundColor Yellow
+}
+
+# Generate stable machine ID (survives hostname changes)
+$machineId = $null
+try {
+    $sid = (Get-CimInstance -ClassName Win32_UserAccount -Filter "LocalAccount=True" -ErrorAction SilentlyContinue |
+        Select-Object -First 1).SID
+    if ($sid) {
+        # Strip the per-user RID to get the machine SID
+        $machineSid = $sid -replace '-\d+$'
+        $sha = [System.Security.Cryptography.SHA256]::Create()
+        $bytes = [System.Text.Encoding]::UTF8.GetBytes($machineSid)
+        $hash = $sha.ComputeHash($bytes)
+        $machineId = -join ($hash[0..15] | ForEach-Object { $_.ToString("x2") })
+    }
+} catch {}
+
+# Register with Herd Pro
+$regEndpoint = $null
+if ($HerdProEndpoint -and $HerdProEndpoint -notmatch 'HERD_PRO_ENDPOINT') {
+    $regEndpoint = $HerdProEndpoint
+}
+
+if ($regEndpoint) {
+    $regUrl = "$regEndpoint/api/nodes/register"
+    if ($EnrollmentKey -and $EnrollmentKey -notmatch 'ENROLLMENT_KEY') {
+        $regUrl += "?enrollment_key=$EnrollmentKey"
+    }
+
+    Write-Host "`n=== Registering with Herd Pro ===" -ForegroundColor Cyan
+    Write-Host "  Endpoint: $regEndpoint"
+
+    $payloadObj = @{
+        hostname          = $env:COMPUTERNAME.ToLower()
+        ollama_url        = $ollama.OllamaUrl
+        gpu               = $gpu.Name
+        vram_mb           = $gpu.VramMb
+        ram_mb            = $ramMb
+        ollama_version    = $ollama.OllamaVersion
+        models_available  = $ollama.ModelsAvailable
+        models_loaded     = $ollama.ModelsLoaded
+        recommended_config = $config
+        config_applied    = $configApplied
+        herd_tune_version = $HerdTuneVersion
+        os                = "windows"
+        registered_at     = (Get-Date -Format "o")
+    }
+    if ($machineId) { $payloadObj.node_id = $machineId }
+    $payload = $payloadObj | ConvertTo-Json -Depth 3
+
+    try {
+        $response = Invoke-RestMethod -Uri $regUrl `
+            -Method Post -Body $payload -ContentType "application/json" -TimeoutSec 10
+        Write-Host "  Status: $($response.status)" -ForegroundColor Green
+        Write-Host "  $($response.message)" -ForegroundColor Green
+    } catch {
+        Write-Warning "Registration failed: $_"
+        Write-Host "  You can register manually later by re-running this script with -HerdPro <url>"
+    }
+} else {
+    Write-Host "`nNo Herd Pro endpoint configured. Run with -HerdPro <url> to register." -ForegroundColor Yellow
+}
+
+Write-Host "`nDone!" -ForegroundColor Green

--- a/scripts/herd-tune.sh
+++ b/scripts/herd-tune.sh
@@ -1,0 +1,230 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ── Herd Pro Registration (auto-configured on download) ──
+HERD_PRO_ENDPOINT="%%HERD_PRO_ENDPOINT%%"
+ENROLLMENT_KEY="%%ENROLLMENT_KEY%%"
+HERD_TUNE_VERSION="0.8.0"
+APPLY=false
+
+# Parse args
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --apply) APPLY=true; shift ;;
+        --herd-pro) HERD_PRO_ENDPOINT="$2"; shift 2 ;;
+        --herd-pro=*) HERD_PRO_ENDPOINT="${1#*=}"; shift ;;
+        --enrollment-key) ENROLLMENT_KEY="$2"; shift 2 ;;
+        --enrollment-key=*) ENROLLMENT_KEY="${1#*=}"; shift ;;
+        -h|--help)
+            echo "Usage: $0 [--apply] [--herd-pro URL] [--enrollment-key KEY]"
+            echo "  --apply           Apply recommended OLLAMA_* env vars and restart Ollama"
+            echo "  --herd-pro        Herd Pro endpoint URL for registration"
+            echo "  --enrollment-key  Enrollment key for node registration"
+            exit 0
+            ;;
+        *) echo "Unknown option: $1"; exit 1 ;;
+    esac
+done
+
+echo ""
+echo "  _               _       _"
+echo " | |_  ___ _ _ __| |  ___| |_ _  _ _ _  ___"
+echo " | ' \/ -_) '_/ _\` | |___| _| || | ' \/ -_)"
+echo " |_||_\___|_| \__,_|     \__|\_,_|_||_\___|"
+echo ""
+echo "  GPU Detection & Ollama Configuration"
+echo "  Version $HERD_TUNE_VERSION"
+echo ""
+
+# ── Detect GPU ──
+echo "=== Hardware Detection ==="
+GPU_NAME=""
+VRAM_MB=0
+
+if command -v nvidia-smi &>/dev/null; then
+    GPU_INFO=$(nvidia-smi --query-gpu=name,memory.total --format=csv,noheader,nounits 2>/dev/null || true)
+    if [ -n "$GPU_INFO" ]; then
+        GPU_NAME=$(echo "$GPU_INFO" | head -1 | cut -d',' -f1 | xargs)
+        VRAM_MB=$(echo "$GPU_INFO" | head -1 | cut -d',' -f2 | xargs)
+    fi
+fi
+
+# Detect RAM
+RAM_MB=$(free -m 2>/dev/null | awk '/^Mem:/{print $2}' || echo 0)
+
+echo "  GPU:  ${GPU_NAME:-Not detected}"
+echo "  VRAM: ${VRAM_MB} MB"
+echo "  RAM:  ${RAM_MB} MB"
+
+# ── Detect Ollama ──
+echo ""
+echo "=== Ollama Detection ==="
+OLLAMA_URL="http://localhost:11434"
+
+OLLAMA_VERSION=$(curl -sf "${OLLAMA_URL}/api/version" 2>/dev/null | grep -o '"version":"[^"]*"' | cut -d'"' -f4 || true)
+if [ -z "$OLLAMA_VERSION" ]; then
+    echo "ERROR: Ollama is not running at ${OLLAMA_URL}"
+    exit 1
+fi
+
+# Get loaded models
+MODELS_LOADED=$(curl -sf "${OLLAMA_URL}/api/ps" 2>/dev/null | python3 -c "
+import sys, json
+try:
+    data = json.load(sys.stdin)
+    names = [m['name'] for m in data.get('models', [])]
+    print(json.dumps(names))
+except: print('[]')
+" 2>/dev/null || echo '[]')
+
+# Get available model count
+MODELS_AVAILABLE=$(curl -sf "${OLLAMA_URL}/api/tags" 2>/dev/null | python3 -c "
+import sys, json
+try:
+    data = json.load(sys.stdin)
+    print(len(data.get('models', [])))
+except: print(0)
+" 2>/dev/null || echo 0)
+
+# Determine best reachable URL (prefer LAN IP over localhost)
+BEST_URL="$OLLAMA_URL"
+LAN_IP=$(hostname -I 2>/dev/null | awk '{print $1}' || true)
+if [ -n "$LAN_IP" ]; then
+    BEST_URL="http://${LAN_IP}:11434"
+fi
+
+echo "  URL:      ${BEST_URL}"
+echo "  Version:  ${OLLAMA_VERSION}"
+echo "  Models:   ${MODELS_AVAILABLE} available"
+
+# ── Calculate recommended config ──
+echo ""
+echo "=== Recommended Configuration ==="
+
+if [ "$VRAM_MB" -ge 24576 ]; then
+    NUM_PARALLEL=8; MAX_LOADED=4; MAX_QUEUE=1024; KEEP_ALIVE="30m"; CTX_LEN=16384
+elif [ "$VRAM_MB" -ge 12288 ]; then
+    NUM_PARALLEL=4; MAX_LOADED=2; MAX_QUEUE=512; KEEP_ALIVE="15m"; CTX_LEN=8192
+elif [ "$VRAM_MB" -ge 8192 ]; then
+    NUM_PARALLEL=2; MAX_LOADED=1; MAX_QUEUE=256; KEEP_ALIVE="10m"; CTX_LEN=4096
+else
+    NUM_PARALLEL=1; MAX_LOADED=1; MAX_QUEUE=128; KEEP_ALIVE="5m"; CTX_LEN=2048
+fi
+
+echo "  num_parallel:     $NUM_PARALLEL"
+echo "  max_loaded_models: $MAX_LOADED"
+echo "  max_queue:        $MAX_QUEUE"
+echo "  keep_alive:       $KEEP_ALIVE"
+echo "  flash_attention:  true"
+echo "  kv_cache_type:    q8_0"
+echo "  context_length:   $CTX_LEN"
+
+# ── Apply config ──
+CONFIG_APPLIED=false
+if [ "$APPLY" = true ]; then
+    echo ""
+    echo "=== Applying Ollama Configuration ==="
+
+    # Write to /etc/environment or systemd override
+    OLLAMA_ENV_FILE="/etc/systemd/system/ollama.service.d/override.conf"
+    mkdir -p "$(dirname "$OLLAMA_ENV_FILE")"
+
+    cat > "$OLLAMA_ENV_FILE" << ENVEOF
+[Service]
+Environment="OLLAMA_NUM_PARALLEL=${NUM_PARALLEL}"
+Environment="OLLAMA_MAX_LOADED_MODELS=${MAX_LOADED}"
+Environment="OLLAMA_MAX_QUEUE=${MAX_QUEUE}"
+Environment="OLLAMA_KEEP_ALIVE=${KEEP_ALIVE}"
+Environment="OLLAMA_FLASH_ATTENTION=1"
+Environment="OLLAMA_KV_CACHE_TYPE=q8_0"
+Environment="OLLAMA_CONTEXT_LENGTH=${CTX_LEN}"
+ENVEOF
+
+    echo "  Wrote ${OLLAMA_ENV_FILE}"
+
+    # Restart Ollama
+    echo "  Restarting Ollama service..."
+    systemctl daemon-reload
+    systemctl restart ollama
+    sleep 3
+    echo "  Ollama service restarted."
+    CONFIG_APPLIED=true
+else
+    echo ""
+    echo "Run with --apply to set these environment variables and restart Ollama."
+fi
+
+# ── Generate stable machine ID ──
+NODE_ID=""
+if [ -f /etc/machine-id ]; then
+    NODE_ID=$(cat /etc/machine-id)
+elif [ -f /var/lib/dbus/machine-id ]; then
+    NODE_ID=$(cat /var/lib/dbus/machine-id)
+else
+    MAC=$(ip link show 2>/dev/null | awk '/ether/{print $2; exit}' || true)
+    NODE_ID=$(echo -n "${MAC}$(hostname)" | sha256sum | cut -d' ' -f1 | head -c 32)
+fi
+
+# ── Register with Herd Pro ──
+if [ -n "$HERD_PRO_ENDPOINT" ] && [ "$HERD_PRO_ENDPOINT" != '%%HERD_PRO_ENDPOINT%%' ]; then
+    echo ""
+    echo "=== Registering with Herd Pro ==="
+    echo "  Endpoint: ${HERD_PRO_ENDPOINT}"
+
+    REG_URL="${HERD_PRO_ENDPOINT}/api/nodes/register"
+    if [ -n "$ENROLLMENT_KEY" ] && [ "$ENROLLMENT_KEY" != '%%ENROLLMENT_KEY%%' ]; then
+        REG_URL="${REG_URL}?enrollment_key=${ENROLLMENT_KEY}"
+    fi
+
+    HOSTNAME_VAL=$(hostname | tr '[:upper:]' '[:lower:]')
+    REGISTERED_AT=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+    NODE_ID_JSON=""
+    if [ -n "$NODE_ID" ]; then
+        NODE_ID_JSON="\"node_id\": \"${NODE_ID}\","
+    fi
+
+    PAYLOAD=$(cat << JSONEOF
+{
+  ${NODE_ID_JSON}
+  "hostname": "${HOSTNAME_VAL}",
+  "ollama_url": "${BEST_URL}",
+  "gpu": "${GPU_NAME}",
+  "vram_mb": ${VRAM_MB},
+  "ram_mb": ${RAM_MB},
+  "ollama_version": "${OLLAMA_VERSION}",
+  "models_available": ${MODELS_AVAILABLE},
+  "models_loaded": ${MODELS_LOADED},
+  "recommended_config": {
+    "num_parallel": ${NUM_PARALLEL},
+    "max_loaded_models": ${MAX_LOADED},
+    "max_queue": ${MAX_QUEUE},
+    "keep_alive": "${KEEP_ALIVE}",
+    "flash_attention": true,
+    "kv_cache_type": "q8_0",
+    "context_length": ${CTX_LEN}
+  },
+  "config_applied": ${CONFIG_APPLIED},
+  "herd_tune_version": "${HERD_TUNE_VERSION}",
+  "os": "linux",
+  "registered_at": "${REGISTERED_AT}"
+}
+JSONEOF
+)
+
+    RESPONSE=$(curl -sf -X POST "${REG_URL}" \
+        -H "Content-Type: application/json" \
+        -d "$PAYLOAD" 2>/dev/null || true)
+
+    if [ -n "$RESPONSE" ]; then
+        echo "  Registration successful!"
+        echo "  $RESPONSE"
+    else
+        echo "  WARNING: Registration failed. You can register later with --herd-pro <url>"
+    fi
+else
+    echo ""
+    echo "No Herd Pro endpoint configured. Run with --herd-pro <url> to register."
+fi
+
+echo ""
+echo "Done!"

--- a/src/agent/audit.rs
+++ b/src/agent/audit.rs
@@ -1,0 +1,253 @@
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+use std::fs::OpenOptions;
+use std::io::{BufRead, BufReader, Write};
+use std::path::PathBuf;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AuditEntry {
+    pub timestamp: i64,
+    pub session_id: String,
+    #[serde(rename = "type")]
+    pub entry_type: AuditType,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub success: Option<bool>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum AuditType {
+    SessionCreated,
+    SessionDeleted,
+    ToolCall,
+    ToolResult,
+    PermissionDenied,
+    Message,
+    Error,
+}
+
+pub struct AgentAudit {
+    log_path: PathBuf,
+    file_lock: Arc<Mutex<()>>,
+}
+
+impl AgentAudit {
+    pub fn new() -> Result<Self> {
+        let log_dir = dirs::home_dir()
+            .ok_or_else(|| anyhow::anyhow!("Could not find home directory"))?
+            .join(".herd");
+
+        std::fs::create_dir_all(&log_dir)?;
+        let log_path = log_dir.join("agent_audit.jsonl");
+
+        // Touch the file
+        let file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&log_path)?;
+        drop(file);
+
+        Ok(Self {
+            log_path,
+            file_lock: Arc::new(Mutex::new(())),
+        })
+    }
+
+    pub async fn log(&self, entry: AuditEntry) -> Result<()> {
+        let _guard = self.file_lock.lock().await;
+        let mut file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&self.log_path)?;
+        let json = serde_json::to_string(&entry)?;
+        writeln!(file, "{}", json)?;
+        file.flush()?;
+        Ok(())
+    }
+
+    pub async fn log_event(&self, event: &crate::agent::types::AgentEvent) {
+        let entry = match event {
+            crate::agent::types::AgentEvent::ToolCall {
+                session_id: sid,
+                tool,
+                arguments,
+            } => AuditEntry {
+                timestamp: chrono::Utc::now().timestamp(),
+                session_id: sid.clone(),
+                entry_type: AuditType::ToolCall,
+                tool: Some(tool.clone()),
+                detail: Some(arguments.to_string()),
+                success: None,
+            },
+            crate::agent::types::AgentEvent::ToolResult {
+                session_id: sid,
+                tool,
+                success,
+                ..
+            } => AuditEntry {
+                timestamp: chrono::Utc::now().timestamp(),
+                session_id: sid.clone(),
+                entry_type: AuditType::ToolResult,
+                tool: Some(tool.clone()),
+                detail: None,
+                success: Some(*success),
+            },
+            crate::agent::types::AgentEvent::PermissionDenied {
+                session_id: sid,
+                tool,
+                reason,
+            } => AuditEntry {
+                timestamp: chrono::Utc::now().timestamp(),
+                session_id: sid.clone(),
+                entry_type: AuditType::PermissionDenied,
+                tool: Some(tool.clone()),
+                detail: Some(reason.clone()),
+                success: Some(false),
+            },
+            crate::agent::types::AgentEvent::Error {
+                session_id: sid,
+                error,
+            } => AuditEntry {
+                timestamp: chrono::Utc::now().timestamp(),
+                session_id: sid.clone(),
+                entry_type: AuditType::Error,
+                tool: None,
+                detail: Some(error.clone()),
+                success: Some(false),
+            },
+            _ => return, // Thinking and Message events are not audited
+        };
+
+        let _ = self.log(entry).await;
+    }
+
+    pub async fn log_session_created(&self, session_id: &str, model: &str) {
+        let entry = AuditEntry {
+            timestamp: chrono::Utc::now().timestamp(),
+            session_id: session_id.to_string(),
+            entry_type: AuditType::SessionCreated,
+            tool: None,
+            detail: Some(model.to_string()),
+            success: None,
+        };
+        let _ = self.log(entry).await;
+    }
+
+    pub async fn log_session_deleted(&self, session_id: &str) {
+        let entry = AuditEntry {
+            timestamp: chrono::Utc::now().timestamp(),
+            session_id: session_id.to_string(),
+            entry_type: AuditType::SessionDeleted,
+            tool: None,
+            detail: None,
+            success: None,
+        };
+        let _ = self.log(entry).await;
+    }
+
+    /// Remove audit entries older than `max_age_secs`. Rewrites the log file
+    /// keeping only recent entries.
+    pub async fn cleanup_old(&self, max_age_secs: i64) -> Result<usize> {
+        let _guard = self.file_lock.lock().await;
+        let cutoff = chrono::Utc::now().timestamp() - max_age_secs;
+
+        let file = match std::fs::File::open(&self.log_path) {
+            Ok(f) => f,
+            Err(_) => return Ok(0),
+        };
+        let reader = BufReader::new(file);
+
+        let mut kept_lines = Vec::new();
+        let mut removed = 0usize;
+
+        for line in reader.lines() {
+            let line = line?;
+            if let Ok(entry) = serde_json::from_str::<AuditEntry>(&line) {
+                if entry.timestamp >= cutoff {
+                    kept_lines.push(line);
+                } else {
+                    removed += 1;
+                }
+            }
+        }
+
+        if removed > 0 {
+            let temp_path = self.log_path.with_extension("jsonl.tmp");
+            let mut temp = std::fs::File::create(&temp_path)?;
+            for line in &kept_lines {
+                writeln!(temp, "{}", line)?;
+            }
+            temp.flush()?;
+            std::fs::rename(&temp_path, &self.log_path)?;
+            tracing::info!("Audit log cleanup: removed {} old entries, kept {}", removed, kept_lines.len());
+        }
+
+        Ok(removed)
+    }
+
+    pub async fn get_stats(&self, since_seconds: i64) -> Result<AgentAuditStats> {
+        let _guard = self.file_lock.lock().await;
+        let cutoff = chrono::Utc::now().timestamp() - since_seconds;
+
+        let file = std::fs::File::open(&self.log_path)?;
+        let reader = BufReader::new(file);
+
+        let mut total_events = 0u64;
+        let mut tool_calls = 0u64;
+        let mut permission_denials = 0u64;
+        let mut sessions_created = 0u64;
+        let mut sessions_deleted = 0u64;
+        let mut errors = 0u64;
+        let mut tool_counts: std::collections::HashMap<String, u64> =
+            std::collections::HashMap::new();
+
+        for line in reader.lines() {
+            let line = line?;
+            if let Ok(entry) = serde_json::from_str::<AuditEntry>(&line) {
+                if entry.timestamp >= cutoff {
+                    total_events += 1;
+                    match entry.entry_type {
+                        AuditType::ToolCall => {
+                            tool_calls += 1;
+                            if let Some(ref tool) = entry.tool {
+                                *tool_counts.entry(tool.clone()).or_insert(0) += 1;
+                            }
+                        }
+                        AuditType::PermissionDenied => permission_denials += 1,
+                        AuditType::SessionCreated => sessions_created += 1,
+                        AuditType::SessionDeleted => sessions_deleted += 1,
+                        AuditType::Error => errors += 1,
+                        _ => {}
+                    }
+                }
+            }
+        }
+
+        Ok(AgentAuditStats {
+            total_events,
+            tool_calls,
+            permission_denials,
+            sessions_created,
+            sessions_deleted,
+            errors,
+            tool_counts,
+        })
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct AgentAuditStats {
+    pub total_events: u64,
+    pub tool_calls: u64,
+    pub permission_denials: u64,
+    pub sessions_created: u64,
+    pub sessions_deleted: u64,
+    pub errors: u64,
+    pub tool_counts: std::collections::HashMap<String, u64>,
+}

--- a/src/agent/executor.rs
+++ b/src/agent/executor.rs
@@ -1,0 +1,339 @@
+use crate::agent::permissions::{PermissionEngine, PermissionResult};
+use crate::agent::session::Session;
+use crate::agent::tools;
+use crate::agent::types::{AgentEvent, AgentMessage, MessageRole, SessionStatus, ToolCall};
+use crate::router::{Router, RouterEnum};
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use tokio::sync::mpsc;
+
+// -- Ollama wire types (only used at the API boundary) --
+
+#[derive(Debug, Serialize)]
+struct OllamaChatRequest {
+    model: String,
+    messages: Vec<OllamaMessage>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tools: Option<Vec<serde_json::Value>>,
+    stream: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct OllamaMessage {
+    role: String,
+    #[serde(default)]
+    content: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tool_calls: Option<Vec<OllamaToolCall>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct OllamaToolCall {
+    function: OllamaFunction,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct OllamaFunction {
+    name: String,
+    arguments: serde_json::Value,
+}
+
+#[derive(Debug, Deserialize)]
+struct OllamaChatResponse {
+    message: OllamaMessage,
+    #[allow(dead_code)]
+    done: bool,
+}
+
+// -- Conversion helpers --
+
+fn to_ollama_message(msg: &AgentMessage) -> OllamaMessage {
+    let role = match msg.role {
+        MessageRole::System => "system",
+        MessageRole::User => "user",
+        MessageRole::Assistant => "assistant",
+        MessageRole::Tool => "tool",
+    };
+
+    let tool_calls = msg.tool_calls.as_ref().map(|calls| {
+        calls
+            .iter()
+            .map(|c| OllamaToolCall {
+                function: OllamaFunction {
+                    name: c.name.clone(),
+                    arguments: c.arguments.clone(),
+                },
+            })
+            .collect()
+    });
+
+    OllamaMessage {
+        role: role.to_string(),
+        content: msg.content.clone(),
+        tool_calls,
+    }
+}
+
+fn from_ollama_tool_calls(calls: &[OllamaToolCall]) -> Vec<ToolCall> {
+    calls
+        .iter()
+        .enumerate()
+        .map(|(i, c)| ToolCall {
+            id: format!("call_{}", i),
+            name: c.function.name.clone(),
+            arguments: c.function.arguments.clone(),
+        })
+        .collect()
+}
+
+// -- Executor --
+
+pub struct AgentExecutor {
+    client: Arc<reqwest::Client>,
+    router: RouterEnum,
+    permissions: PermissionEngine,
+    max_tool_rounds: u32,
+    request_timeout: std::time::Duration,
+}
+
+impl AgentExecutor {
+    pub fn new(
+        client: Arc<reqwest::Client>,
+        router: RouterEnum,
+        permissions: PermissionEngine,
+        max_tool_rounds: u32,
+        request_timeout: std::time::Duration,
+    ) -> Self {
+        Self {
+            client,
+            router,
+            permissions,
+            max_tool_rounds,
+            request_timeout,
+        }
+    }
+
+    /// Run the agent loop: send message, handle tool calls, return final response.
+    /// Mutates the session in-place (appends messages, updates status).
+    pub async fn execute(&self, session: &mut Session, user_message: String) -> Result<String> {
+        self.execute_inner(session, user_message, None).await
+    }
+
+    /// Run the agent loop with event streaming.
+    /// Events are sent to the channel as they happen. The final text content is still returned.
+    pub async fn execute_streaming(
+        &self,
+        session: &mut Session,
+        user_message: String,
+        events: mpsc::Sender<AgentEvent>,
+    ) -> Result<String> {
+        self.execute_inner(session, user_message, Some(events)).await
+    }
+
+    async fn emit(events: &Option<mpsc::Sender<AgentEvent>>, event: AgentEvent) {
+        if let Some(ref tx) = events {
+            let _ = tx.send(event).await;
+        }
+    }
+
+    async fn execute_inner(
+        &self,
+        session: &mut Session,
+        user_message: String,
+        events: Option<mpsc::Sender<AgentEvent>>,
+    ) -> Result<String> {
+        // Append user message
+        session.messages.push(AgentMessage {
+            role: MessageRole::User,
+            content: user_message,
+            tool_calls: None,
+            tool_call_id: None,
+        });
+        session.status = SessionStatus::Processing;
+
+        let tool_defs = tools::tool_definitions(self.permissions.allows_shell_commands());
+
+        for round in 0..self.max_tool_rounds {
+            // Route to a backend that has this model
+            let backend = self.router.route(Some(&session.model), None).await?;
+            tracing::debug!(
+                "Agent session {} routed to {} for model {}",
+                session.id,
+                backend.name,
+                session.model
+            );
+
+            Self::emit(
+                &events,
+                AgentEvent::Thinking {
+                    session_id: session.id.clone(),
+                    round,
+                },
+            )
+            .await;
+
+            // Build Ollama request
+            let ollama_messages: Vec<OllamaMessage> =
+                session.messages.iter().map(to_ollama_message).collect();
+
+            let request = OllamaChatRequest {
+                model: session.model.clone(),
+                messages: ollama_messages,
+                tools: Some(tool_defs.clone()),
+                stream: false,
+            };
+
+            // Call Ollama
+            let url = format!("{}/api/chat", backend.url);
+            let resp = self
+                .client
+                .post(&url)
+                .timeout(self.request_timeout)
+                .json(&request)
+                .send()
+                .await
+                .map_err(|e| anyhow::anyhow!("Backend request failed: {}", e))?;
+
+            if !resp.status().is_success() {
+                let status = resp.status();
+                let body = resp.text().await.unwrap_or_default();
+                let err_msg = format!("Backend returned {}: {}", status, body);
+                Self::emit(
+                    &events,
+                    AgentEvent::Error {
+                        session_id: session.id.clone(),
+                        error: err_msg.clone(),
+                    },
+                )
+                .await;
+                return Err(anyhow::anyhow!(err_msg));
+            }
+
+            let chat_resp: OllamaChatResponse = resp
+                .json()
+                .await
+                .map_err(|e| anyhow::anyhow!("Failed to parse backend response: {}", e))?;
+
+            // Check if model wants to call tools
+            if let Some(ref ollama_calls) = chat_resp.message.tool_calls {
+                if !ollama_calls.is_empty() {
+                    let internal_calls = from_ollama_tool_calls(ollama_calls);
+
+                    // Record assistant message with tool calls
+                    session.messages.push(AgentMessage {
+                        role: MessageRole::Assistant,
+                        content: chat_resp.message.content.clone(),
+                        tool_calls: Some(internal_calls.clone()),
+                        tool_call_id: None,
+                    });
+
+                    // Execute each tool call
+                    for call in &internal_calls {
+                        let result_content = match self.permissions.check_tool_call(call) {
+                            PermissionResult::Allowed => {
+                                tracing::info!(
+                                    "Session {}: executing tool {}",
+                                    session.id,
+                                    call.name
+                                );
+
+                                Self::emit(
+                                    &events,
+                                    AgentEvent::ToolCall {
+                                        session_id: session.id.clone(),
+                                        tool: call.name.clone(),
+                                        arguments: call.arguments.clone(),
+                                    },
+                                )
+                                .await;
+
+                                let result =
+                                    tools::execute_tool(&call.name, &call.arguments).await;
+
+                                Self::emit(
+                                    &events,
+                                    AgentEvent::ToolResult {
+                                        session_id: session.id.clone(),
+                                        tool: call.name.clone(),
+                                        content: result.content.clone(),
+                                        success: result.success,
+                                    },
+                                )
+                                .await;
+
+                                result.content
+                            }
+                            PermissionResult::Denied(reason) => {
+                                tracing::warn!(
+                                    "Session {}: permission denied for {}: {}",
+                                    session.id,
+                                    call.name,
+                                    reason
+                                );
+
+                                Self::emit(
+                                    &events,
+                                    AgentEvent::PermissionDenied {
+                                        session_id: session.id.clone(),
+                                        tool: call.name.clone(),
+                                        reason: reason.clone(),
+                                    },
+                                )
+                                .await;
+
+                                format!("Permission denied: {}", reason)
+                            }
+                        };
+
+                        session.messages.push(AgentMessage {
+                            role: MessageRole::Tool,
+                            content: result_content,
+                            tool_calls: None,
+                            tool_call_id: Some(call.id.clone()),
+                        });
+                    }
+
+                    // Loop — model will see tool results on next iteration
+                    continue;
+                }
+            }
+
+            // No tool calls — this is the final text response
+            let content = chat_resp.message.content.clone();
+            session.messages.push(AgentMessage {
+                role: MessageRole::Assistant,
+                content: content.clone(),
+                tool_calls: None,
+                tool_call_id: None,
+            });
+            session.status = SessionStatus::Active;
+            session.updated_at = chrono::Utc::now().timestamp();
+
+            Self::emit(
+                &events,
+                AgentEvent::Message {
+                    session_id: session.id.clone(),
+                    content: content.clone(),
+                },
+            )
+            .await;
+
+            return Ok(content);
+        }
+
+        // Exhausted tool rounds
+        session.status = SessionStatus::Active;
+        session.updated_at = chrono::Utc::now().timestamp();
+        let err_msg = format!("Maximum tool rounds ({}) exceeded", self.max_tool_rounds);
+        Self::emit(
+            &events,
+            AgentEvent::Error {
+                session_id: session.id.clone(),
+                error: err_msg.clone(),
+            },
+        )
+        .await;
+        Err(anyhow::anyhow!(err_msg))
+    }
+}

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -1,0 +1,13 @@
+pub mod audit;
+pub mod executor;
+pub mod permissions;
+pub mod session;
+pub mod store;
+pub mod tools;
+pub mod types;
+pub mod ws;
+
+pub use audit::AgentAudit;
+pub use session::Session;
+pub use store::SessionStore;
+pub use types::{AgentEvent, AgentMessage, MessageRole, SessionStatus, ToolCall, ToolResult};

--- a/src/agent/permissions.rs
+++ b/src/agent/permissions.rs
@@ -1,0 +1,293 @@
+use crate::agent::types::ToolCall;
+use crate::config::PermissionsConfig;
+use regex::Regex;
+
+#[derive(Debug, Clone)]
+pub enum PermissionResult {
+    Allowed,
+    Denied(String),
+}
+
+#[derive(Clone)]
+pub struct PermissionEngine {
+    deny_file_patterns: Vec<Regex>,
+    deny_bash_patterns: Vec<Regex>,
+    allow_shell_commands: bool,
+    // Keep raw strings for error messages
+    deny_file_raw: Vec<String>,
+    deny_bash_raw: Vec<String>,
+}
+
+impl PermissionEngine {
+    pub fn new(config: &PermissionsConfig) -> Self {
+        let deny_file_patterns = config
+            .deny_file_patterns
+            .iter()
+            .filter_map(|p| match Regex::new(p) {
+                Ok(r) => Some(r),
+                Err(e) => {
+                    tracing::warn!("Invalid file deny pattern '{}': {}", p, e);
+                    None
+                }
+            })
+            .collect();
+
+        let deny_bash_patterns = config
+            .deny_bash_patterns
+            .iter()
+            .filter_map(|p| match Regex::new(p) {
+                Ok(r) => Some(r),
+                Err(e) => {
+                    tracing::warn!("Invalid bash deny pattern '{}': {}", p, e);
+                    None
+                }
+            })
+            .collect();
+
+        Self {
+            deny_file_patterns,
+            deny_bash_patterns,
+            allow_shell_commands: config.allow_shell_commands,
+            deny_file_raw: config.deny_file_patterns.clone(),
+            deny_bash_raw: config.deny_bash_patterns.clone(),
+        }
+    }
+
+    pub fn check_file_access(&self, path: &str) -> PermissionResult {
+        for (i, pattern) in self.deny_file_patterns.iter().enumerate() {
+            if pattern.is_match(path) {
+                let raw = &self.deny_file_raw[i];
+                return PermissionResult::Denied(format!(
+                    "File path '{}' matches deny pattern '{}'",
+                    path, raw
+                ));
+            }
+        }
+        PermissionResult::Allowed
+    }
+
+    pub fn check_bash_command(&self, command: &str) -> PermissionResult {
+        for (i, pattern) in self.deny_bash_patterns.iter().enumerate() {
+            if pattern.is_match(command) {
+                let raw = &self.deny_bash_raw[i];
+                return PermissionResult::Denied(format!(
+                    "Command matches deny pattern '{}'",
+                    raw
+                ));
+            }
+        }
+        PermissionResult::Allowed
+    }
+
+    pub fn check_tool_call(&self, call: &ToolCall) -> PermissionResult {
+        match call.name.as_str() {
+            "read_file" | "write_file" | "list_files" => {
+                if let Some(path) = call.arguments.get("path").and_then(|v| v.as_str()) {
+                    self.check_file_access(path)
+                } else {
+                    PermissionResult::Allowed
+                }
+            }
+            "run_command" => {
+                if !self.allow_shell_commands {
+                    return PermissionResult::Denied(
+                        "Shell commands are disabled by configuration".to_string(),
+                    );
+                }
+                if let Some(cmd) = call.arguments.get("command").and_then(|v| v.as_str()) {
+                    self.check_bash_command(cmd)
+                } else {
+                    PermissionResult::Allowed
+                }
+            }
+            _ => PermissionResult::Allowed,
+        }
+    }
+
+    pub fn allows_shell_commands(&self) -> bool {
+        self.allow_shell_commands
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::PermissionsConfig;
+
+    fn permissive() -> PermissionEngine {
+        PermissionEngine::new(&PermissionsConfig {
+            deny_file_patterns: vec![],
+            deny_bash_patterns: vec![],
+            allow_shell_commands: true,
+        })
+    }
+
+    fn restrictive() -> PermissionEngine {
+        PermissionEngine::new(&PermissionsConfig {
+            deny_file_patterns: vec![
+                r"\.env$".into(),
+                r"\.ssh".into(),
+                r"/etc/shadow".into(),
+            ],
+            deny_bash_patterns: vec![
+                r"rm\s+-rf\s+/".into(),
+                r"\bsudo\b".into(),
+            ],
+            allow_shell_commands: true,
+        })
+    }
+
+    #[test]
+    fn permissive_allows_everything() {
+        let engine = permissive();
+        assert!(matches!(
+            engine.check_file_access("/tmp/test.txt"),
+            PermissionResult::Allowed
+        ));
+        assert!(matches!(
+            engine.check_bash_command("ls -la"),
+            PermissionResult::Allowed
+        ));
+    }
+
+    #[test]
+    fn denies_file_patterns() {
+        let engine = restrictive();
+        assert!(matches!(
+            engine.check_file_access("/app/.env"),
+            PermissionResult::Denied(_)
+        ));
+        assert!(matches!(
+            engine.check_file_access("/home/user/.ssh/id_rsa"),
+            PermissionResult::Denied(_)
+        ));
+        assert!(matches!(
+            engine.check_file_access("/etc/shadow"),
+            PermissionResult::Denied(_)
+        ));
+    }
+
+    #[test]
+    fn allows_non_matching_files() {
+        let engine = restrictive();
+        assert!(matches!(
+            engine.check_file_access("/tmp/test.txt"),
+            PermissionResult::Allowed
+        ));
+        assert!(matches!(
+            engine.check_file_access("/home/user/code.rs"),
+            PermissionResult::Allowed
+        ));
+    }
+
+    #[test]
+    fn denies_bash_patterns() {
+        let engine = restrictive();
+        assert!(matches!(
+            engine.check_bash_command("rm -rf /"),
+            PermissionResult::Denied(_)
+        ));
+        // Regex catches extra whitespace too
+        assert!(matches!(
+            engine.check_bash_command("rm  -rf  /home"),
+            PermissionResult::Denied(_)
+        ));
+        assert!(matches!(
+            engine.check_bash_command("sudo apt install foo"),
+            PermissionResult::Denied(_)
+        ));
+    }
+
+    #[test]
+    fn allows_non_matching_commands() {
+        let engine = restrictive();
+        assert!(matches!(
+            engine.check_bash_command("ls -la"),
+            PermissionResult::Allowed
+        ));
+        assert!(matches!(
+            engine.check_bash_command("cat /tmp/test.txt"),
+            PermissionResult::Allowed
+        ));
+    }
+
+    #[test]
+    fn regex_word_boundary_prevents_false_positives() {
+        let engine = restrictive();
+        // "sudo" with word boundary should NOT match "pseudocode"
+        assert!(matches!(
+            engine.check_bash_command("echo pseudocode"),
+            PermissionResult::Allowed
+        ));
+    }
+
+    #[test]
+    fn check_tool_call_read_file() {
+        let engine = restrictive();
+        let call = ToolCall {
+            id: "1".into(),
+            name: "read_file".into(),
+            arguments: serde_json::json!({"path": "/app/.env"}),
+        };
+        assert!(matches!(
+            engine.check_tool_call(&call),
+            PermissionResult::Denied(_)
+        ));
+    }
+
+    #[test]
+    fn check_tool_call_run_command() {
+        let engine = restrictive();
+        let call = ToolCall {
+            id: "1".into(),
+            name: "run_command".into(),
+            arguments: serde_json::json!({"command": "sudo rm -rf /"}),
+        };
+        assert!(matches!(
+            engine.check_tool_call(&call),
+            PermissionResult::Denied(_)
+        ));
+    }
+
+    #[test]
+    fn check_tool_call_allowed() {
+        let engine = restrictive();
+        let call = ToolCall {
+            id: "1".into(),
+            name: "read_file".into(),
+            arguments: serde_json::json!({"path": "/tmp/test.txt"}),
+        };
+        assert!(matches!(
+            engine.check_tool_call(&call),
+            PermissionResult::Allowed
+        ));
+    }
+
+    #[test]
+    fn unknown_tool_allowed() {
+        let engine = restrictive();
+        let call = ToolCall {
+            id: "1".into(),
+            name: "unknown_tool".into(),
+            arguments: serde_json::json!({}),
+        };
+        assert!(matches!(
+            engine.check_tool_call(&call),
+            PermissionResult::Allowed
+        ));
+    }
+
+    #[test]
+    fn shell_commands_disabled_by_default() {
+        let engine = PermissionEngine::new(&PermissionsConfig::default());
+        let call = ToolCall {
+            id: "1".into(),
+            name: "run_command".into(),
+            arguments: serde_json::json!({"command": "ls -la"}),
+        };
+        assert!(matches!(
+            engine.check_tool_call(&call),
+            PermissionResult::Denied(_)
+        ));
+    }
+}

--- a/src/agent/session.rs
+++ b/src/agent/session.rs
@@ -1,0 +1,12 @@
+use crate::agent::types::{AgentMessage, SessionStatus};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Session {
+    pub id: String,
+    pub model: String,
+    pub messages: Vec<AgentMessage>,
+    pub status: SessionStatus,
+    pub created_at: i64,
+    pub updated_at: i64,
+}

--- a/src/agent/store.rs
+++ b/src/agent/store.rs
@@ -1,0 +1,417 @@
+use crate::agent::session::Session;
+use crate::agent::types::{AgentMessage, MessageRole, SessionStatus};
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+use tokio::sync::{Mutex, RwLock};
+
+#[derive(Clone)]
+pub struct SessionStore {
+    sessions: Arc<RwLock<HashMap<String, Session>>>,
+    /// Per-session locks to prevent read-modify-write races on concurrent messages
+    session_locks: Arc<RwLock<HashMap<String, Arc<Mutex<()>>>>>,
+    max_sessions: usize,
+    persist_dir: Option<PathBuf>,
+}
+
+impl SessionStore {
+    pub fn new(max_sessions: usize) -> Self {
+        Self {
+            sessions: Arc::new(RwLock::new(HashMap::new())),
+            session_locks: Arc::new(RwLock::new(HashMap::new())),
+            max_sessions,
+            persist_dir: None,
+        }
+    }
+
+    /// Create a persistent store that saves sessions to disk.
+    /// Loads any existing sessions from the directory on construction.
+    pub fn persistent(max_sessions: usize, dir: PathBuf) -> anyhow::Result<Self> {
+        std::fs::create_dir_all(&dir)?;
+
+        let mut sessions = HashMap::new();
+        let mut locks = HashMap::new();
+        for entry in std::fs::read_dir(&dir)? {
+            let entry = entry?;
+            let path = entry.path();
+            if path.extension().and_then(|e| e.to_str()) == Some("json") {
+                match std::fs::read_to_string(&path) {
+                    Ok(content) => match serde_json::from_str::<Session>(&content) {
+                        Ok(session) => {
+                            tracing::info!("Restored session {} (model: {})", session.id, session.model);
+                            locks.insert(session.id.clone(), Arc::new(Mutex::new(())));
+                            sessions.insert(session.id.clone(), session);
+                        }
+                        Err(e) => {
+                            tracing::warn!("Skipping corrupt session file {:?}: {}", path, e);
+                        }
+                    },
+                    Err(e) => {
+                        tracing::warn!("Failed to read session file {:?}: {}", path, e);
+                    }
+                }
+            }
+        }
+
+        let count = sessions.len();
+        if count > 0 {
+            tracing::info!("Loaded {} sessions from disk", count);
+        }
+
+        Ok(Self {
+            sessions: Arc::new(RwLock::new(sessions)),
+            session_locks: Arc::new(RwLock::new(locks)),
+            max_sessions,
+            persist_dir: Some(dir),
+        })
+    }
+
+    /// Acquire a per-session lock for exclusive mutation.
+    /// Returns None if the session doesn't exist.
+    pub async fn lock_session(&self, id: &str) -> Option<SessionLockGuard> {
+        let locks = self.session_locks.read().await;
+        let lock = locks.get(id)?.clone();
+        drop(locks);
+        let guard = lock.lock_owned().await;
+        Some(SessionLockGuard { _guard: guard })
+    }
+
+    pub async fn create(
+        &self,
+        model: String,
+        system_prompt: Option<String>,
+    ) -> Result<Session, String> {
+        let mut sessions = self.sessions.write().await;
+        if sessions.len() >= self.max_sessions {
+            return Err(format!("Maximum sessions ({}) reached", self.max_sessions));
+        }
+
+        let now = chrono::Utc::now().timestamp();
+        let id = uuid::Uuid::new_v4().to_string();
+
+        let mut messages = Vec::new();
+        if let Some(prompt) = system_prompt {
+            messages.push(AgentMessage {
+                role: MessageRole::System,
+                content: prompt,
+                tool_calls: None,
+                tool_call_id: None,
+            });
+        }
+
+        let session = Session {
+            id: id.clone(),
+            model,
+            messages,
+            status: SessionStatus::Active,
+            created_at: now,
+            updated_at: now,
+        };
+
+        sessions.insert(id.clone(), session.clone());
+        drop(sessions);
+
+        // Create lock for this session
+        {
+            let mut locks = self.session_locks.write().await;
+            locks.insert(id, Arc::new(Mutex::new(())));
+        }
+
+        self.persist_session(&session);
+        Ok(session)
+    }
+
+    pub async fn get(&self, id: &str) -> Option<Session> {
+        let sessions = self.sessions.read().await;
+        sessions.get(id).cloned()
+    }
+
+    pub async fn list(&self) -> Vec<Session> {
+        let sessions = self.sessions.read().await;
+        let mut list: Vec<Session> = sessions.values().cloned().collect();
+        list.sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
+        list
+    }
+
+    pub async fn delete(&self, id: &str) -> bool {
+        let removed = {
+            let mut sessions = self.sessions.write().await;
+            sessions.remove(id).is_some()
+        };
+        if removed {
+            // Remove the per-session lock
+            let mut locks = self.session_locks.write().await;
+            locks.remove(id);
+            drop(locks);
+            self.remove_persisted(id);
+        }
+        removed
+    }
+
+    pub async fn update(&self, session: Session) {
+        {
+            let mut sessions = self.sessions.write().await;
+            sessions.insert(session.id.clone(), session.clone());
+        }
+        self.persist_session(&session);
+    }
+
+    /// Remove sessions whose `updated_at` is older than `max_age_secs` seconds ago.
+    /// Returns the number of sessions removed.
+    pub async fn reap_expired(&self, max_age_secs: i64) -> usize {
+        let cutoff = chrono::Utc::now().timestamp() - max_age_secs;
+        let expired_ids: Vec<String> = {
+            let sessions = self.sessions.read().await;
+            sessions
+                .iter()
+                .filter(|(_, s)| s.updated_at < cutoff)
+                .map(|(id, _)| id.clone())
+                .collect()
+        };
+        let count = expired_ids.len();
+        if count > 0 {
+            let mut sessions = self.sessions.write().await;
+            let mut locks = self.session_locks.write().await;
+            for id in &expired_ids {
+                sessions.remove(id);
+                locks.remove(id);
+            }
+            drop(sessions);
+            drop(locks);
+            for id in &expired_ids {
+                self.remove_persisted(id);
+            }
+        }
+        count
+    }
+
+    fn is_safe_id(id: &str) -> bool {
+        !id.is_empty()
+            && !id.contains('/')
+            && !id.contains('\\')
+            && !id.contains("..")
+            && id.len() < 128
+    }
+
+    /// Write a session to disk (fire-and-forget, logs errors).
+    fn persist_session(&self, session: &Session) {
+        if let Some(dir) = &self.persist_dir {
+            if !Self::is_safe_id(&session.id) {
+                tracing::error!("Refusing to persist session with unsafe ID: {}", session.id);
+                return;
+            }
+            let path = dir.join(format!("{}.json", session.id));
+            match serde_json::to_string_pretty(session) {
+                Ok(json) => {
+                    if let Err(e) = std::fs::write(&path, json) {
+                        tracing::error!("Failed to persist session {}: {}", session.id, e);
+                    }
+                }
+                Err(e) => {
+                    tracing::error!("Failed to serialize session {}: {}", session.id, e);
+                }
+            }
+        }
+    }
+
+    /// Remove a session file from disk.
+    fn remove_persisted(&self, id: &str) {
+        if let Some(dir) = &self.persist_dir {
+            if !Self::is_safe_id(id) {
+                return;
+            }
+            let path = dir.join(format!("{}.json", id));
+            if path.exists() {
+                if let Err(e) = std::fs::remove_file(&path) {
+                    tracing::error!("Failed to remove session file {}: {}", id, e);
+                }
+            }
+        }
+    }
+}
+
+/// RAII guard for per-session locks. Hold this while mutating a session
+/// to prevent concurrent read-modify-write races.
+pub struct SessionLockGuard {
+    _guard: tokio::sync::OwnedMutexGuard<()>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn create_session_basic() {
+        let store = SessionStore::new(10);
+        let session = store.create("llama3:8b".into(), None).await.unwrap();
+
+        assert_eq!(session.model, "llama3:8b");
+        assert_eq!(session.status, SessionStatus::Active);
+        assert!(session.messages.is_empty());
+        assert!(!session.id.is_empty());
+    }
+
+    #[tokio::test]
+    async fn create_session_with_system_prompt() {
+        let store = SessionStore::new(10);
+        let session = store
+            .create("llama3:8b".into(), Some("You are helpful.".into()))
+            .await
+            .unwrap();
+
+        assert_eq!(session.messages.len(), 1);
+        assert_eq!(session.messages[0].role, MessageRole::System);
+        assert_eq!(session.messages[0].content, "You are helpful.");
+    }
+
+    #[tokio::test]
+    async fn get_returns_created_session() {
+        let store = SessionStore::new(10);
+        let created = store.create("qwen2.5:7b".into(), None).await.unwrap();
+
+        let fetched = store.get(&created.id).await;
+        assert!(fetched.is_some());
+        assert_eq!(fetched.unwrap().id, created.id);
+    }
+
+    #[tokio::test]
+    async fn get_returns_none_for_missing() {
+        let store = SessionStore::new(10);
+        assert!(store.get("nonexistent").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn list_returns_all_sessions() {
+        let store = SessionStore::new(10);
+        store.create("model-a".into(), None).await.unwrap();
+        store.create("model-b".into(), None).await.unwrap();
+        store.create("model-c".into(), None).await.unwrap();
+
+        let list = store.list().await;
+        assert_eq!(list.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn list_empty_store() {
+        let store = SessionStore::new(10);
+        assert!(store.list().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn delete_existing_session() {
+        let store = SessionStore::new(10);
+        let session = store.create("llama3:8b".into(), None).await.unwrap();
+
+        assert!(store.delete(&session.id).await);
+        assert!(store.get(&session.id).await.is_none());
+    }
+
+    #[tokio::test]
+    async fn delete_nonexistent_returns_false() {
+        let store = SessionStore::new(10);
+        assert!(!store.delete("nonexistent").await);
+    }
+
+    #[tokio::test]
+    async fn update_modifies_session() {
+        let store = SessionStore::new(10);
+        let mut session = store.create("llama3:8b".into(), None).await.unwrap();
+
+        session.messages.push(AgentMessage {
+            role: MessageRole::User,
+            content: "Hello".into(),
+            tool_calls: None,
+            tool_call_id: None,
+        });
+        session.status = SessionStatus::Processing;
+        store.update(session.clone()).await;
+
+        let fetched = store.get(&session.id).await.unwrap();
+        assert_eq!(fetched.messages.len(), 1);
+        assert_eq!(fetched.status, SessionStatus::Processing);
+    }
+
+    #[tokio::test]
+    async fn max_sessions_enforced() {
+        let store = SessionStore::new(2);
+        store.create("model-a".into(), None).await.unwrap();
+        store.create("model-b".into(), None).await.unwrap();
+
+        let result = store.create("model-c".into(), None).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Maximum sessions"));
+    }
+
+    #[tokio::test]
+    async fn delete_frees_slot_for_new_session() {
+        let store = SessionStore::new(1);
+        let session = store.create("model-a".into(), None).await.unwrap();
+
+        store.delete(&session.id).await;
+        let result = store.create("model-b".into(), None).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn session_ids_are_unique() {
+        let store = SessionStore::new(100);
+        let mut ids = std::collections::HashSet::new();
+        for _ in 0..50 {
+            let session = store.create("model".into(), None).await.unwrap();
+            assert!(ids.insert(session.id));
+        }
+    }
+
+    #[tokio::test]
+    async fn session_lock_prevents_concurrent_access() {
+        let store = SessionStore::new(10);
+        let session = store.create("model".into(), None).await.unwrap();
+
+        // Should be able to acquire lock
+        let guard = store.lock_session(&session.id).await;
+        assert!(guard.is_some());
+        drop(guard);
+
+        // Nonexistent session returns None
+        assert!(store.lock_session("nonexistent").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn persistent_store_roundtrip() {
+        let dir = std::env::temp_dir().join(format!("herd-test-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+
+        // Create and populate
+        {
+            let store = SessionStore::persistent(10, dir.clone()).unwrap();
+            let session = store.create("llama3:8b".into(), Some("test".into())).await.unwrap();
+            assert!(dir.join(format!("{}.json", session.id)).exists());
+        }
+
+        // Reload from disk
+        {
+            let store = SessionStore::persistent(10, dir.clone()).unwrap();
+            let list = store.list().await;
+            assert_eq!(list.len(), 1);
+            assert_eq!(list[0].model, "llama3:8b");
+        }
+
+        // Cleanup
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn persistent_delete_removes_file() {
+        let dir = std::env::temp_dir().join(format!("herd-test-{}", uuid::Uuid::new_v4()));
+        let store = SessionStore::persistent(10, dir.clone()).unwrap();
+
+        let session = store.create("model".into(), None).await.unwrap();
+        let file_path = dir.join(format!("{}.json", session.id));
+        assert!(file_path.exists());
+
+        store.delete(&session.id).await;
+        assert!(!file_path.exists());
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/src/agent/tools.rs
+++ b/src/agent/tools.rs
@@ -1,0 +1,255 @@
+use crate::agent::types::ToolResult;
+use serde_json::json;
+
+/// Returns tool definitions in Ollama's expected format for `/api/chat`.
+pub fn tool_definitions(allow_shell_commands: bool) -> Vec<serde_json::Value> {
+    let mut tools = vec![
+        json!({
+            "type": "function",
+            "function": {
+                "name": "read_file",
+                "description": "Read the contents of a file at the given path",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "path": {
+                            "type": "string",
+                            "description": "The file path to read"
+                        }
+                    },
+                    "required": ["path"]
+                }
+            }
+        }),
+        json!({
+            "type": "function",
+            "function": {
+                "name": "write_file",
+                "description": "Write content to a file at the given path",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "path": {
+                            "type": "string",
+                            "description": "The file path to write to"
+                        },
+                        "content": {
+                            "type": "string",
+                            "description": "The content to write"
+                        }
+                    },
+                    "required": ["path", "content"]
+                }
+            }
+        }),
+        json!({
+            "type": "function",
+            "function": {
+                "name": "list_files",
+                "description": "List files and directories at the given path",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "path": {
+                            "type": "string",
+                            "description": "The directory path to list"
+                        }
+                    },
+                    "required": ["path"]
+                }
+            }
+        }),
+    ];
+
+    if allow_shell_commands {
+        tools.push(json!({
+            "type": "function",
+            "function": {
+                "name": "run_command",
+                "description": "Run a shell command and return its output",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "command": {
+                            "type": "string",
+                            "description": "The shell command to execute"
+                        }
+                    },
+                    "required": ["command"]
+                }
+            }
+        }));
+    }
+
+    tools
+}
+
+/// Execute a tool call and return the result.
+pub async fn execute_tool(name: &str, arguments: &serde_json::Value) -> ToolResult {
+    match name {
+        "read_file" => execute_read_file(arguments).await,
+        "write_file" => execute_write_file(arguments).await,
+        "list_files" => execute_list_files(arguments).await,
+        "run_command" => execute_run_command(arguments).await,
+        _ => ToolResult {
+            content: format!("Unknown tool: {}", name),
+            success: false,
+        },
+    }
+}
+
+async fn execute_read_file(args: &serde_json::Value) -> ToolResult {
+    let path = match args.get("path").and_then(|v| v.as_str()) {
+        Some(p) => p,
+        None => {
+            return ToolResult {
+                content: "Missing required parameter: path".into(),
+                success: false,
+            }
+        }
+    };
+
+    const MAX_READ_BYTES: u64 = 10 * 1024 * 1024; // 10 MB cap
+
+    // Check file size before reading to prevent OOM
+    match tokio::fs::metadata(path).await {
+        Ok(meta) if meta.len() > MAX_READ_BYTES => {
+            return ToolResult {
+                content: format!("File too large ({} bytes, max {})", meta.len(), MAX_READ_BYTES),
+                success: false,
+            };
+        }
+        Err(e) => {
+            return ToolResult {
+                content: format!("Error reading file: {}", e),
+                success: false,
+            };
+        }
+        _ => {}
+    }
+
+    match tokio::fs::read_to_string(path).await {
+        Ok(content) => ToolResult {
+            content,
+            success: true,
+        },
+        Err(e) => ToolResult {
+            content: format!("Error reading file: {}", e),
+            success: false,
+        },
+    }
+}
+
+async fn execute_write_file(args: &serde_json::Value) -> ToolResult {
+    let path = match args.get("path").and_then(|v| v.as_str()) {
+        Some(p) => p,
+        None => {
+            return ToolResult {
+                content: "Missing required parameter: path".into(),
+                success: false,
+            }
+        }
+    };
+    let content = match args.get("content").and_then(|v| v.as_str()) {
+        Some(c) => c,
+        None => {
+            return ToolResult {
+                content: "Missing required parameter: content".into(),
+                success: false,
+            }
+        }
+    };
+
+    match tokio::fs::write(path, content).await {
+        Ok(()) => ToolResult {
+            content: format!("Successfully wrote {} bytes to {}", content.len(), path),
+            success: true,
+        },
+        Err(e) => ToolResult {
+            content: format!("Error writing file: {}", e),
+            success: false,
+        },
+    }
+}
+
+async fn execute_list_files(args: &serde_json::Value) -> ToolResult {
+    let path = match args.get("path").and_then(|v| v.as_str()) {
+        Some(p) => p,
+        None => {
+            return ToolResult {
+                content: "Missing required parameter: path".into(),
+                success: false,
+            }
+        }
+    };
+
+    match tokio::fs::read_dir(path).await {
+        Ok(mut entries) => {
+            let mut names = Vec::new();
+            while let Ok(Some(entry)) = entries.next_entry().await {
+                let file_type = entry.file_type().await.ok();
+                let suffix = if file_type.map_or(false, |t| t.is_dir()) {
+                    "/"
+                } else {
+                    ""
+                };
+                names.push(format!("{}{}", entry.file_name().to_string_lossy(), suffix));
+            }
+            names.sort();
+            ToolResult {
+                content: names.join("\n"),
+                success: true,
+            }
+        }
+        Err(e) => ToolResult {
+            content: format!("Error listing directory: {}", e),
+            success: false,
+        },
+    }
+}
+
+async fn execute_run_command(args: &serde_json::Value) -> ToolResult {
+    let command = match args.get("command").and_then(|v| v.as_str()) {
+        Some(c) => c,
+        None => {
+            return ToolResult {
+                content: "Missing required parameter: command".into(),
+                success: false,
+            }
+        }
+    };
+
+    let output = if cfg!(target_os = "windows") {
+        tokio::process::Command::new("cmd")
+            .args(["/C", command])
+            .output()
+            .await
+    } else {
+        tokio::process::Command::new("sh")
+            .args(["-c", command])
+            .output()
+            .await
+    };
+
+    match output {
+        Ok(out) => {
+            let stdout = String::from_utf8_lossy(&out.stdout);
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            let content = if stderr.is_empty() {
+                stdout.to_string()
+            } else if stdout.is_empty() {
+                stderr.to_string()
+            } else {
+                format!("{}\n{}", stdout, stderr)
+            };
+            ToolResult {
+                content,
+                success: out.status.success(),
+            }
+        }
+        Err(e) => ToolResult {
+            content: format!("Error executing command: {}", e),
+            success: false,
+        },
+    }
+}

--- a/src/agent/types.rs
+++ b/src/agent/types.rs
@@ -1,0 +1,184 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum MessageRole {
+    System,
+    User,
+    Assistant,
+    Tool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentMessage {
+    pub role: MessageRole,
+    pub content: String,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_calls: Option<Vec<ToolCall>>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_call_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolCall {
+    pub id: String,
+    pub name: String,
+    pub arguments: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolResult {
+    pub content: String,
+    pub success: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum AgentEvent {
+    Thinking {
+        session_id: String,
+        round: u32,
+    },
+    ToolCall {
+        session_id: String,
+        tool: String,
+        arguments: serde_json::Value,
+    },
+    ToolResult {
+        session_id: String,
+        tool: String,
+        content: String,
+        success: bool,
+    },
+    PermissionDenied {
+        session_id: String,
+        tool: String,
+        reason: String,
+    },
+    Message {
+        session_id: String,
+        content: String,
+    },
+    Error {
+        session_id: String,
+        error: String,
+    },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum SessionStatus {
+    Active,
+    Processing,
+    Completed,
+    Error,
+}
+
+impl std::fmt::Display for SessionStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SessionStatus::Active => write!(f, "active"),
+            SessionStatus::Processing => write!(f, "processing"),
+            SessionStatus::Completed => write!(f, "completed"),
+            SessionStatus::Error => write!(f, "error"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn message_role_serializes_lowercase() {
+        assert_eq!(serde_json::to_string(&MessageRole::System).unwrap(), "\"system\"");
+        assert_eq!(serde_json::to_string(&MessageRole::User).unwrap(), "\"user\"");
+        assert_eq!(serde_json::to_string(&MessageRole::Assistant).unwrap(), "\"assistant\"");
+        assert_eq!(serde_json::to_string(&MessageRole::Tool).unwrap(), "\"tool\"");
+    }
+
+    #[test]
+    fn message_role_deserializes_lowercase() {
+        assert_eq!(serde_json::from_str::<MessageRole>("\"system\"").unwrap(), MessageRole::System);
+        assert_eq!(serde_json::from_str::<MessageRole>("\"user\"").unwrap(), MessageRole::User);
+        assert_eq!(serde_json::from_str::<MessageRole>("\"assistant\"").unwrap(), MessageRole::Assistant);
+        assert_eq!(serde_json::from_str::<MessageRole>("\"tool\"").unwrap(), MessageRole::Tool);
+    }
+
+    #[test]
+    fn session_status_display() {
+        assert_eq!(SessionStatus::Active.to_string(), "active");
+        assert_eq!(SessionStatus::Processing.to_string(), "processing");
+        assert_eq!(SessionStatus::Completed.to_string(), "completed");
+        assert_eq!(SessionStatus::Error.to_string(), "error");
+    }
+
+    #[test]
+    fn session_status_roundtrip() {
+        for status in [SessionStatus::Active, SessionStatus::Processing, SessionStatus::Completed, SessionStatus::Error] {
+            let json = serde_json::to_string(&status).unwrap();
+            let back: SessionStatus = serde_json::from_str(&json).unwrap();
+            assert_eq!(back, status);
+        }
+    }
+
+    #[test]
+    fn agent_message_minimal_json() {
+        let msg = AgentMessage {
+            role: MessageRole::User,
+            content: "Hello".into(),
+            tool_calls: None,
+            tool_call_id: None,
+        };
+        let json = serde_json::to_value(&msg).unwrap();
+        assert_eq!(json["role"], "user");
+        assert_eq!(json["content"], "Hello");
+        // None fields should be skipped
+        assert!(json.get("tool_calls").is_none());
+        assert!(json.get("tool_call_id").is_none());
+    }
+
+    #[test]
+    fn agent_message_with_tool_calls() {
+        let msg = AgentMessage {
+            role: MessageRole::Assistant,
+            content: String::new(),
+            tool_calls: Some(vec![ToolCall {
+                id: "call_1".into(),
+                name: "read_file".into(),
+                arguments: serde_json::json!({"path": "/tmp/test.txt"}),
+            }]),
+            tool_call_id: None,
+        };
+        let json = serde_json::to_value(&msg).unwrap();
+        assert_eq!(json["tool_calls"][0]["name"], "read_file");
+        assert_eq!(json["tool_calls"][0]["arguments"]["path"], "/tmp/test.txt");
+    }
+
+    #[test]
+    fn tool_call_roundtrip() {
+        let call = ToolCall {
+            id: "abc123".into(),
+            name: "run_command".into(),
+            arguments: serde_json::json!({"command": "ls -la"}),
+        };
+        let json = serde_json::to_string(&call).unwrap();
+        let back: ToolCall = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.id, "abc123");
+        assert_eq!(back.name, "run_command");
+    }
+
+    #[test]
+    fn tool_result_roundtrip() {
+        let result = ToolResult {
+            content: "file contents here".into(),
+            success: true,
+        };
+        let json = serde_json::to_string(&result).unwrap();
+        let back: ToolResult = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.content, "file contents here");
+        assert!(back.success);
+    }
+}

--- a/src/agent/ws.rs
+++ b/src/agent/ws.rs
@@ -1,0 +1,160 @@
+use crate::agent::executor::AgentExecutor;
+use crate::agent::permissions::PermissionEngine;
+use crate::server::AppState;
+use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
+use axum::extract::{Path, Query, State};
+use axum::http::StatusCode;
+use axum::response::Response;
+use serde::Deserialize;
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::mpsc;
+
+#[derive(Debug, Deserialize)]
+struct WsMessage {
+    content: String,
+}
+
+pub async fn ws_handler(
+    ws: WebSocketUpgrade,
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+    Query(params): Query<HashMap<String, String>>,
+) -> Result<Response, StatusCode> {
+    // Authenticate via query parameter (WebSocket can't use custom headers during upgrade)
+    {
+        let config = state.config.read().await;
+        let expected = config
+            .server
+            .api_key
+            .as_deref()
+            .map(str::trim)
+            .filter(|v| !v.is_empty())
+            .ok_or(StatusCode::FORBIDDEN)?;
+
+        let provided = params.get("api_key").ok_or(StatusCode::UNAUTHORIZED)?;
+        if !crate::server::constant_time_eq(expected.as_bytes(), provided.trim().as_bytes()) {
+            return Err(StatusCode::UNAUTHORIZED);
+        }
+    }
+
+    // Verify session exists
+    state
+        .session_store
+        .get(&id)
+        .await
+        .ok_or(StatusCode::NOT_FOUND)?;
+
+    Ok(ws.on_upgrade(move |socket| handle_ws(socket, state, id)))
+}
+
+async fn handle_ws(mut socket: WebSocket, state: AppState, session_id: String) {
+    tracing::info!("WebSocket connected for session {}", session_id);
+
+    loop {
+        // Wait for a message from the client
+        let msg = match socket.recv().await {
+            Some(Ok(Message::Text(text))) => text,
+            Some(Ok(Message::Close(_))) | None => {
+                tracing::debug!("WebSocket closed for session {}", session_id);
+                break;
+            }
+            Some(Ok(_)) => continue, // Ignore binary/ping/pong
+            Some(Err(e)) => {
+                tracing::warn!("WebSocket error for session {}: {}", session_id, e);
+                break;
+            }
+        };
+
+        // Parse the user's message
+        let ws_msg: WsMessage = match serde_json::from_str(&msg) {
+            Ok(m) => m,
+            Err(e) => {
+                let err = serde_json::json!({
+                    "type": "error",
+                    "session_id": session_id,
+                    "error": format!("Invalid message format: {}", e),
+                });
+                let _ = socket.send(Message::Text(err.to_string().into())).await;
+                continue;
+            }
+        };
+
+        // Acquire per-session lock to prevent concurrent mutation races
+        let _lock = match state.session_store.lock_session(&session_id).await {
+            Some(g) => g,
+            None => {
+                let err = serde_json::json!({
+                    "type": "error",
+                    "session_id": session_id,
+                    "error": "Session not found",
+                });
+                let _ = socket.send(Message::Text(err.to_string().into())).await;
+                break;
+            }
+        };
+
+        // Get current session
+        let mut session = match state.session_store.get(&session_id).await {
+            Some(s) => s,
+            None => {
+                let err = serde_json::json!({
+                    "type": "error",
+                    "session_id": session_id,
+                    "error": "Session not found",
+                });
+                let _ = socket.send(Message::Text(err.to_string().into())).await;
+                break;
+            }
+        };
+
+        // Create executor with event channel
+        let (tx, mut rx) = mpsc::channel(64);
+        let config = state.config.read().await;
+        let permissions = PermissionEngine::new(&config.agent.permissions);
+        let max_tool_rounds = config.agent.max_tool_rounds;
+        drop(config);
+        let router = state.router.read().await.clone();
+        let executor = AgentExecutor::new(
+            Arc::clone(&state.client),
+            router,
+            permissions,
+            max_tool_rounds,
+            state.routing_timeout(),
+        );
+
+        // Spawn executor in background so we can forward events
+        let content = ws_msg.content;
+        let exec_handle = tokio::spawn(async move {
+            executor.execute_streaming(&mut session, content, tx).await.map(|result| (result, session))
+        });
+
+        // Forward events to WebSocket and audit log
+        while let Some(event) = rx.recv().await {
+            state.agent_audit.log_event(&event).await;
+            let json = match serde_json::to_string(&event) {
+                Ok(j) => j,
+                Err(_) => continue,
+            };
+            if socket.send(Message::Text(json.into())).await.is_err() {
+                tracing::debug!("WebSocket send failed for session {}", session_id);
+                return; // Client disconnected
+            }
+        }
+
+        // Executor finished — get the result and save session
+        match exec_handle.await {
+            Ok(Ok((_, session))) => {
+                state.session_store.update(session).await;
+            }
+            Ok(Err(e)) => {
+                tracing::error!("Agent executor error for session {}: {}", session_id, e);
+            }
+            Err(e) => {
+                tracing::error!("Agent executor panicked for session {}: {}", session_id, e);
+            }
+        }
+    }
+
+    tracing::info!("WebSocket disconnected for session {}", session_id);
+}

--- a/src/api/admin.rs
+++ b/src/api/admin.rs
@@ -347,3 +347,88 @@ pub async fn list_backend_models(
         "models": data.get("models").cloned().unwrap_or(serde_json::json!([])),
     })))
 }
+
+// ---------------------------------------------------------------------------
+// Config editor endpoints
+// ---------------------------------------------------------------------------
+
+/// GET /admin/config — Return current config as JSON (api_key redacted).
+pub async fn get_config(State(state): State<AppState>) -> Json<serde_json::Value> {
+    let config = state.config_snapshot().await;
+    let mut json = serde_json::to_value(&config).unwrap_or_default();
+    // Redact secrets — show presence but not value
+    if let Some(server) = json.get_mut("server") {
+        for field in &["api_key", "enrollment_key"] {
+            if let Some(key) = server.get(*field) {
+                if key.is_string() {
+                    server[*field] = serde_json::json!("********");
+                }
+            }
+        }
+    }
+    Json(json)
+}
+
+/// PUT /admin/config — Validate, write to disk, and hot-reload.
+pub async fn update_config(
+    State(state): State<AppState>,
+    Json(mut new_config): Json<crate::config::Config>,
+) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
+    // If secrets are the redacted sentinel, preserve existing values
+    let current = state.config_snapshot().await;
+    if new_config.server.api_key.as_deref() == Some("********") {
+        new_config.server.api_key = current.server.api_key.clone();
+    }
+    if new_config.server.enrollment_key.as_deref() == Some("********") {
+        new_config.server.enrollment_key = current.server.enrollment_key.clone();
+    }
+    drop(current);
+
+    // Validate before writing
+    new_config.validate().map_err(|e| {
+        (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({"error": e.to_string()})),
+        )
+    })?;
+
+    // Write to disk (atomic: temp file + rename)
+    let path = state.config_path.as_ref().ok_or_else(|| {
+        (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({"error": "No config file path — server was started without a config file"})),
+        )
+    })?;
+
+    let yaml = new_config.to_yaml().map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({"error": format!("Failed to serialize config: {}", e)})),
+        )
+    })?;
+
+    let temp_path = path.with_extension("yaml.tmp");
+    tokio::fs::write(&temp_path, &yaml).await.map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({"error": format!("Failed to write config: {}", e)})),
+        )
+    })?;
+    tokio::fs::rename(&temp_path, path).await.map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({"error": format!("Failed to save config: {}", e)})),
+        )
+    })?;
+
+    // Trigger hot-reload
+    let msg = state.reload_config().await.map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({"error": format!("Config saved but reload failed: {}", e)})),
+        )
+    })?;
+
+    tracing::info!("Config updated via dashboard: {}", msg);
+    Ok(Json(serde_json::json!({"status": "ok", "message": msg})))
+}

--- a/src/api/agent.rs
+++ b/src/api/agent.rs
@@ -1,0 +1,182 @@
+use crate::agent::executor::AgentExecutor;
+use crate::agent::permissions::PermissionEngine;
+use crate::server::AppState;
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    Json,
+};
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+
+#[derive(Debug, Deserialize)]
+pub struct CreateSessionRequest {
+    pub model: String,
+    #[serde(default)]
+    pub system_prompt: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct SessionSummary {
+    pub id: String,
+    pub model: String,
+    pub status: String,
+    pub message_count: usize,
+    pub created_at: i64,
+    pub updated_at: i64,
+}
+
+#[derive(Debug, Serialize)]
+pub struct SessionDetail {
+    pub id: String,
+    pub model: String,
+    pub status: String,
+    pub messages: Vec<crate::agent::AgentMessage>,
+    pub created_at: i64,
+    pub updated_at: i64,
+}
+
+fn summarize(s: &crate::agent::Session) -> SessionSummary {
+    SessionSummary {
+        id: s.id.clone(),
+        model: s.model.clone(),
+        status: s.status.to_string(),
+        message_count: s.messages.len(),
+        created_at: s.created_at,
+        updated_at: s.updated_at,
+    }
+}
+
+pub async fn create_session(
+    State(state): State<AppState>,
+    Json(req): Json<CreateSessionRequest>,
+) -> Result<(StatusCode, Json<SessionSummary>), (StatusCode, String)> {
+    let session = state
+        .session_store
+        .create(req.model, req.system_prompt)
+        .await
+        .map_err(|e| (StatusCode::CONFLICT, e))?;
+
+    tracing::info!("Created agent session {} (model: {})", session.id, session.model);
+    state
+        .agent_audit
+        .log_session_created(&session.id, &session.model)
+        .await;
+    Ok((StatusCode::CREATED, Json(summarize(&session))))
+}
+
+pub async fn list_sessions(
+    State(state): State<AppState>,
+) -> Json<Vec<SessionSummary>> {
+    let sessions = state.session_store.list().await;
+    Json(sessions.iter().map(summarize).collect())
+}
+
+pub async fn get_session(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> Result<Json<SessionDetail>, StatusCode> {
+    let session = state
+        .session_store
+        .get(&id)
+        .await
+        .ok_or(StatusCode::NOT_FOUND)?;
+
+    Ok(Json(SessionDetail {
+        id: session.id,
+        model: session.model,
+        status: session.status.to_string(),
+        messages: session.messages,
+        created_at: session.created_at,
+        updated_at: session.updated_at,
+    }))
+}
+
+pub async fn delete_session(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> Result<StatusCode, StatusCode> {
+    if state.session_store.delete(&id).await {
+        tracing::info!("Deleted agent session {}", id);
+        state.agent_audit.log_session_deleted(&id).await;
+        Ok(StatusCode::NO_CONTENT)
+    } else {
+        Err(StatusCode::NOT_FOUND)
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct SendMessageRequest {
+    pub content: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct MessageResponse {
+    pub content: String,
+    pub tool_calls_made: usize,
+}
+
+pub async fn send_message(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+    Json(req): Json<SendMessageRequest>,
+) -> Result<Json<MessageResponse>, (StatusCode, String)> {
+    // Acquire per-session lock to prevent concurrent mutation races
+    let _lock = state
+        .session_store
+        .lock_session(&id)
+        .await
+        .ok_or((StatusCode::NOT_FOUND, "Session not found".into()))?;
+
+    let mut session = state
+        .session_store
+        .get(&id)
+        .await
+        .ok_or((StatusCode::NOT_FOUND, "Session not found".into()))?;
+
+    let message_count_before = session.messages.len();
+
+    let config = state.config.read().await;
+    let permissions = PermissionEngine::new(&config.agent.permissions);
+    let max_tool_rounds = config.agent.max_tool_rounds;
+    drop(config);
+    let router = state.router.read().await.clone();
+    let executor = AgentExecutor::new(
+        Arc::clone(&state.client),
+        router,
+        permissions,
+        max_tool_rounds,
+        state.routing_timeout(),
+    );
+
+    let (tx, mut rx) = tokio::sync::mpsc::channel(64);
+    let audit = Arc::clone(&state.agent_audit);
+
+    // Drain events to audit log in background
+    let audit_handle = tokio::spawn(async move {
+        while let Some(event) = rx.recv().await {
+            audit.log_event(&event).await;
+        }
+    });
+
+    let content = executor
+        .execute_streaming(&mut session, req.content, tx)
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    // Wait for audit drain to complete
+    let _ = audit_handle.await;
+
+    // Count tool calls made during this execution
+    let tool_calls_made = session.messages[message_count_before..]
+        .iter()
+        .filter(|m| m.role == crate::agent::MessageRole::Tool)
+        .count();
+
+    state.session_store.update(session).await;
+
+    Ok(Json(MessageResponse {
+        content,
+        tool_calls_made,
+    }))
+}

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,4 +1,6 @@
 pub mod admin;
+pub mod agent;
+pub mod nodes;
 pub mod openai;
 pub mod status;
 

--- a/src/api/nodes.rs
+++ b/src/api/nodes.rs
@@ -1,0 +1,258 @@
+use crate::nodes::{NodeRegistration, NodeRegistrationResponse, NodeUpdate};
+use crate::server::{constant_time_eq, AppState};
+use axum::{
+    extract::{Path, Query, State},
+    http::{HeaderMap, StatusCode},
+    Json,
+};
+use serde::{Deserialize, Serialize};
+
+const SCRIPT_WINDOWS: &str = include_str!("../../scripts/herd-tune.ps1");
+const SCRIPT_LINUX: &str = include_str!("../../scripts/herd-tune.sh");
+
+#[derive(Serialize)]
+pub struct NodesListResponse {
+    pub nodes: Vec<crate::nodes::Node>,
+}
+
+#[derive(Deserialize)]
+pub struct EnrollmentQuery {
+    pub enrollment_key: Option<String>,
+}
+
+/// POST /api/nodes/register — called by herd-tune scripts
+pub async fn register_node(
+    State(state): State<AppState>,
+    Query(query): Query<EnrollmentQuery>,
+    headers: HeaderMap,
+    Json(reg): Json<NodeRegistration>,
+) -> Result<(StatusCode, Json<NodeRegistrationResponse>), (StatusCode, Json<serde_json::Value>)> {
+    // Check enrollment key if configured
+    {
+        let config = state.config.read().await;
+        if let Some(ref expected) = config.server.enrollment_key {
+            let provided = query
+                .enrollment_key
+                .as_deref()
+                .or_else(|| headers.get("x-enrollment-key")?.to_str().ok());
+            match provided {
+                Some(key) if constant_time_eq(key.as_bytes(), expected.as_bytes()) => {}
+                _ => {
+                    return Err((
+                        StatusCode::UNAUTHORIZED,
+                        Json(serde_json::json!({"error": "Invalid or missing enrollment key"})),
+                    ));
+                }
+            }
+        }
+    }
+
+    let (id, is_new) = state.node_db.upsert_node(&reg).map_err(|e| {
+        tracing::error!("Failed to register node: {}", e);
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({"error": format!("Registration failed: {}", e)})),
+        )
+    })?;
+
+    let status_code = if is_new {
+        StatusCode::CREATED
+    } else {
+        StatusCode::OK
+    };
+    let message = if is_new {
+        "Node registered successfully. Health polling started.".to_string()
+    } else {
+        "Node re-registered successfully. Configuration updated.".to_string()
+    };
+
+    tracing::info!(
+        "Node {} ({}) {} — id={}",
+        reg.hostname,
+        reg.ollama_url,
+        if is_new { "registered" } else { "re-registered" },
+        id
+    );
+
+    Ok((
+        status_code,
+        Json(NodeRegistrationResponse {
+            id,
+            hostname: reg.hostname,
+            status: "registered".to_string(),
+            message,
+        }),
+    ))
+}
+
+/// GET /api/nodes — list all registered nodes
+pub async fn list_nodes(
+    State(state): State<AppState>,
+) -> Result<Json<NodesListResponse>, (StatusCode, Json<serde_json::Value>)> {
+    let nodes = state.node_db.list_nodes().map_err(|e| {
+        tracing::error!("Failed to list nodes: {}", e);
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({"error": format!("Failed to list nodes: {}", e)})),
+        )
+    })?;
+    Ok(Json(NodesListResponse { nodes }))
+}
+
+/// GET /api/nodes/:id — get a single node
+pub async fn get_node(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> Result<Json<crate::nodes::Node>, (StatusCode, Json<serde_json::Value>)> {
+    match state.node_db.get_node(&id) {
+        Ok(Some(node)) => Ok(Json(node)),
+        Ok(None) => Err((
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({"error": "Node not found"})),
+        )),
+        Err(e) => {
+            tracing::error!("Failed to get node: {}", e);
+            Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({"error": format!("Failed to get node: {}", e)})),
+            ))
+        }
+    }
+}
+
+/// Check api_key from request headers against config. Returns Ok if no key
+/// is configured or if the provided key matches.
+fn check_api_key(
+    headers: &HeaderMap,
+    expected: &Option<String>,
+) -> Result<(), (StatusCode, Json<serde_json::Value>)> {
+    let Some(expected) = expected.as_deref() else {
+        return Ok(());
+    };
+    let provided = headers
+        .get("x-api-key")
+        .and_then(|v| v.to_str().ok())
+        .or_else(|| {
+            headers
+                .get("authorization")
+                .and_then(|v| v.to_str().ok())
+                .and_then(|s| s.strip_prefix("Bearer "))
+        });
+    match provided {
+        Some(key) if constant_time_eq(key.as_bytes(), expected.as_bytes()) => Ok(()),
+        _ => Err((
+            StatusCode::UNAUTHORIZED,
+            Json(serde_json::json!({"error": "API key required"})),
+        )),
+    }
+}
+
+/// PUT /api/nodes/:id — update operator-controlled fields
+pub async fn update_node(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+    headers: HeaderMap,
+    Json(update): Json<NodeUpdate>,
+) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
+    let config = state.config.read().await;
+    check_api_key(&headers, &config.server.api_key)?;
+    drop(config);
+
+    match state.node_db.update_node(&id, &update) {
+        Ok(true) => Ok(Json(serde_json::json!({"status": "updated"}))),
+        Ok(false) => Err((
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({"error": "Node not found"})),
+        )),
+        Err(e) => {
+            tracing::error!("Failed to update node: {}", e);
+            Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({"error": format!("Failed to update node: {}", e)})),
+            ))
+        }
+    }
+}
+
+/// DELETE /api/nodes/:id — remove node from fleet
+pub async fn delete_node(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+    headers: HeaderMap,
+) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
+    let config = state.config.read().await;
+    check_api_key(&headers, &config.server.api_key)?;
+    drop(config);
+    match state.node_db.delete_node(&id) {
+        Ok(true) => {
+            tracing::info!("Node {} removed from fleet", id);
+            Ok(Json(serde_json::json!({"status": "deleted"})))
+        }
+        Ok(false) => Err((
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({"error": "Node not found"})),
+        )),
+        Err(e) => {
+            tracing::error!("Failed to delete node: {}", e);
+            Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({"error": format!("Failed to delete node: {}", e)})),
+            ))
+        }
+    }
+}
+
+/// GET /api/nodes/script?os={windows|linux} — serve herd-tune script with endpoint baked in
+pub async fn download_script(
+    State(state): State<AppState>,
+    req: axum::http::Request<axum::body::Body>,
+) -> Result<axum::response::Response, (StatusCode, Json<serde_json::Value>)> {
+    // Parse query params from URI
+    let query = req.uri().query().unwrap_or("");
+    let os_param = query
+        .split('&')
+        .find_map(|p| p.strip_prefix("os="))
+        .unwrap_or("windows");
+
+    let (template, filename, content_type) = match os_param {
+        "linux" | "bash" | "sh" => (SCRIPT_LINUX, "herd-tune.sh", "application/x-sh"),
+        _ => (SCRIPT_WINDOWS, "herd-tune.ps1", "application/octet-stream"),
+    };
+
+    // Determine public URL: prefer explicit env var, fall back to Host header
+    let public_url = std::env::var("HERD_PRO_PUBLIC_URL")
+        .ok()
+        .unwrap_or_else(|| {
+            let host = req
+                .headers()
+                .get("host")
+                .and_then(|h| h.to_str().ok())
+                .unwrap_or("localhost:40114");
+            format!("http://{}", host)
+        });
+
+    let config = state.config.read().await;
+    let enrollment_key = config.server.enrollment_key.clone().unwrap_or_default();
+    drop(config);
+
+    let script = template
+        .replace("%%HERD_PRO_ENDPOINT%%", public_url.trim_end_matches('/'))
+        .replace("%%ENROLLMENT_KEY%%", &enrollment_key);
+
+    let response = axum::response::Response::builder()
+        .status(StatusCode::OK)
+        .header("content-type", content_type)
+        .header(
+            "content-disposition",
+            format!("attachment; filename=\"{}\"", filename),
+        )
+        .body(axum::body::Body::from(script))
+        .map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({"error": e.to_string()})),
+            )
+        })?;
+
+    Ok(response)
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -27,6 +27,9 @@ pub struct Config {
 
     #[serde(default)]
     pub task_classifier: TaskClassifierConfig,
+
+    #[serde(default)]
+    pub agent: AgentConfig,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -40,6 +43,10 @@ pub struct ServerConfig {
     #[serde(default)]
     pub api_key: Option<String>,
 
+    /// Enrollment key required for node registration. Auto-generated if not set.
+    #[serde(default)]
+    pub enrollment_key: Option<String>,
+
     /// Global rate limit in requests per second. 0 = unlimited.
     #[serde(default)]
     pub rate_limit: u64,
@@ -51,6 +58,7 @@ impl Default for ServerConfig {
             host: default_host(),
             port: default_port(),
             api_key: None,
+            enrollment_key: None,
             rate_limit: 0,
         }
     }
@@ -310,6 +318,72 @@ pub struct TierConfig {
     #[serde(default)]
     pub keywords: Vec<String>,
     pub model: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentConfig {
+    #[serde(default)]
+    pub enabled: bool,
+
+    #[serde(default = "default_max_sessions")]
+    pub max_sessions: usize,
+
+    #[serde(default = "default_max_tool_rounds")]
+    pub max_tool_rounds: u32,
+
+    #[serde(default)]
+    pub default_model: Option<String>,
+
+    #[serde(default)]
+    pub permissions: PermissionsConfig,
+
+    #[serde(default = "default_session_ttl")]
+    pub session_ttl_minutes: u64,
+}
+
+impl Default for AgentConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            max_sessions: default_max_sessions(),
+            max_tool_rounds: default_max_tool_rounds(),
+            default_model: None,
+            permissions: PermissionsConfig::default(),
+            session_ttl_minutes: default_session_ttl(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PermissionsConfig {
+    #[serde(default)]
+    pub deny_file_patterns: Vec<String>,
+
+    #[serde(default)]
+    pub deny_bash_patterns: Vec<String>,
+
+    #[serde(default)]
+    pub allow_shell_commands: bool,
+}
+
+impl Default for PermissionsConfig {
+    fn default() -> Self {
+        Self {
+            deny_file_patterns: Vec::new(),
+            deny_bash_patterns: Vec::new(),
+            allow_shell_commands: false,
+        }
+    }
+}
+
+fn default_max_sessions() -> usize {
+    100
+}
+fn default_max_tool_rounds() -> u32 {
+    10
+}
+fn default_session_ttl() -> u64 {
+    60
 }
 
 impl Config {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,13 +1,14 @@
+pub mod agent;
+pub mod analytics;
 pub mod api;
 pub mod backend;
 pub mod classifier;
+pub mod cli;
 pub mod config;
+pub mod metrics;
+pub mod nodes;
 pub mod router;
 pub mod server;
-
-pub mod analytics;
-pub mod cli;
-pub mod metrics;
 pub mod updater;
 
 pub use config::Config;

--- a/src/nodes/db.rs
+++ b/src/nodes/db.rs
@@ -1,0 +1,358 @@
+use super::types::*;
+use anyhow::Result;
+use rusqlite::Connection;
+use std::sync::Mutex;
+
+pub struct NodeDb {
+    conn: Mutex<Connection>,
+}
+
+impl NodeDb {
+    /// Open (or create) the database at ~/.herd/herd.db and run migrations.
+    pub fn open() -> Result<Self> {
+        let herd_dir = dirs::home_dir()
+            .ok_or_else(|| anyhow::anyhow!("Could not find home directory"))?
+            .join(".herd");
+        std::fs::create_dir_all(&herd_dir)?;
+        let db_path = herd_dir.join("herd.db");
+        let conn = Connection::open(&db_path)?;
+        conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;")?;
+        let db = Self {
+            conn: Mutex::new(conn),
+        };
+        db.migrate()?;
+        Ok(db)
+    }
+
+    fn migrate(&self) -> Result<()> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| anyhow::anyhow!("DB lock: {}", e))?;
+        conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS nodes (
+                id TEXT PRIMARY KEY,
+                hostname TEXT NOT NULL UNIQUE,
+                ollama_url TEXT NOT NULL,
+                gpu TEXT,
+                vram_mb INTEGER DEFAULT 0,
+                ram_mb INTEGER DEFAULT 0,
+                max_concurrent INTEGER DEFAULT 1,
+                ollama_version TEXT,
+                os TEXT,
+                status TEXT DEFAULT 'healthy',
+                priority INTEGER DEFAULT 10,
+                enabled INTEGER DEFAULT 1,
+                tags TEXT DEFAULT '[]',
+                models_available INTEGER DEFAULT 0,
+                models_loaded TEXT DEFAULT '[]',
+                recommended_config TEXT DEFAULT '{}',
+                config_applied INTEGER DEFAULT 0,
+                last_health_check TEXT,
+                registered_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            );",
+        )?;
+        // Migration: add stable machine identity column
+        conn.execute_batch("ALTER TABLE nodes ADD COLUMN node_id TEXT;")
+            .ok(); // silently ignores "duplicate column" on subsequent runs
+        // Create unique index separately (idempotent)
+        conn.execute_batch(
+            "CREATE UNIQUE INDEX IF NOT EXISTS idx_nodes_node_id ON nodes(node_id) WHERE node_id IS NOT NULL;",
+        )?;
+        Ok(())
+    }
+
+    /// Map a SELECT row (21 columns, node_id at index 1) to a Node struct.
+    /// Column order: id, node_id, hostname, ollama_url, gpu, vram_mb, ram_mb,
+    ///   max_concurrent, ollama_version, os, status, priority, enabled, tags,
+    ///   models_available, models_loaded, recommended_config, config_applied,
+    ///   last_health_check, registered_at, updated_at
+    fn row_to_node(row: &rusqlite::Row) -> rusqlite::Result<Node> {
+        Ok(Node {
+            id: row.get(0)?,
+            node_id: row.get(1)?,
+            hostname: row.get(2)?,
+            ollama_url: row.get(3)?,
+            gpu: row.get(4)?,
+            vram_mb: row.get::<_, i32>(5)? as u32,
+            ram_mb: row.get::<_, i32>(6)? as u32,
+            max_concurrent: row.get::<_, i32>(7)? as u32,
+            ollama_version: row.get(8)?,
+            os: row.get(9)?,
+            status: row.get(10)?,
+            priority: row.get::<_, i32>(11)? as u32,
+            enabled: row.get::<_, i32>(12)? != 0,
+            tags: serde_json::from_str(&row.get::<_, String>(13)?).unwrap_or_default(),
+            models_available: row.get::<_, i32>(14)? as u32,
+            models_loaded: serde_json::from_str(&row.get::<_, String>(15)?)
+                .unwrap_or_default(),
+            recommended_config: serde_json::from_str(&row.get::<_, String>(16)?)
+                .unwrap_or_default(),
+            config_applied: row.get::<_, i32>(17)? != 0,
+            last_health_check: row.get(18)?,
+            registered_at: row.get(19)?,
+            updated_at: row.get(20)?,
+        })
+    }
+
+    const NODE_COLUMNS: &'static str =
+        "id, node_id, hostname, ollama_url, gpu, vram_mb, ram_mb, max_concurrent,
+         ollama_version, os, status, priority, enabled, tags, models_available,
+         models_loaded, recommended_config, config_applied, last_health_check,
+         registered_at, updated_at";
+
+    /// Insert or update a node by hostname (idempotent registration).
+    /// Returns (node_id, is_new).
+    pub fn upsert_node(&self, reg: &NodeRegistration) -> Result<(String, bool)> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| anyhow::anyhow!("DB lock: {}", e))?;
+        let now = chrono::Utc::now().to_rfc3339();
+        let registered_at = reg.registered_at.clone().unwrap_or_else(|| now.clone());
+
+        // Prefer node_id for identity (stable across hostname changes),
+        // fall back to hostname for backward compatibility with old scripts.
+        let existing_id: Option<String> = reg
+            .node_id
+            .as_ref()
+            .and_then(|nid| {
+                conn.query_row(
+                    "SELECT id FROM nodes WHERE node_id = ?1",
+                    rusqlite::params![nid],
+                    |row| row.get(0),
+                )
+                .ok()
+            })
+            .or_else(|| {
+                conn.query_row(
+                    "SELECT id FROM nodes WHERE hostname = ?1",
+                    rusqlite::params![reg.hostname],
+                    |row| row.get(0),
+                )
+                .ok()
+            });
+
+        let models_loaded_json = serde_json::to_string(&reg.models_loaded)?;
+        let recommended_config_json = serde_json::to_string(&reg.recommended_config)?;
+
+        // Derive max_concurrent from recommended_config.num_parallel or default to 1
+        let max_concurrent = reg
+            .recommended_config
+            .get("num_parallel")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(1) as u32;
+
+        if let Some(id) = existing_id {
+            // Update existing node (also upgrades node_id + hostname on re-registration)
+            conn.execute(
+                "UPDATE nodes SET
+                    ollama_url = ?1, gpu = ?2, vram_mb = ?3, ram_mb = ?4,
+                    max_concurrent = ?5, ollama_version = ?6, os = ?7,
+                    status = 'healthy', models_available = ?8, models_loaded = ?9,
+                    recommended_config = ?10, config_applied = ?11, updated_at = ?12,
+                    node_id = COALESCE(?14, node_id), hostname = ?15
+                WHERE id = ?13",
+                rusqlite::params![
+                    reg.ollama_url,
+                    reg.gpu,
+                    reg.vram_mb,
+                    reg.ram_mb,
+                    max_concurrent,
+                    reg.ollama_version,
+                    reg.os,
+                    reg.models_available,
+                    models_loaded_json,
+                    recommended_config_json,
+                    reg.config_applied as i32,
+                    now,
+                    id,
+                    reg.node_id,
+                    reg.hostname
+                ],
+            )?;
+            Ok((id, false))
+        } else {
+            // Insert new node
+            let id = uuid::Uuid::new_v4().to_string();
+            conn.execute(
+                "INSERT INTO nodes (id, node_id, hostname, ollama_url, gpu, vram_mb, ram_mb,
+                    max_concurrent, ollama_version, os, status, models_available,
+                    models_loaded, recommended_config, config_applied,
+                    registered_at, updated_at)
+                VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, 'healthy', ?11, ?12, ?13, ?14, ?15, ?16)",
+                rusqlite::params![
+                    id,
+                    reg.node_id,
+                    reg.hostname,
+                    reg.ollama_url,
+                    reg.gpu,
+                    reg.vram_mb,
+                    reg.ram_mb,
+                    max_concurrent,
+                    reg.ollama_version,
+                    reg.os,
+                    reg.models_available,
+                    models_loaded_json,
+                    recommended_config_json,
+                    reg.config_applied as i32,
+                    registered_at,
+                    now
+                ],
+            )?;
+            Ok((id, true))
+        }
+    }
+
+    /// Get all nodes.
+    pub fn list_nodes(&self) -> Result<Vec<Node>> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| anyhow::anyhow!("DB lock: {}", e))?;
+        let sql = format!(
+            "SELECT {} FROM nodes ORDER BY priority ASC, hostname ASC",
+            Self::NODE_COLUMNS
+        );
+        let mut stmt = conn.prepare(&sql)?;
+        let nodes = stmt
+            .query_map([], Self::row_to_node)?
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(nodes)
+    }
+
+    /// Get a single node by ID.
+    pub fn get_node(&self, id: &str) -> Result<Option<Node>> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| anyhow::anyhow!("DB lock: {}", e))?;
+        let sql = format!(
+            "SELECT {} FROM nodes WHERE id = ?1",
+            Self::NODE_COLUMNS
+        );
+        let result = conn.query_row(&sql, rusqlite::params![id], Self::row_to_node);
+        match result {
+            Ok(node) => Ok(Some(node)),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    /// Update operator-controlled fields (priority, tags, enabled).
+    pub fn update_node(&self, id: &str, update: &NodeUpdate) -> Result<bool> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| anyhow::anyhow!("DB lock: {}", e))?;
+        let now = chrono::Utc::now().to_rfc3339();
+
+        // Check if node exists
+        let exists: bool = conn.query_row(
+            "SELECT COUNT(*) FROM nodes WHERE id = ?1",
+            rusqlite::params![id],
+            |row| row.get::<_, i32>(0),
+        )? > 0;
+
+        if !exists {
+            return Ok(false);
+        }
+
+        if let Some(priority) = update.priority {
+            conn.execute(
+                "UPDATE nodes SET priority = ?1, updated_at = ?2 WHERE id = ?3",
+                rusqlite::params![priority as i32, &now, id],
+            )?;
+        }
+        if let Some(ref tags) = update.tags {
+            let tags_json = serde_json::to_string(tags)?;
+            conn.execute(
+                "UPDATE nodes SET tags = ?1, updated_at = ?2 WHERE id = ?3",
+                rusqlite::params![tags_json, &now, id],
+            )?;
+        }
+        if let Some(enabled) = update.enabled {
+            let status = if enabled { "healthy" } else { "disabled" };
+            conn.execute(
+                "UPDATE nodes SET enabled = ?1, status = ?2, updated_at = ?3 WHERE id = ?4",
+                rusqlite::params![enabled as i32, status, &now, id],
+            )?;
+        }
+
+        Ok(true)
+    }
+
+    /// Delete a node.
+    pub fn delete_node(&self, id: &str) -> Result<bool> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| anyhow::anyhow!("DB lock: {}", e))?;
+        let rows = conn.execute("DELETE FROM nodes WHERE id = ?1", rusqlite::params![id])?;
+        Ok(rows > 0)
+    }
+
+    /// Update node health status and loaded models (called by health poller).
+    pub fn update_health(
+        &self,
+        id: &str,
+        status: &str,
+        models_loaded: &[String],
+        models_available: Option<u32>,
+    ) -> Result<()> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| anyhow::anyhow!("DB lock: {}", e))?;
+        let now = chrono::Utc::now().to_rfc3339();
+        let models_json = serde_json::to_string(models_loaded)?;
+
+        if let Some(avail) = models_available {
+            conn.execute(
+                "UPDATE nodes SET status = ?1, models_loaded = ?2, models_available = ?3, last_health_check = ?4, updated_at = ?4 WHERE id = ?5",
+                rusqlite::params![status, models_json, avail as i32, now, id],
+            )?;
+        } else {
+            conn.execute(
+                "UPDATE nodes SET status = ?1, models_loaded = ?2, last_health_check = ?3, updated_at = ?3 WHERE id = ?4",
+                rusqlite::params![status, models_json, now, id],
+            )?;
+        }
+        Ok(())
+    }
+
+    /// Get nodes that should be health-checked (enabled, not disabled by operator).
+    pub fn get_pollable_nodes(&self) -> Result<Vec<Node>> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| anyhow::anyhow!("DB lock: {}", e))?;
+        let sql = format!(
+            "SELECT {} FROM nodes WHERE enabled = 1",
+            Self::NODE_COLUMNS
+        );
+        let mut stmt = conn.prepare(&sql)?;
+        let nodes = stmt
+            .query_map([], Self::row_to_node)?
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(nodes)
+    }
+
+    /// Get nodes eligible for routing (enabled + healthy/degraded).
+    pub fn get_routable_nodes(&self) -> Result<Vec<Node>> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| anyhow::anyhow!("DB lock: {}", e))?;
+        let sql = format!(
+            "SELECT {} FROM nodes WHERE enabled = 1 AND status IN ('healthy', 'degraded') ORDER BY priority ASC",
+            Self::NODE_COLUMNS
+        );
+        let mut stmt = conn.prepare(&sql)?;
+        let nodes = stmt
+            .query_map([], Self::row_to_node)?
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(nodes)
+    }
+}

--- a/src/nodes/health.rs
+++ b/src/nodes/health.rs
@@ -1,0 +1,239 @@
+use crate::backend::BackendPool;
+use crate::nodes::NodeDb;
+use serde::Deserialize;
+use std::sync::Arc;
+use std::time::Duration;
+
+/// Ollama /api/ps response
+#[derive(Debug, Deserialize)]
+struct OllamaPsResponse {
+    #[serde(default)]
+    models: Vec<OllamaPsModel>,
+}
+
+#[derive(Debug, Deserialize)]
+struct OllamaPsModel {
+    name: String,
+}
+
+/// Ollama /api/tags response
+#[derive(Debug, Deserialize)]
+struct OllamaTagsResponse {
+    #[serde(default)]
+    models: Vec<OllamaTagModel>,
+}
+
+#[derive(Debug, Deserialize)]
+struct OllamaTagModel {
+    #[allow(dead_code)]
+    name: String,
+}
+
+pub struct NodeHealthPoller {
+    client: reqwest::Client,
+    poll_interval: Duration,
+    tags_interval: Duration,
+}
+
+impl NodeHealthPoller {
+    pub fn new(poll_interval_secs: u64, tags_interval_secs: u64) -> Self {
+        Self {
+            client: reqwest::Client::builder()
+                .timeout(Duration::from_secs(5))
+                .build()
+                .unwrap(),
+            poll_interval: Duration::from_secs(poll_interval_secs),
+            tags_interval: Duration::from_secs(tags_interval_secs),
+        }
+    }
+
+    /// Spawn the poller as a background tokio task.
+    /// After each poll cycle, routable nodes are synced into the BackendPool
+    /// so the existing routing strategies can route to them.
+    pub fn spawn(self, node_db: Arc<NodeDb>, pool: Arc<BackendPool>) {
+        tokio::spawn(async move {
+            let mut poll_ticker = tokio::time::interval(self.poll_interval);
+            let mut tags_counter: u64 = 0;
+            let tags_every = (self.tags_interval.as_secs() / self.poll_interval.as_secs()).max(1);
+
+            loop {
+                poll_ticker.tick().await;
+                tags_counter += 1;
+                let check_tags = tags_counter >= tags_every;
+                if check_tags {
+                    tags_counter = 0;
+                }
+                self.poll_all(&node_db, check_tags).await;
+                self.sync_to_pool(&node_db, &pool).await;
+            }
+        });
+    }
+
+    /// Syncs routable registered nodes into the BackendPool so existing
+    /// routing strategies can route to them alongside static config backends.
+    async fn sync_to_pool(&self, node_db: &NodeDb, pool: &BackendPool) {
+        let nodes = match node_db.get_routable_nodes() {
+            Ok(n) => n,
+            Err(e) => {
+                tracing::error!("Failed to get routable nodes for pool sync: {}", e);
+                return;
+            }
+        };
+
+        // Get current pool entries to detect removals
+        let current_names = pool.all().await;
+        let node_names: std::collections::HashSet<String> = nodes
+            .iter()
+            .map(|n| format!("node:{}", n.hostname))
+            .collect();
+
+        // Remove node entries that are no longer routable
+        for name in &current_names {
+            if name.starts_with("node:") && !node_names.contains(name) {
+                pool.remove(name).await;
+                tracing::debug!("Removed node backend {} from pool", name);
+            }
+        }
+
+        // Add or update node entries
+        for node in &nodes {
+            let backend_name = format!("node:{}", node.hostname);
+            let backend = crate::config::Backend {
+                name: backend_name.clone(),
+                url: node.ollama_url.clone(),
+                priority: node.priority,
+                tags: node.tags.clone(),
+                ..Default::default()
+            };
+
+            if current_names.contains(&backend_name) {
+                // Update existing entry
+                if let Some(mut state) = pool.get(&backend_name).await {
+                    state.config = backend;
+                    state.models = node.models_loaded.clone();
+                    state.healthy =
+                        node.status == "healthy" || node.status == "degraded";
+                    if node.vram_mb > 0 {
+                        state.vram_total_mb = Some(node.vram_mb as u64);
+                        state.vram_populated = true;
+                    }
+                    pool.update(state).await;
+                }
+            } else {
+                // Add new entry
+                pool.add(backend).await;
+                // Immediately set models and VRAM
+                pool.update_models(&backend_name, node.models_loaded.clone())
+                    .await;
+                if node.vram_mb > 0 {
+                    pool.set_vram(&backend_name, node.vram_mb as u64).await;
+                }
+                tracing::info!(
+                    "Added node backend {} to pool ({})",
+                    backend_name,
+                    node.ollama_url
+                );
+            }
+        }
+    }
+
+    async fn poll_all(&self, node_db: &NodeDb, check_tags: bool) {
+        let nodes = match node_db.get_pollable_nodes() {
+            Ok(n) => n,
+            Err(e) => {
+                tracing::error!("Failed to get pollable nodes: {}", e);
+                return;
+            }
+        };
+
+        for node in &nodes {
+            self.poll_node(node_db, node, check_tags).await;
+        }
+    }
+
+    async fn poll_node(&self, node_db: &NodeDb, node: &crate::nodes::Node, check_tags: bool) {
+        let base_url = node.ollama_url.trim_end_matches('/');
+
+        // GET /api/ps — loaded models
+        let ps_url = format!("{}/api/ps", base_url);
+        let ps_result = self.client.get(&ps_url).send().await;
+
+        match ps_result {
+            Ok(resp) if resp.status().is_success() => {
+                let models_loaded: Vec<String> = match resp.json::<OllamaPsResponse>().await {
+                    Ok(ps) => ps.models.into_iter().map(|m| m.name).collect(),
+                    Err(_) => vec![],
+                };
+
+                let status = "healthy";
+
+                // Optionally check /api/tags for available model count
+                let models_available = if check_tags {
+                    let tags_url = format!("{}/api/tags", base_url);
+                    match self.client.get(&tags_url).send().await {
+                        Ok(r) if r.status().is_success() => {
+                            match r.json::<OllamaTagsResponse>().await {
+                                Ok(tags) => Some(tags.models.len() as u32),
+                                Err(_) => None,
+                            }
+                        }
+                        _ => None,
+                    }
+                } else {
+                    None
+                };
+
+                if let Err(e) =
+                    node_db.update_health(&node.id, status, &models_loaded, models_available)
+                {
+                    tracing::error!(
+                        "Failed to update health for node {}: {}",
+                        node.hostname,
+                        e
+                    );
+                }
+            }
+            Ok(resp) => {
+                // Non-success status — mark degraded or unreachable
+                tracing::warn!(
+                    "Node {} ({}) returned status {} from /api/ps",
+                    node.hostname,
+                    base_url,
+                    resp.status()
+                );
+                let new_status = if node.status == "healthy" || node.status == "degraded" {
+                    "degraded"
+                } else {
+                    "unreachable"
+                };
+                if let Err(e) = node_db.update_health(&node.id, new_status, &[], None) {
+                    tracing::error!(
+                        "Failed to update health for node {}: {}",
+                        node.hostname,
+                        e
+                    );
+                }
+            }
+            Err(e) => {
+                tracing::warn!(
+                    "Node {} ({}) health check failed: {}",
+                    node.hostname,
+                    base_url,
+                    e
+                );
+                let new_status = match node.status.as_str() {
+                    "healthy" => "degraded",
+                    "degraded" => "unreachable",
+                    _ => "unreachable",
+                };
+                if let Err(e) = node_db.update_health(&node.id, new_status, &[], None) {
+                    tracing::error!(
+                        "Failed to update health for node {}: {}",
+                        node.hostname,
+                        e
+                    );
+                }
+            }
+        }
+    }
+}

--- a/src/nodes/mod.rs
+++ b/src/nodes/mod.rs
@@ -1,0 +1,7 @@
+pub mod db;
+pub mod health;
+pub mod types;
+
+pub use db::NodeDb;
+pub use health::NodeHealthPoller;
+pub use types::*;

--- a/src/nodes/types.rs
+++ b/src/nodes/types.rs
@@ -1,0 +1,76 @@
+use serde::{Deserialize, Serialize};
+
+/// Registration payload from herd-tune scripts
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NodeRegistration {
+    pub hostname: String,
+    pub ollama_url: String,
+    /// Stable machine identifier (preferred over hostname for upsert).
+    #[serde(default)]
+    pub node_id: Option<String>,
+    #[serde(default)]
+    pub gpu: Option<String>,
+    #[serde(default)]
+    pub vram_mb: u32,
+    #[serde(default)]
+    pub ram_mb: u32,
+    #[serde(default)]
+    pub ollama_version: Option<String>,
+    #[serde(default)]
+    pub models_available: u32,
+    #[serde(default)]
+    pub models_loaded: Vec<String>,
+    #[serde(default)]
+    pub recommended_config: serde_json::Value,
+    #[serde(default)]
+    pub config_applied: bool,
+    #[serde(default)]
+    pub herd_tune_version: Option<String>,
+    #[serde(default)]
+    pub os: Option<String>,
+    #[serde(default)]
+    pub registered_at: Option<String>,
+}
+
+/// Stored node record from SQLite
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Node {
+    pub id: String,
+    pub node_id: Option<String>,
+    pub hostname: String,
+    pub ollama_url: String,
+    pub gpu: Option<String>,
+    pub vram_mb: u32,
+    pub ram_mb: u32,
+    pub max_concurrent: u32,
+    pub ollama_version: Option<String>,
+    pub os: Option<String>,
+    pub status: String,
+    pub priority: u32,
+    pub enabled: bool,
+    pub tags: Vec<String>,
+    pub models_available: u32,
+    pub models_loaded: Vec<String>,
+    pub recommended_config: serde_json::Value,
+    pub config_applied: bool,
+    pub last_health_check: Option<String>,
+    pub registered_at: String,
+    pub updated_at: String,
+}
+
+/// Update payload for PUT /api/nodes/:id
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NodeUpdate {
+    pub priority: Option<u32>,
+    pub tags: Option<Vec<String>>,
+    pub enabled: Option<bool>,
+}
+
+/// Response after registration
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NodeRegistrationResponse {
+    pub id: String,
+    pub hostname: String,
+    pub status: String,
+    pub message: String,
+}

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,5 +1,7 @@
+use crate::agent::{AgentAudit, SessionStore};
+use crate::agent::ws as agent_ws;
 use crate::analytics::{Analytics, RequestLog};
-use crate::api::{admin, openai};
+use crate::api::{admin, agent, openai};
 use crate::backend::{BackendPool, HealthChecker, ModelDiscovery, ModelWarmer};
 use crate::config::{parse_duration, Config};
 use crate::router::{create_router, Router};
@@ -33,6 +35,9 @@ pub struct AppState {
     pub config: Arc<tokio::sync::RwLock<Config>>,
     pub analytics: Arc<Analytics>,
     pub metrics: Arc<crate::metrics::Metrics>,
+    pub session_store: Arc<SessionStore>,
+    pub agent_audit: Arc<AgentAudit>,
+    pub node_db: Arc<crate::nodes::NodeDb>,
     pub routing_timeout_ms: Arc<AtomicU64>,
     pub routing_retry_count: Arc<AtomicU32>,
     pub config_path: Option<PathBuf>,
@@ -176,7 +181,7 @@ impl Server {
         }
     }
 
-    pub async fn run(self) -> Result<()> {
+    pub async fn run(mut self) -> Result<()> {
         let addr = format!("{}:{}", self.config.server.host, self.config.server.port);
         info!(
             "Starting Herd on {} with {} backends",
@@ -202,6 +207,17 @@ impl Server {
             false
         } else {
             self.config.observability.admin_api
+        };
+
+        let agent_enabled = if self.config.agent.enabled
+            && self.config.server.api_key.is_none()
+        {
+            tracing::warn!(
+                "agent is enabled but server.api_key is not set — disabling agent API"
+            );
+            false
+        } else {
+            self.config.agent.enabled
         };
 
         // Create backend pool with circuit breaker config
@@ -280,6 +296,31 @@ impl Server {
                 .build()?,
         );
 
+        // Initialize agent session store and audit log
+        let session_store = if agent_enabled {
+            let session_dir = dirs::home_dir()
+                .ok_or_else(|| anyhow::anyhow!("Could not find home directory"))?
+                .join(".herd")
+                .join("sessions");
+            Arc::new(SessionStore::persistent(self.config.agent.max_sessions, session_dir)?)
+        } else {
+            Arc::new(SessionStore::new(self.config.agent.max_sessions))
+        };
+        let agent_audit = Arc::new(AgentAudit::new()?);
+
+        // Auto-generate enrollment_key if not set
+        if self.config.server.enrollment_key.is_none() {
+            let key = uuid::Uuid::new_v4().to_string();
+            tracing::info!("No enrollment_key configured. Auto-generated: {}", key);
+            self.config.server.enrollment_key = Some(key);
+        }
+
+        let node_db = Arc::new(crate::nodes::NodeDb::open()?);
+
+        // Start node health poller (polls registered nodes every 10s, tags every 60s)
+        let node_poller = crate::nodes::NodeHealthPoller::new(10, 60);
+        node_poller.spawn(Arc::clone(&node_db), Arc::clone(&pool));
+
         let state = AppState {
             pool: Arc::clone(&pool),
             router: Arc::new(tokio::sync::RwLock::new(router)),
@@ -287,11 +328,34 @@ impl Server {
             mgmt_client,
             config: Arc::new(tokio::sync::RwLock::new(self.config.clone())),
             analytics,
+            session_store,
+            agent_audit,
             metrics,
+            node_db,
             routing_timeout_ms: Arc::new(AtomicU64::new(routing_timeout.as_millis() as u64)),
             routing_retry_count: Arc::new(AtomicU32::new(self.config.routing.retry_count)),
             config_path: self.config_path.clone(),
         };
+
+        // Start session reaper and audit log cleanup (every 5 minutes)
+        if agent_enabled {
+            let ttl_secs = (self.config.agent.session_ttl_minutes * 60) as i64;
+            let store_clone = Arc::clone(&state.session_store);
+            let audit_clone = Arc::clone(&state.agent_audit);
+            tokio::spawn(async move {
+                let mut ticker = tokio::time::interval(Duration::from_secs(300));
+                loop {
+                    ticker.tick().await;
+                    let removed = store_clone.reap_expired(ttl_secs).await;
+                    if removed > 0 {
+                        tracing::info!("Session reaper removed {} expired sessions", removed);
+                    }
+                    if let Err(e) = audit_clone.cleanup_old(7 * 24 * 3600).await {
+                        tracing::error!("Audit log cleanup failed: {}", e);
+                    }
+                }
+            });
+        }
 
         // Build app with routes
         let mut app = axum::Router::new()
@@ -313,13 +377,38 @@ impl Server {
             .route("/gpu", axum::routing::get(gpu_handler))
             // Agent skills reference
             .route("/skills", axum::routing::get(skills_handler))
-            .route("/skills.md", axum::routing::get(skills_md_handler));
+            .route("/skills.md", axum::routing::get(skills_md_handler))
+            // herd-tune script download (no auth)
+            .route(
+                "/api/nodes/script",
+                axum::routing::get(crate::api::nodes::download_script),
+            )
+            // Node registration (enrollment key auth — called by herd-tune scripts)
+            .route(
+                "/api/nodes/register",
+                axum::routing::post(crate::api::nodes::register_node),
+            )
+            // Node management (public — dashboard uses these)
+            .route(
+                "/api/nodes",
+                axum::routing::get(crate::api::nodes::list_nodes),
+            )
+            .route(
+                "/api/nodes/:id",
+                axum::routing::get(crate::api::nodes::get_node)
+                    .put(crate::api::nodes::update_node)
+                    .delete(crate::api::nodes::delete_node),
+            );
 
         // Conditionally mount metrics
         if self.config.observability.metrics {
             app = app
                 .route("/metrics", axum::routing::get(metrics_handler))
-                .route("/analytics", axum::routing::get(analytics_handler));
+                .route("/analytics", axum::routing::get(analytics_handler))
+                .route(
+                    "/analytics/agent",
+                    axum::routing::get(agent_analytics_handler),
+                );
         }
 
         // Conditionally mount admin API (requires auth)
@@ -355,6 +444,42 @@ impl Server {
                 .nest("/admin/backends", admin_routes)
                 .merge(reload_route);
         }
+
+        // Conditionally mount agent API (requires auth)
+        if agent_enabled {
+            let auth_layer = axum::middleware::from_fn_with_state(state.clone(), require_api_key);
+            let agent_routes = axum::Router::new()
+                .route(
+                    "/agent/sessions",
+                    axum::routing::get(agent::list_sessions).post(agent::create_session),
+                )
+                .route(
+                    "/agent/sessions/:id",
+                    axum::routing::get(agent::get_session).delete(agent::delete_session),
+                )
+                .route(
+                    "/agent/sessions/:id/messages",
+                    axum::routing::post(agent::send_message),
+                )
+                .route(
+                    "/agent/sessions/:id/ws",
+                    axum::routing::get(agent_ws::ws_handler),
+                )
+                .layer(auth_layer);
+            app = app.merge(agent_routes);
+        }
+
+        // Config editor — always mounted (bootstrap mode for containerized deploys)
+        let config_routes = axum::Router::new()
+            .route(
+                "/admin/config",
+                axum::routing::get(admin::get_config).put(admin::update_config),
+            )
+            .layer(axum::middleware::from_fn_with_state(
+                state.clone(),
+                require_api_key,
+            ));
+        app = app.merge(config_routes);
 
         // Clone state for file watcher before it's consumed by with_state()
         let watcher_state = state.clone();
@@ -510,7 +635,7 @@ fn extract_api_key(req: &axum::extract::Request) -> Option<String> {
     None
 }
 
-fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+pub(crate) fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
     if a.len() != b.len() {
         return false;
     }
@@ -945,6 +1070,29 @@ async fn analytics_handler(
     }
 }
 
+async fn agent_analytics_handler(
+    axum::extract::State(state): axum::extract::State<AppState>,
+    axum::extract::Query(params): axum::extract::Query<std::collections::HashMap<String, String>>,
+) -> axum::Json<serde_json::Value> {
+    let hours = params
+        .get("hours")
+        .and_then(|h| h.parse::<i64>().ok())
+        .unwrap_or(24)
+        .clamp(1, 168);
+
+    let seconds = hours * 3600;
+
+    match state.agent_audit.get_stats(seconds).await {
+        Ok(stats) => axum::Json(
+            serde_json::to_value(&stats)
+                .unwrap_or_else(|_| serde_json::json!({"error": "serialization failed"})),
+        ),
+        Err(e) => axum::Json(serde_json::json!({
+            "error": format!("Failed to get agent analytics: {}", e)
+        })),
+    }
+}
+
 async fn reload_handler(
     axum::extract::State(state): axum::extract::State<AppState>,
 ) -> Result<axum::Json<serde_json::Value>, (axum::http::StatusCode, String)> {
@@ -1252,7 +1400,10 @@ mod tests {
             mgmt_client: Arc::new(reqwest::Client::new()),
             config: Arc::new(tokio::sync::RwLock::new(initial)),
             analytics: Arc::new(Analytics::new().unwrap()),
+            session_store: Arc::new(SessionStore::new(100)),
+            agent_audit: Arc::new(AgentAudit::new().unwrap()),
             metrics: Arc::new(crate::metrics::Metrics::new()),
+            node_db: Arc::new(crate::nodes::NodeDb::open().unwrap()),
             routing_timeout_ms: Arc::new(AtomicU64::new(1_000)),
             routing_retry_count: Arc::new(AtomicU32::new(1)),
             config_path: Some(temp_path.clone()),


### PR DESCRIPTION
## Summary

- Consolidates herd-pro (private repo) into herd (public) as the single canonical open-source project. Herd-pro will be archived after merge.
- Adds agent session management, tool calling, permission engine, audit logging, WebSocket streaming, node registration (herd-tune), fleet management, and dashboard Sessions/Fleet/Settings tabs
- All existing herd features preserved: task classifier, 4 routing strategies, circuit breakers, OpenAI compat, Prometheus metrics, keep_alive injection, hot model warming

## What's new from herd-pro

| Feature | Module |
|---------|--------|
| Agent sessions (create, list, resume, delete, TTL reaping) | `src/agent/` (9 files) |
| Built-in tools (read_file, write_file, list_files, run_command) | `src/agent/tools.rs` |
| Permission engine (regex deny patterns for files & shell) | `src/agent/permissions.rs` |
| JSONL audit logging | `src/agent/audit.rs` |
| WebSocket streaming for agent events | `src/agent/ws.rs` |
| Node registration via herd-tune scripts | `src/nodes/` (4 files), `scripts/` |
| Fleet management + SQLite node registry | `src/nodes/db.rs`, `src/api/nodes.rs` |
| Config editor API (GET/PUT /admin/config) | `src/api/admin.rs` |
| Dashboard: Sessions, Fleet, Settings tabs | `dashboard.html` |

## New dependency

- `rusqlite 0.31` (bundled SQLite) for node registry

## Test plan

- [x] `cargo check` passes
- [x] `cargo build` passes
- [x] `cargo test` — 111 tests passing (96 unit + 15 integration), 0 failures
- [ ] Smoke test: start with existing `herd.yaml` (no agent/nodes config) — should work unchanged
- [ ] Smoke test: enable `agent.enabled: true` with `api_key` set, verify session CRUD
- [ ] Smoke test: verify dashboard loads with all tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)