### PR TITLE
feat: Herd v1.0 — llama-server backend, multi-vendor fleet support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,11 +11,24 @@
 | **Repo** | `swift-innovate/herd` (GitHub) |
 | **Language** | Rust |
 | **Version** | 0.9.0 |
-| **Purpose** | Intelligent Ollama router — GPU-aware routing, circuit breakers, OpenAI compat, agent sessions, fleet management, dashboard |
+| **Purpose** | Intelligent LLM router — GPU-aware routing, circuit breakers, OpenAI compat, agent sessions, fleet management, dashboard |
 
-Herd is a single-binary reverse proxy for Ollama backends. It routes AI workloads across local GPU nodes with model awareness, health tracking, and observability.
+Herd is a single-binary reverse proxy for local LLM backends. It routes AI workloads across local GPU nodes with model awareness, health tracking, and observability.
 
 As of v0.9.0, the former private "Herd Pro" repository has been merged into this repo. **There is only one Herd repo now.**
+
+## Backend Strategy
+
+Herd supports two backend types per node:
+
+1. **Ollama** (current, stable) — Herd talks to Ollama's HTTP API. herd-tune configures Ollama env vars.
+2. **llama-server** (target for v1.x) — Herd talks to llama.cpp's llama-server via its OpenAI-compatible API. herd-tune detects GPU vendor, downloads the correct llama-server binary, and starts it.
+
+**Why llama-server?** Benchmarked on RTX 5090 (2026-04-08): llama-server delivers 44-80% faster TTFT and ~4x throughput vs Ollama on the same model and hardware. Ollama's Go serving layer is the bottleneck. Full benchmark data and architecture details in `docs/LLAMA_CPP_BACKEND.md`.
+
+**Herd doesn't care about GPU vendor.** Both backends expose OpenAI-compatible HTTP. The GPU backend complexity (CUDA vs ROCm vs SYCL vs Vulkan) is pushed to node setup via herd-tune. Herd routes requests — it doesn't do inference.
+
+**Important:** Ollama support is NOT being removed. Both backends coexist. The `backend` field in node registration distinguishes them. Existing Ollama fleet deployments continue working unchanged.
 
 ## Architecture
 
@@ -48,6 +61,12 @@ cargo test           # 111 tests (unit + integration)
 cargo build --release  # Release build
 ```
 
+## Key Design Docs
+
+- `docs/LLAMA_CPP_BACKEND.md` — Benchmark results, llama-server backend strategy, GPU support matrix, herd-tune changes, fleet architecture
+- `docs/specs/herd-tune-spec.md` — Node auto-registration spec (supports both Ollama and llama-server backends)
+- `ROADMAP.md` — Release milestones and feature targets
+
 ## Code Quality Rules
 
 - All new features default to `enabled: false` — zero overhead when not opted in
@@ -57,11 +76,16 @@ cargo build --release  # Release build
 - Tests for each feature — at minimum: enabled/disabled, happy path, edge cases
 - All public-facing headers use the `X-Herd-` prefix
 - **Never bail! on config errors** — degrade gracefully, warn+disable features
+- **Backend-agnostic routing** — routing logic must work identically for Ollama and llama-server backends. Use the `backend` field in node registration to determine health check paths and model list behavior, but the router itself treats all nodes as OpenAI-compatible HTTP endpoints.
 
 ## Commit Format
 
 Use conventional commits: `feat:`, `fix:`, `chore:`, `refactor:`, `docs:`, `test:`
 
+Git default branch is `main`. Always `git branch -M main` after `git init`.
+
 ## Roadmap
 
-See `ROADMAP.md`. Next milestone targets: budget caps, routing profiles, multi-model consensus.
+See `ROADMAP.md`. Current priorities:
+- **llama-server backend support** — herd-tune GPU detection, binary download, backend-aware health checks
+- Budget caps, routing profiles, multi-model consensus (v1.0+)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ dirs = "5.0"
 uuid = { version = "1", features = ["v4"] }
 self_update = { version = "0.42", features = ["archive-zip", "archive-tar", "compression-flate2", "compression-zip-deflate"] }
 rusqlite = { version = "0.31", features = ["bundled"] }
+futures-util = "0.3"
 
 [dev-dependencies]
 tokio-test = "0.4"

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,16 +1,17 @@
 # Herd Roadmap
 
-**Updated:** April 5, 2026
+**Updated:** April 8, 2026
 
 ## Vision
 
-Herd is the **fastest way to route AI workloads across local Ollama backends**.
+Herd is the **fastest way to route AI workloads across local inference backends**.
 
 One fast, single Rust binary gives you:
-- GPU-aware routing across multiple Ollama nodes
+- GPU-aware routing across multiple inference nodes (llama-server, Ollama, or any OpenAI-compatible backend)
 - Circuit breaker resilience with configurable failure thresholds
 - Unified observability: metrics, analytics, and a live dashboard
 - OpenAI-compatible API for drop-in compatibility
+- Fleet mode: one host orchestrates multiple GPU nodes across hardware vendors (NVIDIA, AMD, Intel)
 
 No cloud dependency. No API keys exposed. Full local control.
 
@@ -78,7 +79,23 @@ No cloud dependency. No API keys exposed. Full local control.
 - Dashboard: Sessions, Fleet, and Settings (config editor) tabs
 - Config editor API (`GET/PUT /admin/config`) with secret redaction
 
-### v1.0.0+ — Scale & Ecosystem (Future)
+### v1.0.0 — llama.cpp Backend & Multi-Vendor Fleet
+
+> **Strategic shift:** Benchmarking validated that Ollama's Go layer adds 45-80% TTFT overhead vs raw llama-server. Herd v1.0 adds llama-server as a first-class backend, making Herd vendor-agnostic across NVIDIA, AMD, and Intel GPUs. See `docs/LLAMA_CPP_BACKEND.md` for full analysis and benchmark data.
+
+- **llama-server backend support** — route to llama-server (llama.cpp) endpoints alongside Ollama
+- **Backend type field** — `backend: "ollama" | "llama-server" | "openai-compat"` per node in config and registry
+- **herd-tune GPU detection** — auto-detect NVIDIA (nvidia-smi), AMD (rocm-smi), Intel (sycl-ls) and select correct llama-server binary
+- **herd-tune binary provisioning** — download and verify correct llama-server build (CUDA 12/13, ROCm, SYCL, Vulkan fallback)
+- **Blackwell detection** — CUDA 13.x required for RTX 5000-series; CUDA 12.x silently falls back to CPU (critical herd-tune check)
+- **Extended node registration** — `gpu_vendor`, `gpu_backend`, `cuda_version`, `backend_version`, `capabilities` fields
+- **Model search CLI** — `herd search <query>` for HuggingFace GGUF discovery (inspired by Fox engine UX)
+- **Model download with resume** — robust GGUF pull with partial download tracking
+- **Ollama blob extraction** — reuse existing Ollama models by extracting raw GGUF from blob storage
+- **Health check abstraction** — backend-aware health probes (Ollama `/api/ps` vs llama-server `/health`)
+- Backward compatible — existing Ollama-only configs continue to work unchanged
+
+### v1.1.0+ — Scale & Ecosystem (Future)
 
 - Multi-node discovery (mDNS / static fleet config)
 - TLS termination
@@ -88,6 +105,7 @@ No cloud dependency. No API keys exposed. Full local control.
 - Budget caps and cost tracking
 - Routing profiles (named presets)
 - Multi-model consensus routing
+- llama.cpp RPC integration for tensor-parallel sharding across fleet nodes
 
 ## Get Involved
 

--- a/dashboard.html
+++ b/dashboard.html
@@ -441,6 +441,123 @@
             .stat-value { font-size: 22px; }
         }
 
+        /* Backend Type Badges */
+        .badge-backend {
+            display: inline-block; padding: 2px 8px; border-radius: 10px;
+            font-size: 10px; font-weight: 700; text-transform: uppercase;
+            letter-spacing: 0.5px; vertical-align: middle;
+        }
+        .badge-backend.ollama { background: rgba(96, 165, 250, 0.15); color: #60a5fa; }
+        .badge-backend.llama-server { background: rgba(74, 222, 128, 0.15); color: #4ade80; }
+        .badge-backend.unknown { background: rgba(100, 116, 139, 0.15); color: #94a3b8; }
+
+        /* GPU Info Tags */
+        .gpu-info-row { display: flex; gap: 6px; flex-wrap: wrap; margin-bottom: 10px; }
+        .gpu-info-tag {
+            font-size: 10px; padding: 2px 6px; border-radius: 4px;
+            background: rgba(255,255,255,0.04); color: #94a3b8;
+        }
+        .gpu-info-tag strong { color: #e2e8f0; }
+        .capability-tag {
+            font-size: 10px; padding: 2px 6px; border-radius: 4px;
+            background: rgba(251, 191, 36, 0.1); color: #fbbf24; font-weight: 600;
+        }
+
+        /* Models Tab */
+        .models-search-bar {
+            display: flex; gap: 12px; align-items: center; flex-wrap: wrap;
+            margin-bottom: 20px; padding: 16px 20px;
+            background: linear-gradient(135deg, #1a1a2e 0%, #16213e 100%);
+            border: 1px solid rgba(255,255,255,0.06); border-radius: 12px;
+        }
+        .models-search-bar input[type="text"] {
+            flex: 1; min-width: 200px; padding: 8px 14px; border-radius: 8px;
+            border: 1px solid rgba(255,255,255,0.1); background: rgba(255,255,255,0.04);
+            color: #e2e8f0; font-size: 14px; outline: none;
+        }
+        .models-search-bar input[type="text"]:focus { border-color: rgba(99,102,241,0.5); }
+        .models-search-bar select {
+            padding: 8px 12px; border-radius: 8px;
+            border: 1px solid rgba(255,255,255,0.1); background: #1e293b;
+            color: #e2e8f0; font-size: 13px; outline: none;
+        }
+        .model-result-card {
+            background: linear-gradient(135deg, #1a1a2e 0%, #16213e 100%);
+            border: 1px solid rgba(255,255,255,0.06); border-radius: 12px;
+            padding: 16px 20px; margin-bottom: 12px;
+            transition: border-color 0.3s;
+        }
+        .model-result-card:hover { border-color: rgba(99, 102, 241, 0.3); }
+        .model-result-header { display: flex; justify-content: space-between; align-items: flex-start; margin-bottom: 8px; }
+        .model-result-name { font-size: 15px; font-weight: 600; color: #e2e8f0; }
+        .model-result-author { font-size: 12px; color: #64748b; }
+        .model-result-meta { display: flex; gap: 12px; flex-wrap: wrap; align-items: center; margin-bottom: 8px; }
+        .model-result-meta .meta-item { font-size: 12px; }
+        .model-fits-badges { display: flex; gap: 4px; flex-wrap: wrap; margin-top: 6px; }
+        .fit-badge {
+            font-size: 10px; padding: 2px 6px; border-radius: 4px;
+            background: rgba(74, 222, 128, 0.1); color: #4ade80; font-weight: 600;
+        }
+        .downloads-section {
+            margin-bottom: 20px; padding: 16px 20px;
+            background: linear-gradient(135deg, #1a1a2e 0%, #16213e 100%);
+            border: 1px solid rgba(255,255,255,0.06); border-radius: 12px;
+        }
+        .downloads-section h3 { font-size: 14px; font-weight: 600; color: #e2e8f0; margin-bottom: 12px; }
+        .download-progress-item {
+            display: flex; align-items: center; gap: 12px; margin-bottom: 8px;
+            font-size: 13px; color: #94a3b8;
+        }
+        .download-progress-bar {
+            flex: 1; height: 6px; background: rgba(255,255,255,0.06);
+            border-radius: 3px; overflow: hidden;
+        }
+        .download-progress-fill {
+            height: 100%; border-radius: 3px; background: #818cf8;
+            transition: width 0.3s;
+        }
+
+        /* Download Modal */
+        .node-select-list { max-height: 200px; overflow-y: auto; margin: 12px 0; }
+        .node-select-item {
+            display: flex; justify-content: space-between; align-items: center;
+            padding: 8px 12px; border-radius: 8px; cursor: pointer;
+            margin-bottom: 4px; font-size: 13px; color: #94a3b8;
+            background: rgba(255,255,255,0.03);
+            transition: background 0.2s;
+        }
+        .node-select-item:hover { background: rgba(99, 102, 241, 0.1); }
+        .node-select-item.selected { background: rgba(99, 102, 241, 0.2); border: 1px solid rgba(99, 102, 241, 0.4); }
+        .node-select-item .node-vram { font-size: 11px; color: #64748b; }
+
+        /* Analytics Extended */
+        .analytics-grid-2col {
+            display: grid; grid-template-columns: 1fr 1fr; gap: 16px;
+            margin-top: 16px;
+        }
+        .metric-hero {
+            text-align: center; padding: 20px;
+            background: linear-gradient(135deg, #1a1a2e 0%, #16213e 100%);
+            border: 1px solid rgba(255,255,255,0.06); border-radius: 12px;
+        }
+        .metric-hero-value { font-size: 32px; font-weight: 700; letter-spacing: -1px; }
+        .metric-hero-label { font-size: 12px; color: #64748b; margin-top: 4px; }
+        .metric-hero-sub { font-size: 11px; color: #475569; margin-top: 2px; }
+        .metric-hero.cost .metric-hero-value { color: #4ade80; }
+        .metric-hero.tps .metric-hero-value { color: #fbbf24; }
+        .latency-table-card {
+            background: linear-gradient(135deg, #1a1a2e 0%, #16213e 100%);
+            border: 1px solid rgba(255,255,255,0.06); border-radius: 12px;
+            padding: 16px 20px; margin-top: 16px;
+        }
+        .latency-table-card h3 {
+            font-size: 14px; font-weight: 600; color: #94a3b8; margin-bottom: 12px;
+        }
+        @media (max-width: 768px) {
+            .analytics-grid-2col { grid-template-columns: 1fr; }
+            .models-search-bar { flex-direction: column; }
+        }
+
         /* Fleet Management */
         .fleet-add-node {
             margin-bottom: 24px; padding: 20px;
@@ -595,6 +712,9 @@
             <div class="tab" data-tab="fleet" onclick="switchTab('fleet')">
                 Fleet <span class="tab-badge" id="fleet-tab-badge">0</span>
             </div>
+            <div class="tab" data-tab="models" onclick="switchTab('models')">
+                Models
+            </div>
             <div class="tab" data-tab="settings" onclick="switchTab('settings')">
                 Settings
             </div>
@@ -640,6 +760,62 @@
                     <div class="latency-value" id="lat-p99">--</div>
                     <div class="latency-label">p99 Latency</div>
                 </div>
+            </div>
+
+            <!-- Token & Cost Metrics -->
+            <div class="analytics-grid-2col" style="margin-top:16px;">
+                <div class="metric-hero cost">
+                    <div class="metric-hero-value" id="analytics-cost">$0.00</div>
+                    <div class="metric-hero-label">Estimated API Cost Avoided</div>
+                    <div class="metric-hero-sub">Based on equivalent cloud API pricing</div>
+                </div>
+                <div class="metric-hero tps">
+                    <div class="metric-hero-value" id="analytics-tps">--</div>
+                    <div class="metric-hero-label">Avg Tokens/Second</div>
+                    <div class="metric-hero-sub" id="analytics-tokens-total"></div>
+                </div>
+            </div>
+
+            <!-- Token Usage Chart -->
+            <div class="chart-card" style="margin-top:16px;">
+                <div class="chart-title">Token Usage by Model</div>
+                <div class="chart-container" style="height:250px;">
+                    <canvas id="tokenUsageChart"></canvas>
+                </div>
+            </div>
+
+            <!-- Top Models by Token Volume -->
+            <div class="chart-card" style="margin-top:16px;">
+                <div class="chart-title">Top Models by Token Volume</div>
+                <div class="chart-container" style="height:200px;">
+                    <canvas id="topModelsTokenChart"></canvas>
+                </div>
+            </div>
+
+            <!-- Per-Model Latency Table -->
+            <div class="latency-table-card">
+                <h3>Per-Model Latency</h3>
+                <table class="data-table" id="model-latency-table">
+                    <thead>
+                        <tr><th>Model</th><th>P50</th><th>P95</th><th>P99</th></tr>
+                    </thead>
+                    <tbody id="model-latency-body">
+                        <tr><td colspan="4" style="text-align:center; color:#64748b; padding:20px;">No data yet</td></tr>
+                    </tbody>
+                </table>
+            </div>
+
+            <!-- Per-Backend Latency Table -->
+            <div class="latency-table-card">
+                <h3>Per-Backend Latency</h3>
+                <table class="data-table" id="backend-latency-table">
+                    <thead>
+                        <tr><th>Backend</th><th>P50</th><th>P95</th><th>P99</th></tr>
+                    </thead>
+                    <tbody id="backend-latency-body">
+                        <tr><td colspan="4" style="text-align:center; color:#64748b; padding:20px;">No data yet</td></tr>
+                    </tbody>
+                </table>
             </div>
         </div>
 
@@ -787,13 +963,22 @@ Content-Type: application/json
         <div class="tab-content" id="tab-fleet">
             <div class="fleet-add-node">
                 <h3>Add Node to Fleet</h3>
-                <p>Run the herd-tune script on any machine with Ollama to auto-detect hardware and register with this Herd instance.</p>
+                <p>Run the herd-tune script on any machine to auto-detect hardware and register with this Herd instance.</p>
 
-                <div class="script-download-buttons">
-                    <a href="/api/nodes/script?os=windows" class="btn btn-primary" download>
+                <div style="margin: 12px 0;">
+                    <label style="font-size:12px; color:#94a3b8; display:block; margin-bottom:6px;">Backend Type</label>
+                    <select id="fleet-backend-select" onchange="updateFleetScriptLinks()" style="padding:6px 12px; border-radius:8px; border:1px solid rgba(255,255,255,0.1); background:#1e293b; color:#e2e8f0; font-size:13px;">
+                        <option value="auto">Auto-detect</option>
+                        <option value="ollama">Ollama</option>
+                        <option value="llama-server">llama-server</option>
+                    </select>
+                </div>
+
+                <div class="script-download-buttons" id="fleet-script-buttons">
+                    <a href="/api/nodes/script?os=windows" class="btn btn-primary" download id="fleet-script-win">
                         Windows (PowerShell)
                     </a>
-                    <a href="/api/nodes/script?os=linux" class="btn btn-secondary" download>
+                    <a href="/api/nodes/script?os=linux" class="btn btn-secondary" download id="fleet-script-linux">
                         Linux (Bash)
                     </a>
                 </div>
@@ -806,7 +991,7 @@ Content-Type: application/json
                                 <h4>Windows</h4>
                                 <ol>
                                     <li>Download herd-tune.ps1 (button above)</li>
-                                    <li>Open PowerShell as Administrator on your Ollama machine</li>
+                                    <li>Open PowerShell as Administrator on your machine</li>
                                     <li>Run: <code>.\herd-tune.ps1 -Apply</code></li>
                                     <li>Done &mdash; your node will appear in the fleet below</li>
                                 </ol>
@@ -815,7 +1000,7 @@ Content-Type: application/json
                                 <h4>Linux</h4>
                                 <ol>
                                     <li>Download herd-tune.sh (button above)</li>
-                                    <li>On your Ollama machine:<br>
+                                    <li>On your machine:<br>
                                         <code>chmod +x herd-tune.sh</code><br>
                                         <code>sudo ./herd-tune.sh --apply</code></li>
                                     <li>Done &mdash; your node will appear in the fleet below</li>
@@ -832,12 +1017,12 @@ Content-Type: application/json
                     <thead>
                         <tr>
                             <th>Hostname</th>
+                            <th>Backend</th>
                             <th>GPU</th>
                             <th>VRAM</th>
                             <th>RAM</th>
                             <th>Status</th>
-                            <th>Models Loaded</th>
-                            <th>Available</th>
+                            <th>Models</th>
                             <th>Parallel</th>
                             <th>Priority</th>
                             <th>Actions</th>
@@ -847,6 +1032,61 @@ Content-Type: application/json
                         <tr><td colspan="10" class="empty-state">No nodes registered yet. Download and run herd-tune to add nodes.</td></tr>
                     </tbody>
                 </table>
+            </div>
+        </div>
+
+        <!-- Models Tab -->
+        <div class="tab-content" id="tab-models">
+            <!-- Active Downloads -->
+            <div class="downloads-section" id="models-downloads-section" style="display:none;">
+                <h3>Active Downloads</h3>
+                <div id="models-downloads-list"></div>
+            </div>
+
+            <!-- Search Bar -->
+            <div class="models-search-bar">
+                <input type="text" id="models-search-input" placeholder="Search HuggingFace for GGUF models..." onkeydown="if(event.key==='Enter')searchModels()">
+                <select id="models-quant-filter">
+                    <option value="">All Quants</option>
+                    <option value="Q4_K_M">Q4_K_M</option>
+                    <option value="Q4_K_S">Q4_K_S</option>
+                    <option value="Q5_K_M">Q5_K_M</option>
+                    <option value="Q5_K_S">Q5_K_S</option>
+                    <option value="Q6_K">Q6_K</option>
+                    <option value="Q8_0">Q8_0</option>
+                    <option value="IQ4_XS">IQ4_XS</option>
+                </select>
+                <select id="models-size-filter">
+                    <option value="">Any Size</option>
+                    <option value="4">4 GB</option>
+                    <option value="8">8 GB</option>
+                    <option value="16">16 GB</option>
+                    <option value="32">32 GB</option>
+                </select>
+                <button class="btn btn-primary" onclick="searchModels()">Search</button>
+            </div>
+
+            <!-- Results -->
+            <div id="models-results">
+                <div class="empty-state">
+                    <div class="empty-state-title">Search for GGUF Models</div>
+                    <div class="empty-state-text">Enter a model name above to search HuggingFace for GGUF quantized models.</div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Model Download Modal -->
+        <div class="modal-overlay" id="model-download-modal-overlay">
+            <div class="modal">
+                <h2>Download Model</h2>
+                <p style="color:#94a3b8; font-size:13px; margin-bottom:12px;" id="download-modal-model-name"></p>
+                <p style="color:#64748b; font-size:12px; margin-bottom:12px;" id="download-modal-file-info"></p>
+                <label style="display:block; font-size:13px; color:#94a3b8; margin-bottom:8px;">Select target node:</label>
+                <div class="node-select-list" id="download-node-list"></div>
+                <div class="modal-actions">
+                    <button class="btn-cancel" onclick="closeDownloadModal()">Cancel</button>
+                    <button class="btn-submit" id="download-modal-start-btn" onclick="startModelDownload()" disabled>Download</button>
+                </div>
             </div>
         </div>
 
@@ -1094,7 +1334,7 @@ Content-Type: application/json
     <div class="toast-container" id="toast-container"></div>
 
     <script>
-        let timelineChart, modelChart, backendChart;
+        let timelineChart, modelChart, backendChart, tokenUsageChart, topModelsTokenChart;
         let currentSessionId = null;
         let refreshCountdown = 5;
         let countdownInterval = null;
@@ -1114,6 +1354,8 @@ Content-Type: application/json
                     timelineChart?.resize();
                     modelChart?.resize();
                     backendChart?.resize();
+                    tokenUsageChart?.resize();
+                    topModelsTokenChart?.resize();
                 }, 50);
             }
             // Fleet tab: start/stop auto-refresh
@@ -1470,10 +1712,14 @@ Content-Type: application/json
 
             const urlDisplay = b.url ? truncate(b.url, 40) : '';
 
+            const backendType = b.backend || 'ollama';
+            const backendBadgeClass = backendType === 'llama-server' ? 'llama-server' : backendType === 'ollama' ? 'ollama' : 'unknown';
+            const backendBadgeLabel = backendType === 'llama-server' ? 'llama-server' : 'Ollama';
+
             return `
                 <div class="card ${isOnline ? '' : 'offline'}">
                     <div class="card-header">
-                        <span class="card-name">${escapeHtml(b.name)}</span>
+                        <span class="card-name">${escapeHtml(b.name)} <span class="badge-backend ${backendBadgeClass}">${backendBadgeLabel}</span></span>
                         <div class="card-actions">
                             <button class="btn btn-sm" onclick="openEditModal('${b.name}')">Edit</button>
                             <button class="btn btn-sm btn-danger" onclick="removeBackend('${b.name}')">&#x2715;</button>
@@ -1485,6 +1731,7 @@ Content-Type: application/json
                         <span class="meta-item">P: <strong>${b.priority}</strong></span>
                         <span class="meta-item">Models: <strong>${b.model_count || b.models?.length || 0}</strong></span>
                         ${b.vram_total_mb ? `<span class="meta-item">VRAM: <strong>${(b.vram_total_mb / 1024).toFixed(1)} GB</strong></span>` : ''}
+                        ${b.backend_version ? `<span class="meta-item">Ver: <strong>${escapeHtml(b.backend_version)}</strong></span>` : ''}
                         <span class="card-status ${cls}"><span class="dot ${cls}"></span>${isOnline ? 'Online' : 'Offline'}</span>
                     </div>
                     ${gpuHtml}
@@ -1543,6 +1790,36 @@ Content-Type: application/json
                     y: { grid: { display: false }, ticks: { color: '#64748b' } }
                 }}
             });
+
+            // Token Usage stacked bar chart
+            tokenUsageChart = new Chart(document.getElementById('tokenUsageChart'), {
+                type: 'bar',
+                data: {
+                    labels: [],
+                    datasets: [
+                        { label: 'Tokens In', data: [], backgroundColor: '#818cf8', borderRadius: 4, stack: 'tokens' },
+                        { label: 'Tokens Out', data: [], backgroundColor: '#4ade80', borderRadius: 4, stack: 'tokens' }
+                    ]
+                },
+                options: {
+                    ...opts,
+                    plugins: { legend: { display: true, labels: { color: '#64748b', font: { size: 11 } } } },
+                    scales: {
+                        x: { grid: { display: false }, ticks: { color: '#64748b' }, stacked: true },
+                        y: { beginAtZero: true, grid: { color: 'rgba(255,255,255,0.05)' }, ticks: { color: '#64748b' }, stacked: true }
+                    }
+                }
+            });
+
+            // Top Models by Token Volume horizontal bar
+            topModelsTokenChart = new Chart(document.getElementById('topModelsTokenChart'), {
+                type: 'bar',
+                data: { labels: [], datasets: [{ label: 'Total Tokens', data: [], backgroundColor: '#fbbf24', borderRadius: 4 }] },
+                options: { ...opts, indexAxis: 'y', scales: {
+                    x: { beginAtZero: true, grid: { color: 'rgba(255,255,255,0.05)' }, ticks: { color: '#64748b' } },
+                    y: { grid: { display: false }, ticks: { color: '#64748b' } }
+                }}
+            });
         }
 
         // -- Update Stats & Charts from Analytics --
@@ -1591,6 +1868,75 @@ Content-Type: application/json
                     backendChart.data.labels = backends.map(b => b[0]);
                     backendChart.data.datasets[0].data = backends.map(b => b[1]);
                     backendChart.update('none');
+                }
+
+                // Token usage by model (stacked bar)
+                if (data.model_token_counts) {
+                    const tokenModels = Object.entries(data.model_token_counts).slice(0, 10);
+                    tokenUsageChart.data.labels = tokenModels.map(m => m[0].split(':')[0]);
+                    tokenUsageChart.data.datasets[0].data = tokenModels.map(m => Array.isArray(m[1]) ? m[1][0] : (m[1].tokens_in || 0));
+                    tokenUsageChart.data.datasets[1].data = tokenModels.map(m => Array.isArray(m[1]) ? m[1][1] : (m[1].tokens_out || 0));
+                    tokenUsageChart.update('none');
+                }
+
+                // Top models by total token volume
+                if (data.model_token_counts) {
+                    const sorted = Object.entries(data.model_token_counts)
+                        .map(([k, v]) => {
+                            const tin = Array.isArray(v) ? v[0] : (v.tokens_in || 0);
+                            const tout = Array.isArray(v) ? v[1] : (v.tokens_out || 0);
+                            return [k, tin + tout];
+                        })
+                        .sort((a, b) => b[1] - a[1]).slice(0, 5);
+                    topModelsTokenChart.data.labels = sorted.map(m => m[0].split(':')[0]);
+                    topModelsTokenChart.data.datasets[0].data = sorted.map(m => m[1]);
+                    topModelsTokenChart.update('none');
+                }
+
+                // Cost estimation
+                if (data.estimated_api_cost_usd !== undefined) {
+                    document.getElementById('analytics-cost').textContent = '$' + data.estimated_api_cost_usd.toFixed(2);
+                }
+
+                // Tokens per second
+                if (data.tokens_per_second_avg !== undefined) {
+                    document.getElementById('analytics-tps').textContent = data.tokens_per_second_avg.toFixed(1) + ' t/s';
+                }
+
+                // Total tokens summary
+                const totalIn = data.total_tokens_in || 0;
+                const totalOut = data.total_tokens_out || 0;
+                if (totalIn > 0 || totalOut > 0) {
+                    document.getElementById('analytics-tokens-total').textContent =
+                        `${totalIn.toLocaleString()} in / ${totalOut.toLocaleString()} out`;
+                }
+
+                // Per-model latency table
+                if (data.model_latency) {
+                    const tbody = document.getElementById('model-latency-body');
+                    const entries = Object.entries(data.model_latency);
+                    if (entries.length > 0) {
+                        tbody.innerHTML = entries.map(([model, lat]) => `<tr>
+                            <td><strong>${escapeHtml(model)}</strong></td>
+                            <td>${formatMs(lat.p50 || 0)}</td>
+                            <td>${formatMs(lat.p95 || 0)}</td>
+                            <td>${formatMs(lat.p99 || 0)}</td>
+                        </tr>`).join('');
+                    }
+                }
+
+                // Per-backend latency table
+                if (data.backend_latency) {
+                    const tbody = document.getElementById('backend-latency-body');
+                    const entries = Object.entries(data.backend_latency);
+                    if (entries.length > 0) {
+                        tbody.innerHTML = entries.map(([backend, lat]) => `<tr>
+                            <td><strong>${escapeHtml(backend)}</strong></td>
+                            <td>${formatMs(lat.p50 || 0)}</td>
+                            <td>${formatMs(lat.p95 || 0)}</td>
+                            <td>${formatMs(lat.p99 || 0)}</td>
+                        </tr>`).join('');
+                    }
                 }
             } catch (e) {
                 console.error('Charts update failed:', e);
@@ -1836,7 +2182,6 @@ Content-Type: application/json
                                    node.status === 'degraded' ? 'status-degraded' :
                                    node.status === 'disabled' ? 'status-disabled' : 'status-unreachable';
                 const statusDot = `<span class="status-dot ${statusClass}"></span>`;
-                const modelsLoaded = (node.models_loaded || []).join(', ') || '\u2014';
                 const vramGB = node.vram_mb ? (node.vram_mb / 1024).toFixed(1) + ' GB' : '\u2014';
                 const ramGB = node.ram_mb ? (node.ram_mb / 1024).toFixed(1) + ' GB' : '\u2014';
                 const enabledToggle = `<label class="toggle-switch">
@@ -1844,14 +2189,58 @@ Content-Type: application/json
                     <span class="toggle-slider"></span>
                 </label>`;
 
+                // Backend type badge
+                const bt = node.backend || 'ollama';
+                const btClass = bt === 'llama-server' ? 'llama-server' : bt === 'ollama' ? 'ollama' : 'unknown';
+                const btLabel = bt === 'llama-server' ? 'llama-server' : 'Ollama';
+                const backendBadge = `<span class="badge-backend ${btClass}">${btLabel}</span>`;
+                const backendVer = node.backend_version ? `<br><small style="color:#64748b;">${escapeHtml(node.backend_version)}</small>` : '';
+
+                // GPU info
+                const gpuModel = node.gpu_model || node.gpu || '\u2014';
+                let gpuInfoHtml = escapeHtml(gpuModel);
+                const gpuTags = [];
+                if (node.gpu_vendor) gpuTags.push(node.gpu_vendor);
+                if (node.gpu_backend) gpuTags.push(node.gpu_backend);
+                if (node.cuda_version) gpuTags.push('CUDA ' + node.cuda_version);
+                if (gpuTags.length > 0) {
+                    gpuInfoHtml += '<br><span style="display:flex; gap:3px; flex-wrap:wrap; margin-top:3px;">' +
+                        gpuTags.map(t => `<span class="gpu-info-tag">${escapeHtml(t)}</span>`).join('') + '</span>';
+                }
+                // Capabilities
+                const caps = node.capabilities || [];
+                if (caps.length > 0) {
+                    gpuInfoHtml += '<span style="display:flex; gap:3px; flex-wrap:wrap; margin-top:3px;">' +
+                        caps.map(c => `<span class="capability-tag">${escapeHtml(c)}</span>`).join('') + '</span>';
+                }
+
+                // Models info
+                let modelsHtml = '';
+                const modelsLoaded = node.models_loaded || [];
+                if (modelsLoaded.length > 0) {
+                    modelsHtml = '<small>' + modelsLoaded.map(m => escapeHtml(m)).join(', ') + '</small>';
+                }
+                // For llama-server, also show model_paths as available GGUFs
+                const modelPaths = node.model_paths || [];
+                if (bt === 'llama-server' && modelPaths.length > 0) {
+                    const ggufNames = modelPaths.map(p => {
+                        const parts = p.replace(/\\/g, '/').split('/');
+                        return parts[parts.length - 1];
+                    });
+                    if (modelsLoaded.length > 0) modelsHtml += '<br>';
+                    modelsHtml += '<small style="color:#64748b;">GGUFs: ' + ggufNames.map(n => escapeHtml(n)).join(', ') + '</small>';
+                } else if (modelsLoaded.length === 0) {
+                    modelsHtml = '<small style="color:#64748b;">\u2014</small>';
+                }
+
                 return `<tr class="${!node.enabled ? 'row-disabled' : ''}">
                     <td><strong>${escapeHtml(node.hostname || '')}</strong><br><small style="color:#64748b;">${escapeHtml(node.ollama_url || '')}</small></td>
-                    <td>${escapeHtml(node.gpu || '\u2014')}</td>
+                    <td>${backendBadge}${backendVer}</td>
+                    <td>${gpuInfoHtml}</td>
                     <td>${vramGB}</td>
                     <td>${ramGB}</td>
                     <td>${statusDot} ${escapeHtml(node.status || 'unknown')}</td>
-                    <td><small>${escapeHtml(modelsLoaded)}</small></td>
-                    <td>${node.models_available || 0}</td>
+                    <td>${modelsHtml}</td>
                     <td>${node.max_concurrent || 0}</td>
                     <td>
                         <input type="number" class="inline-input" value="${node.priority || 50}" min="1" max="100"
@@ -1917,6 +2306,208 @@ Content-Type: application/json
                 clearInterval(fleetRefreshInterval);
                 fleetRefreshInterval = null;
             }
+        }
+
+        // -- Fleet Script Backend Selector --
+        function updateFleetScriptLinks() {
+            const backend = document.getElementById('fleet-backend-select').value;
+            const suffix = backend !== 'auto' ? `&backend=${backend}` : '';
+            document.getElementById('fleet-script-win').href = `/api/nodes/script?os=windows${suffix}`;
+            document.getElementById('fleet-script-linux').href = `/api/nodes/script?os=linux${suffix}`;
+        }
+
+        // -- Models Tab --
+        let modelSearchResults = [];
+        let activeModelDownloads = {};
+        let selectedDownloadNode = null;
+        let pendingDownloadModel = null;
+
+        async function searchModels() {
+            const query = document.getElementById('models-search-input').value.trim();
+            if (!query) return;
+            const quant = document.getElementById('models-quant-filter').value;
+            const maxSize = document.getElementById('models-size-filter').value;
+            const resultsEl = document.getElementById('models-results');
+            resultsEl.innerHTML = '<div class="empty-state"><div class="empty-state-title">Searching...</div></div>';
+
+            try {
+                let url = `/api/models/search?q=${encodeURIComponent(query)}`;
+                if (quant) url += `&quant=${encodeURIComponent(quant)}`;
+                if (maxSize) url += `&max_size_gb=${maxSize}`;
+                const res = await authFetch(url);
+                if (!res.ok) throw new Error(`Search failed (${res.status})`);
+                const data = await res.json();
+                modelSearchResults = data.results || data.models || [];
+                renderModelResults();
+            } catch (e) {
+                resultsEl.innerHTML = `<div class="empty-state"><div class="empty-state-title">Search Failed</div><div class="empty-state-text">${escapeHtml(e.message)}</div></div>`;
+            }
+        }
+
+        function formatFileSize(bytes) {
+            if (!bytes) return '?';
+            const gb = bytes / (1024 * 1024 * 1024);
+            if (gb >= 1) return gb.toFixed(1) + ' GB';
+            const mb = bytes / (1024 * 1024);
+            return mb.toFixed(0) + ' MB';
+        }
+
+        function renderModelResults() {
+            const el = document.getElementById('models-results');
+            if (modelSearchResults.length === 0) {
+                el.innerHTML = '<div class="empty-state"><div class="empty-state-title">No results</div><div class="empty-state-text">Try a different search term or adjust filters.</div></div>';
+                return;
+            }
+            el.innerHTML = modelSearchResults.map((m, i) => {
+                const name = m.name || m.model_name || '';
+                const author = m.author || '';
+                const quant = m.quant || m.quantization || '';
+                const size = m.size || m.file_size || 0;
+                const downloads = m.downloads || m.download_count || 0;
+                const fitsOn = m.fits_on || [];
+
+                return `<div class="model-result-card">
+                    <div class="model-result-header">
+                        <div>
+                            <div class="model-result-name">${escapeHtml(name)}</div>
+                            ${author ? `<div class="model-result-author">by ${escapeHtml(author)}</div>` : ''}
+                        </div>
+                        <button class="btn btn-primary btn-sm" onclick="openDownloadModal(${i})">Download</button>
+                    </div>
+                    <div class="model-result-meta">
+                        ${quant ? `<span class="meta-item">Quant: <strong>${escapeHtml(quant)}</strong></span>` : ''}
+                        ${size ? `<span class="meta-item">Size: <strong>${formatFileSize(size)}</strong></span>` : ''}
+                        ${downloads ? `<span class="meta-item">Downloads: <strong>${downloads.toLocaleString()}</strong></span>` : ''}
+                    </div>
+                    ${fitsOn.length > 0 ? `<div class="model-fits-badges">
+                        <span style="font-size:11px; color:#64748b; margin-right:4px;">Fits on:</span>
+                        ${fitsOn.map(h => `<span class="fit-badge">${escapeHtml(h)}</span>`).join('')}
+                    </div>` : ''}
+                </div>`;
+            }).join('');
+        }
+
+        function openDownloadModal(index) {
+            pendingDownloadModel = modelSearchResults[index];
+            selectedDownloadNode = null;
+            const name = pendingDownloadModel.name || pendingDownloadModel.model_name || '';
+            const size = pendingDownloadModel.size || pendingDownloadModel.file_size || 0;
+            document.getElementById('download-modal-model-name').textContent = name;
+            document.getElementById('download-modal-file-info').textContent = size ? `File size: ${formatFileSize(size)}` : '';
+            document.getElementById('download-modal-start-btn').disabled = true;
+
+            // Build node list from fleet
+            const listEl = document.getElementById('download-node-list');
+            if (fleetNodes.length === 0) {
+                listEl.innerHTML = '<div style="padding:12px; color:#64748b; font-size:13px;">No nodes registered in fleet.</div>';
+            } else {
+                listEl.innerHTML = fleetNodes.filter(n => n.enabled && n.status === 'healthy').map(n => {
+                    const vram = n.vram_mb ? (n.vram_mb / 1024).toFixed(1) + ' GB VRAM' : '';
+                    return `<div class="node-select-item" data-node-id="${n.id}" onclick="selectDownloadNode('${n.id}', this)">
+                        <span><strong>${escapeHtml(n.hostname || n.id)}</strong></span>
+                        <span class="node-vram">${vram}</span>
+                    </div>`;
+                }).join('');
+            }
+
+            document.getElementById('model-download-modal-overlay').classList.add('active');
+        }
+
+        function selectDownloadNode(id, el) {
+            selectedDownloadNode = id;
+            document.querySelectorAll('#download-node-list .node-select-item').forEach(n => n.classList.remove('selected'));
+            el.classList.add('selected');
+            document.getElementById('download-modal-start-btn').disabled = false;
+        }
+
+        function closeDownloadModal() {
+            document.getElementById('model-download-modal-overlay').classList.remove('active');
+            pendingDownloadModel = null;
+            selectedDownloadNode = null;
+        }
+
+        async function startModelDownload() {
+            if (!selectedDownloadNode || !pendingDownloadModel) return;
+            const modelName = pendingDownloadModel.name || pendingDownloadModel.model_name || '';
+            const nodeId = selectedDownloadNode;
+            closeDownloadModal();
+
+            const downloadId = `${nodeId}-${Date.now()}`;
+            activeModelDownloads[downloadId] = { nodeId, model: modelName, progress: 0, status: 'Starting...' };
+            renderActiveDownloads();
+
+            try {
+                const res = await authFetch(`/api/nodes/${nodeId}/models/download`, {
+                    method: 'POST',
+                    headers: {'Content-Type': 'application/json'},
+                    body: JSON.stringify({
+                        model: modelName,
+                        url: pendingDownloadModel.download_url || pendingDownloadModel.url || '',
+                        file_name: pendingDownloadModel.file_name || ''
+                    })
+                });
+                if (!res.ok) {
+                    const text = await res.text();
+                    throw new Error(text);
+                }
+
+                // Try to read streaming progress
+                if (res.body) {
+                    const reader = res.body.getReader();
+                    const decoder = new TextDecoder();
+                    let buffer = '';
+                    while (true) {
+                        const {done, value} = await reader.read();
+                        if (done) break;
+                        buffer += decoder.decode(value, {stream: true});
+                        const lines = buffer.split('\n');
+                        buffer = lines.pop();
+                        for (const line of lines) {
+                            if (!line.trim()) continue;
+                            try {
+                                const data = JSON.parse(line);
+                                if (data.progress !== undefined) {
+                                    activeModelDownloads[downloadId].progress = data.progress;
+                                }
+                                if (data.status) {
+                                    activeModelDownloads[downloadId].status = data.status;
+                                }
+                                renderActiveDownloads();
+                            } catch (_) {}
+                        }
+                    }
+                }
+
+                delete activeModelDownloads[downloadId];
+                renderActiveDownloads();
+                showToast(`Downloaded ${modelName}`);
+            } catch (e) {
+                activeModelDownloads[downloadId].status = `Failed: ${e.message}`;
+                renderActiveDownloads();
+                setTimeout(() => { delete activeModelDownloads[downloadId]; renderActiveDownloads(); }, 5000);
+                showToast(`Download failed: ${e.message}`, 'error');
+            }
+        }
+
+        function renderActiveDownloads() {
+            const section = document.getElementById('models-downloads-section');
+            const list = document.getElementById('models-downloads-list');
+            const entries = Object.entries(activeModelDownloads);
+            if (entries.length === 0) {
+                section.style.display = 'none';
+                return;
+            }
+            section.style.display = 'block';
+            list.innerHTML = entries.map(([id, dl]) => {
+                const pct = Math.round(dl.progress || 0);
+                return `<div class="download-progress-item">
+                    <span style="min-width:120px;"><strong>${escapeHtml(dl.model)}</strong></span>
+                    <div class="download-progress-bar">
+                        <div class="download-progress-fill" style="width:${pct}%"></div>
+                    </div>
+                    <span style="min-width:80px; text-align:right;">${escapeHtml(dl.status)}</span>
+                </div>`;
+            }).join('');
         }
 
         // -- Settings / Config Editor --
@@ -2107,13 +2698,16 @@ Content-Type: application/json
 
         // -- Keyboard & Click Handlers --
         document.addEventListener('keydown', e => {
-            if (e.key === 'Escape') { closeModal(); closeSessionModal(); }
+            if (e.key === 'Escape') { closeModal(); closeSessionModal(); closeDownloadModal(); }
         });
         document.getElementById('modal-overlay').addEventListener('click', e => {
             if (e.target === e.currentTarget) closeModal();
         });
         document.getElementById('session-modal-overlay').addEventListener('click', e => {
             if (e.target === e.currentTarget) closeSessionModal();
+        });
+        document.getElementById('model-download-modal-overlay').addEventListener('click', e => {
+            if (e.target === e.currentTarget) closeDownloadModal();
         });
 
         // -- Initialize --

--- a/docs/LLAMA_CPP_BACKEND.md
+++ b/docs/LLAMA_CPP_BACKEND.md
@@ -1,0 +1,155 @@
+# Herd + llama.cpp: Backend Strategy
+
+**Date:** 2026-04-08
+**Status:** Validated via benchmark — proceeding with implementation planning
+
+## Summary
+
+Benchmarking on CITADEL (RTX 5090) proved that Ollama's Go serving layer adds massive overhead compared to raw llama-server. On identical hardware and the same model (Gemma 4 26B-A4B, Q4_K_M), llama-server delivers 44-80% faster TTFT and ~4x throughput. This validates Herd's long-term direction: replace Ollama as the per-node inference backend with llama-server, while keeping Herd as the fleet router.
+
+## Benchmark Results
+
+**Hardware:** RTX 5090 (32GB VRAM), CITADEL, Windows 11
+**Model:** Gemma 4 26B-A4B (MoE, 4B active params) — unsloth UD-Q4_K_M (15.7GB)
+**llama.cpp build:** b8678 (CUDA 13.1)
+**Ollama:** warmed model, v1 API
+
+| Test | Ollama TTFT | llama.cpp TTFT | Delta |
+|------|-------------|----------------|-------|
+| Cold single-shot | 6,812 ms | 3,781 ms | -44.5% |
+| Heavy system prompt (~1.5k tokens) | 14,331 ms | 5,574 ms | -61.1% |
+| Multi-turn (5 rounds) | 13,832 ms | 5,576 ms | -59.7% |
+| Concurrent (4 clients) | 40,980 ms | 8,282 ms | -79.8% |
+| Long generation (1024 tokens) | 20,474 ms | 8,257 ms | -59.7% |
+| Code generation | 20,528 ms | 7,058 ms | -65.6% |
+
+**Throughput (where measured):** Ollama ~35 tok/sec vs llama-server ~145 tok/sec (~4x)
+
+**Average TTFT improvement: -61.7%**
+
+Concurrent load is the killer stat for VALOR: 41 seconds vs 8 seconds average TTFT when 4 operatives hit the same node simultaneously.
+
+Note: streaming token counter in the benchmark harness had a bug — several tests reported 0 tokens. TTFT measurements are valid (based on first SSE chunk timing). Benchmark script and raw JSON results are in `G:\Projects\SIT\llm-benchmark\`.
+
+## Fox Engine Evaluation (ferrumox/fox)
+
+Evaluated Fox as an intermediate step. Conclusion: **not ready, but architecturally interesting.**
+
+**What worked:**
+- `fox search` — HuggingFace model search from CLI is excellent UX
+- `fox pull` — model download with quant selection (but no resume on failure)
+- OpenAI-compatible API, Ollama-compatible API (dual compat)
+- Prometheus metrics built in
+
+**What didn't work:**
+- Windows CUDA build from source fails (llama.dll linking issues)
+- `fox pull` drops connection on large files (no resume, error 10054)
+- Memory estimator is broken for MoE models — refused to load a 15.7GB model with 26.8GB free VRAM, even with --max-context-len 2048 and --gpu-memory-fraction 0.5
+- llama.cpp submodule pinned at bc05a68 — likely predates Gemma 4 MoE support
+
+**Fox ideas worth stealing for Herd:**
+- Model search CLI (`herd search <query>`)
+- Prometheus metrics at `/metrics` (already in Herd roadmap)
+- Dual OpenAI + Ollama API compat at the server level
+
+## Fleet Architecture: Herd + llama-server
+
+### Current (v0.9.0)
+```
+[Herd Router] --HTTP--> [Ollama node 1]
+              --HTTP--> [Ollama node 2]
+              --HTTP--> [Ollama node 3]
+```
+
+### Target (v1.x)
+```
+[Herd Router] --HTTP/OpenAI--> [llama-server node 1 (CUDA)]
+              --HTTP/OpenAI--> [llama-server node 2 (CUDA)]
+              --HTTP/OpenAI--> [llama-server node 3 (ROCm)]
+              --HTTP/OpenAI--> [llama-server node 4 (SYCL)]
+              --HTTP/OpenAI--> [llama-server node 5 (Vulkan)]
+```
+
+Herd doesn't care about GPU vendor — it talks OpenAI-compatible HTTP to each node's llama-server. Backend complexity (CUDA vs ROCm vs SYCL) is pushed to node setup via herd-tune.
+
+### Fleet Modes
+
+**Standalone mode** (current): Single Herd instance routes to local or remote Ollama/llama-server endpoints.
+
+**Fleet mode** (new): One Herd instance is the host. Each additional node runs llama-server with the appropriate GPU backend. herd-tune detects hardware, downloads the correct llama-server binary, and registers with the host.
+
+### Node Setup (herd-tune changes)
+
+herd-tune currently assumes Ollama. For llama-server backends, herd-tune needs to:
+
+1. **Detect GPU vendor** — NVIDIA (nvidia-smi), AMD (rocm-smi / hipconfig), Intel (sycl-ls), or CPU-only
+2. **Select correct llama-server binary:**
+   - NVIDIA: CUDA 12.x or CUDA 13.x (Blackwell/5000-series needs 13.x — silent CPU fallback if wrong!)
+   - AMD: ROCm build matching gfx arch (gfx110X for RDNA3, gfx120X for RDNA4, etc.)
+   - Intel: SYCL build (functional but rough — see caveats below)
+   - Fallback: Vulkan (universal, slower) or CPU
+3. **Download and verify binary** — from llama.cpp GitHub releases or AMD's ROCm repo
+4. **Probe VRAM** — determine which models fit, suggest quant levels
+5. **Start llama-server** — with correct flags (-ngl 99, -c context, --port)
+6. **Register with Herd host** — POST node capabilities including GPU vendor, VRAM, backend type
+
+### Registration Payload Extension
+
+Add to the existing POST /api/nodes/register:
+
+```json
+{
+  "hostname": "minipc",
+  "backend": "llama-server",
+  "backend_version": "b8678",
+  "gpu_vendor": "nvidia",
+  "gpu_model": "NVIDIA GeForce RTX 4080",
+  "gpu_backend": "cuda",
+  "cuda_version": "12.4",
+  "vram_mb": 16384,
+  "ram_mb": 65536,
+  "llama_server_url": "http://192.168.1.101:8090",
+  "llama_server_port": 8090,
+  "models_loaded": ["gemma-4-26B-A4B-it-UD-Q4_K_M.gguf"],
+  "model_paths": ["/models/gemma-4-26B-A4B-it-UD-Q4_K_M.gguf"],
+  "capabilities": ["cuda", "flash_attn", "moe"]
+}
+```
+
+## GPU Backend Support Matrix
+
+| GPU Vendor | Backend | llama.cpp Support | Maturity | Notes |
+|------------|---------|-------------------|----------|-------|
+| NVIDIA (Ampere, Ada, Blackwell) | CUDA | Full, pre-built binaries | Production | Blackwell (5000-series) requires CUDA 13.x — 12.x silently falls back to CPU |
+| AMD Radeon (RDNA3+) | ROCm/HIP | Full, pre-built binaries (Windows + Linux) | Solid | Nightly builds from lemonade-sdk. AMD ships validated binaries. RPC multi-node tested at scale. |
+| AMD Instinct (MI300X, MI325X) | ROCm/HIP | Full, Docker images from AMD | Production | Officially supported by AMD ROCm team |
+| Intel Arc (A-series, B-series) | SYCL | Supported, pre-built Windows binaries | Beta | Maintained by volunteer contributors. B580 performance well below theoretical. Flash attention broken on Xe2 iGPUs. IPEX-LLM archived Jan 2026. |
+| Intel Data Center (Max, Flex) | SYCL | Supported | Functional | Better optimized than consumer Arc |
+| Any (universal fallback) | Vulkan | Supported | Functional | ~25% slower than native backends but zero vendor-specific setup |
+
+## Model Download Lessons Learned
+
+From the Fox eval and HuggingFace download testing:
+
+1. **Xet Storage is the new default** — major GGUF providers host on HF Xet. Need `hf_xet` package or Xet protocol support in Rust.
+2. **Resume is mandatory** — 17GB files will drop. Fox's `fox pull` failed twice. Track partial downloads, resume from last byte.
+3. **hf_transfer is fragile** — Rust-based fast downloader, but wheel availability lags Python releases (broken on 3.13). Feature-flag it.
+4. **Model path flexibility** — don't assume cache layouts. Take a direct GGUF path. Normalize on filename or SHA256, not display names.
+5. **Ollama blob extraction** — existing Ollama models can be reused: read manifest at `{OLLAMA_MODELS}/manifests/registry.ollama.ai/library/{model}/{tag}`, find the layer with `mediaType: application/vnd.ollama.image.model`, blob file is the raw GGUF.
+6. **Quant naming is a mess** — `UD-Q4_K_M` vs `Q4_K_M` vs Ollama's internal tags. Store quant metadata as structured fields, don't trust display names.
+
+## VALOR Relevance
+
+Prefix caching (available in llama-server) is directly relevant to VALOR operatives. Every operative hits the same system prompts and Engram context on every call — that's exactly the workload where prefix caching pays off hardest. The benchmark's multi-turn test showed a 60% TTFT reduction with context reuse.
+
+## TODO
+
+- [ ] Update herd-tune spec to support llama-server backend detection and setup
+- [ ] Add `backend` field to node registration payload
+- [ ] Implement GPU vendor detection in herd-tune (nvidia-smi / rocm-smi / sycl-ls)
+- [ ] Build llama-server binary download + verification into herd-tune
+- [ ] Test ROCm backend on an AMD node (minipc candidate if swapped to AMD GPU)
+- [ ] Fix streaming token counter in benchmark harness for complete throughput data
+- [ ] Investigate llama.cpp RPC for tensor-parallel sharding across fleet nodes (v2.0+)
+- [ ] Add `herd search` CLI command (inspired by Fox's model search UX)
+- [ ] Evaluate CUDA 13.x detection logic for Blackwell GPUs in herd-tune

--- a/docs/specs/herd-tune-spec.md
+++ b/docs/specs/herd-tune-spec.md
@@ -2,15 +2,20 @@
 
 ## Overview
 
-Herd needs a frictionless way for operators to add Ollama backend nodes to their fleet. The workflow:
+Herd needs a frictionless way for operators to add backend nodes to their fleet. herd-tune supports two backend types:
+
+- **Ollama** — probes existing Ollama instance, configures env vars, registers with Herd
+- **llama-server** — detects GPU vendor, downloads correct llama-server binary, starts it, registers with Herd
+
+The workflow:
 
 1. Operator opens the Herd dashboard in a browser (from any machine, including the node itself)
 2. Clicks "Add Node" — dashboard offers a download of the appropriate `herd-tune` script (PowerShell for Windows, bash for Linux), pre-configured with this Herd instance's registration endpoint
-3. Operator runs the script on the Ollama node
-4. Script detects local GPU/VRAM/RAM, probes the local Ollama instance, applies recommended `OLLAMA_*` environment variables, and POSTs a registration payload to Herd
+3. Operator runs the script on the target node
+4. Script detects local GPU/VRAM/RAM, sets up the chosen backend, and POSTs a registration payload to Herd
 5. Node appears in the dashboard fleet view immediately
 
-No SSH. No file uploads. No manual config editing. The script is the only thing that touches the node. Herd only ever talks to nodes via their Ollama HTTP API.
+No SSH. No file uploads. No manual config editing. The script is the only thing that touches the node. Herd only ever talks to nodes via their OpenAI-compatible HTTP API.
 
 ## Architecture
 
@@ -27,8 +32,53 @@ No SSH. No file uploads. No manual config editing. The script is the only thing 
   ├── PUT /api/nodes/:id               → Update node (priority, tags, enabled)
   ├── DELETE /api/nodes/:id            → Remove node from fleet
   │
-  └── Background: health poller polls each node's Ollama /api/ps every N seconds
+  └── Background: health poller polls each node's API on a per-backend schedule
 ```
+
+## Backend Detection Logic (herd-tune)
+
+herd-tune runs the following detection sequence on the target node:
+
+### 1. GPU Vendor Detection
+
+| Vendor | Detection Method | Backend |
+|--------|-----------------|---------|
+| NVIDIA | `nvidia-smi` → parse GPU name, VRAM, driver version, CUDA version | CUDA build of llama-server |
+| AMD | `rocm-smi` or `hipconfig` → parse GPU arch (gfx110X, gfx120X, etc.) | ROCm build of llama-server |
+| Intel | `sycl-ls` or WMI/lspci for Arc GPUs | SYCL build of llama-server |
+| None / CPU only | Fallback | Vulkan build or CPU-only llama-server |
+
+### 2. CUDA Version Selection (NVIDIA only)
+
+**Critical:** Blackwell GPUs (RTX 5090, 5080, etc.) require CUDA 13.x. CUDA 12.x silently falls back to CPU with no error — llama-server starts, loads the model to CPU RAM, and runs 10x slower. herd-tune must:
+
+1. Parse CUDA version from `nvidia-smi` output
+2. Parse GPU architecture from driver info
+3. If Blackwell (compute capability 12.x or sm_120+) → require CUDA 13 build
+4. Otherwise → CUDA 12.4 build is fine
+
+### 3. llama-server Binary Selection
+
+Download the correct pre-built binary from llama.cpp GitHub releases:
+
+| Platform | GPU | Binary |
+|----------|-----|--------|
+| Windows x64 | NVIDIA (non-Blackwell) | `llama-b{ver}-bin-win-cuda-cu12.4-x64.zip` |
+| Windows x64 | NVIDIA (Blackwell) | `llama-b{ver}-bin-win-cuda-cu13.x-x64.zip` |
+| Windows x64 | AMD | `llama-b{ver}-bin-win-hip-x64.zip` or AMD's validated binary from rocm.docs.amd.com |
+| Windows x64 | Intel | `llama-b{ver}-bin-win-sycl-x64.zip` |
+| Windows x64 | CPU/Vulkan | `llama-b{ver}-bin-win-vulkan-x64.zip` |
+| Linux x64 | NVIDIA | `llama-b{ver}-bin-ubuntu-x64-cuda-cu12.4.tar.gz` (or cu13) |
+| Linux x64 | AMD | `llama-b{ver}-bin-ubuntu-x64-rocm-7.x.tar.gz` or lemonade-sdk nightly |
+| Linux x64 | Intel | Build from source with `-DGGML_SYCL=ON` (no reliable pre-built Linux binaries) |
+
+### 4. Backend Mode Selection
+
+herd-tune supports a `--backend` flag:
+
+- `--backend ollama` — legacy mode, probes/configures existing Ollama (current behavior)
+- `--backend llama-server` — downloads and starts llama-server
+- `--backend auto` (default) — if Ollama is running locally, use it; otherwise set up llama-server
 
 ## API Endpoints
 
@@ -40,26 +90,51 @@ Called by `herd-tune` after local detection. Registers or updates a node.
 ```json
 {
   "hostname": "citadel",
-  "ollama_url": "http://192.168.1.100:11434",
-  "gpu": "NVIDIA GeForce RTX 5090",
+  "backend": "llama-server",
+  "backend_version": "b8678",
+  "backend_url": "http://192.168.1.100:8090",
+  "backend_port": 8090,
+  "gpu_vendor": "nvidia",
+  "gpu_model": "NVIDIA GeForce RTX 5090",
+  "gpu_backend": "cuda",
+  "gpu_driver_version": "591.86",
+  "cuda_version": "13.1",
   "vram_mb": 32768,
   "ram_mb": 131072,
+  "models_loaded": ["gemma-4-26B-A4B-it-UD-Q4_K_M.gguf"],
+  "model_paths": ["/models/gemma-4-26B-A4B-it-UD-Q4_K_M.gguf"],
+  "capabilities": ["cuda", "flash_attn", "moe"],
+  "max_context_len": 4096,
+  "herd_tune_version": "0.4.0",
+  "os": "windows",
+  "registered_at": "2026-04-08T14:30:00Z"
+}
+```
+
+For Ollama backends, the payload remains backward-compatible:
+```json
+{
+  "hostname": "minipc",
+  "backend": "ollama",
+  "backend_url": "http://192.168.1.101:11434",
+  "gpu_vendor": "nvidia",
+  "gpu_model": "NVIDIA GeForce RTX 4080",
+  "vram_mb": 16384,
+  "ram_mb": 65536,
   "ollama_version": "0.16.1",
   "models_available": 42,
   "models_loaded": ["qwen3:32b", "gemma3:27b"],
   "recommended_config": {
     "num_parallel": 8,
     "max_loaded_models": 4,
-    "max_queue": 1024,
-    "keep_alive": "30m",
     "flash_attention": true,
     "kv_cache_type": "q8_0",
     "context_length": 16384
   },
   "config_applied": true,
-  "herd_tune_version": "0.3.0",
-  "os": "windows",
-  "registered_at": "2026-03-29T14:30:00Z"
+  "herd_tune_version": "0.4.0",
+  "os": "linux",
+  "registered_at": "2026-04-08T14:30:00Z"
 }
 ```
 
@@ -76,66 +151,35 @@ Called by `herd-tune` after local detection. Registers or updates a node.
 **Behavior:**
 - If a node with the same `hostname` already exists, update it (re-registration is idempotent)
 - Start health polling immediately on successful registration
+- Health check path depends on backend: Ollama uses `/api/ps`, llama-server uses `/v1/models`
 - Store in SQLite (consistent with Herd's existing data layer)
 
-### GET /api/nodes/script?os={windows|linux}
+### GET /api/nodes/script?os={windows|linux}&backend={ollama|llama-server|auto}
 
-Returns the `herd-tune` script with the Herd registration endpoint pre-configured.
+Returns the `herd-tune` script with the Herd registration endpoint and backend preference pre-configured.
 
-**Behavior:**
-- Read the script template from an embedded resource or file
-- Replace the placeholder endpoint URL with the actual Herd base URL (derived from the request's Host header or a configured public URL)
-- Set `Content-Disposition: attachment; filename="herd-tune.ps1"` (or `.sh`)
-- Set appropriate `Content-Type`
+### Other endpoints
 
-**Example:** If Herd is running at `http://192.168.1.50:8081`, the downloaded script will have `$HerdEndpoint = "http://192.168.1.50:8081"` baked in.
-
-### GET /api/nodes
-
-Returns all registered nodes with current health status.
-
-```json
-{
-  "nodes": [
-    {
-      "id": "uuid",
-      "hostname": "citadel",
-      "ollama_url": "http://192.168.1.100:11434",
-      "gpu": "NVIDIA GeForce RTX 5090",
-      "vram_mb": 32768,
-      "ram_mb": 131072,
-      "max_concurrent": 8,
-      "status": "healthy",
-      "models_loaded": ["qwen3:32b"],
-      "models_available": 42,
-      "last_health_check": "2026-03-29T14:35:00Z",
-      "registered_at": "2026-03-29T14:30:00Z",
-      "priority": 1,
-      "enabled": true,
-      "tags": ["local"]
-    }
-  ]
-}
-```
-
-### PUT /api/nodes/:id
-
-Update operator-controlled fields: `priority`, `tags`, `enabled`.
-Hardware fields are only updated via re-registration (re-run `herd-tune`).
-
-### DELETE /api/nodes/:id
-
-Remove a node from the fleet. Stops health polling. In-flight requests to this node should drain gracefully.
+Unchanged from current spec:
+- `GET /api/nodes` — list all registered nodes
+- `GET /api/nodes/:id` — single node detail
+- `PUT /api/nodes/:id` — update node (priority, tags, enabled)
+- `DELETE /api/nodes/:id` — remove node from fleet
 
 ## Health Polling
 
-After registration, Herd polls each node on a configurable interval (default 10s):
+After registration, Herd polls each node on a configurable interval (default 10s). The health check path depends on the backend type:
 
-1. `GET {ollama_url}/api/ps` → loaded models, VRAM usage, context length, expiration
-2. `GET {ollama_url}/api/tags` → available models (less frequent, every 60s)
-3. Track response latency as a routing signal
+### Ollama Nodes
+1. `GET {backend_url}/api/ps` → loaded models, VRAM usage
+2. `GET {backend_url}/api/tags` → available models (less frequent, every 60s)
 
-**Node status states:**
+### llama-server Nodes
+1. `GET {backend_url}/v1/models` → loaded model(s)
+2. `GET {backend_url}/health` → server health status (llama-server provides this)
+3. `GET {backend_url}/metrics` → Prometheus metrics (optional, for detailed monitoring)
+
+### Node Status States
 - `healthy` — responding, models loaded
 - `degraded` — responding but high latency or VRAM pressure
 - `unreachable` — failed health checks (after 3 consecutive failures)
@@ -143,97 +187,27 @@ After registration, Herd polls each node on a configurable interval (default 10s
 
 Unreachable nodes are not removed — they stay registered but excluded from routing. They automatically return to `healthy` when they start responding again.
 
-## herd-tune Scripts
-
-### PowerShell (Windows) — herd-tune.ps1
-
-Core logic:
-
-- **Detect** GPU (nvidia-smi, WMI fallback), RAM, local Ollama via API
-- **Calculate** recommended `OLLAMA_*` settings based on VRAM
-- **Apply** (with `-Apply` flag) — set Machine-level env vars + restart Ollama service
-- **Register** — POST payload to `{Herd}/api/nodes/register`
-- **Fallback** — if `-Herd` not set and no baked endpoint, skip registration, do local detection only
-
-### Bash (Linux) — herd-tune.sh
-
-Same logic, adapted:
-
-- `nvidia-smi` for GPU, `free -m` for RAM
-- `systemctl` for Ollama service management
-- `curl` for registration POST
-
-### Script Template Placeholders
-
-Both scripts have a clearly marked placeholder at the top:
-
-```powershell
-# ── Herd Registration (auto-configured on download) ──
-$HerdEndpoint = "%%HERD_ENDPOINT%%"
-```
-
-```bash
-# ── Herd Registration (auto-configured on download) ──
-HERD_ENDPOINT="%%HERD_ENDPOINT%%"
-```
-
-The `/api/nodes/script` endpoint replaces `%%HERD_ENDPOINT%%` with the real URL before serving.
-
-## Dashboard UI — Add Node Flow
-
-### "Add Node" page (`/dashboard/add-node` or section in settings)
-
-**Content:**
-
-1. Brief explanation: "Run the herd-tune script on any machine running Ollama to add it to your fleet."
-
-2. Two download buttons:
-   - **Windows (PowerShell)** → `GET /api/nodes/script?os=windows`
-   - **Linux (Bash)** → `GET /api/nodes/script?os=linux`
-
-3. Quick-start instructions shown inline:
-
-   **Windows:**
-   ```
-   1. Download herd-tune.ps1 (button above)
-   2. Open PowerShell as Administrator on your Ollama machine
-   3. Run:  .\herd-tune.ps1 -Apply
-   4. Done — your node will appear in the fleet below
-   ```
-
-   **Linux:**
-   ```
-   1. Download herd-tune.sh (button above)
-   2. On your Ollama machine:
-      chmod +x herd-tune.sh
-      sudo ./herd-tune.sh --apply
-   3. Done — your node will appear in the fleet below
-   ```
-
-4. **Live fleet table** below the instructions — shows registered nodes updating in real-time (poll `/api/nodes` or use SSE). Operator sees the node appear after running the script.
-
-### Fleet Management (existing dashboard, or new section)
-
-- Table of nodes: hostname, GPU, VRAM, status, loaded models, parallel slots, priority
-- Toggle enabled/disabled per node
-- Edit priority and tags
-- Remove node
-- "Re-tune" button that shows the command to re-run `herd-tune` on that node
-
 ## Data Storage
 
-Add a `nodes` table to Herd's SQLite database:
+Updated `nodes` table schema to support both backends:
 
 ```sql
 CREATE TABLE IF NOT EXISTS nodes (
     id TEXT PRIMARY KEY,
     hostname TEXT NOT NULL UNIQUE,
-    ollama_url TEXT NOT NULL,
-    gpu TEXT,
+    backend TEXT NOT NULL DEFAULT 'ollama',       -- 'ollama' or 'llama-server'
+    backend_version TEXT,                          -- ollama version or llama.cpp build number
+    backend_url TEXT NOT NULL,                     -- unified: replaces ollama_url
+    backend_port INTEGER DEFAULT 11434,
+    gpu_vendor TEXT,                               -- 'nvidia', 'amd', 'intel', 'none'
+    gpu_model TEXT,
+    gpu_backend TEXT,                              -- 'cuda', 'rocm', 'sycl', 'vulkan', 'cpu'
+    gpu_driver_version TEXT,
+    cuda_version TEXT,                             -- NULL for non-NVIDIA
     vram_mb INTEGER DEFAULT 0,
     ram_mb INTEGER DEFAULT 0,
     max_concurrent INTEGER DEFAULT 1,
-    ollama_version TEXT,
+    max_context_len INTEGER DEFAULT 4096,
     os TEXT,
     status TEXT DEFAULT 'healthy',
     priority INTEGER DEFAULT 10,
@@ -241,6 +215,8 @@ CREATE TABLE IF NOT EXISTS nodes (
     tags TEXT DEFAULT '[]',
     models_available INTEGER DEFAULT 0,
     models_loaded TEXT DEFAULT '[]',
+    model_paths TEXT DEFAULT '[]',                 -- llama-server: paths to GGUF files
+    capabilities TEXT DEFAULT '[]',                -- ['cuda', 'flash_attn', 'moe', etc.]
     recommended_config TEXT DEFAULT '{}',
     config_applied INTEGER DEFAULT 0,
     last_health_check TEXT,
@@ -251,32 +227,35 @@ CREATE TABLE IF NOT EXISTS nodes (
 
 ## Integration with Routing
 
-The node registry replaces the current static backend configuration. Herd's router should:
+The node registry is backend-agnostic at the routing layer. Herd's router:
 
-1. Query the `nodes` table for `enabled = 1 AND status IN ('healthy', 'degraded')`
-2. Use `max_concurrent` to know how many parallel slots each node has
-3. Use health poll data (loaded models, response latency) for model affinity and least-loaded routing
-4. Respect `priority` for tie-breaking
+1. Queries `nodes` table for `enabled = 1 AND status IN ('healthy', 'degraded')`
+2. All nodes expose OpenAI-compatible `/v1/chat/completions` — Ollama at `/v1/chat/completions`, llama-server at `/v1/chat/completions` (same path)
+3. Uses `max_concurrent` to know how many parallel slots each node has
+4. Uses health poll data (loaded models, response latency) for model affinity and least-loaded routing
+5. Respects `priority` for tie-breaking
 
-This means the `[[backends]]` section in the TOML/YAML config becomes optional — nodes registered via `herd-tune` are the primary source. Static config backends still work for non-Ollama backends (vLLM, cloud providers) that don't run `herd-tune`.
+Static `[[backends]]` in YAML config still works for non-herd-tune backends.
 
 ## Implementation Order
 
-1. **SQLite `nodes` table** — migration in Herd
-2. **POST /api/nodes/register** — accept and store registrations
-3. **GET /api/nodes** — list nodes (dashboard needs this)
-4. **Health poller** — background task polling registered nodes
-5. **Router integration** — read from `nodes` table instead of (or in addition to) static config
-6. **Script templates** — embed herd-tune.ps1 and herd-tune.sh as resources
-7. **GET /api/nodes/script** — serve scripts with endpoint baked in
-8. **Dashboard UI** — add node page, fleet table, management controls
-9. **PUT/DELETE /api/nodes/:id** — management endpoints
-10. **herd-tune scripts** — finalize with registration POST
+1. **SQLite `nodes` table migration** — add new columns (backend, gpu_vendor, gpu_backend, etc.)
+2. **POST /api/nodes/register** — accept both Ollama and llama-server payloads
+3. **GET /api/nodes** — return backend type in response
+4. **Health poller** — branch on `backend` field for health check path
+5. **Router integration** — read from `nodes` table, route to `backend_url + /v1/chat/completions`
+6. **herd-tune scripts** — add `--backend` flag, GPU vendor detection, llama-server binary download
+7. **Script template endpoint** — add `backend` query param
+8. **Dashboard UI** — show backend type per node, add backend selector to "Add Node" flow
+9. **PUT/DELETE endpoints** — unchanged
+10. **Model management** — for llama-server nodes, `herd search` and model download commands
 
 ## Notes
 
-- Scripts ship embedded in the Herd binary/container, not as separate downloads. When the container is built, the scripts are bundled.
-- Registration is idempotent. Running `herd-tune` again on a node updates its entry. This is how you "re-tune" after hardware changes.
-- The dashboard "Add Node" instructions should be visible even with zero nodes registered (first-run experience).
-- Herd's public URL / external address may differ from its container internal address. Consider a `HERD_PUBLIC_URL` env var for generating correct script endpoints.
-- The scripts should detect the Ollama URL on the local machine and prefer Tailscale IP > LAN IP > localhost for the `ollama_url` field, since Herd needs to reach it from the container network.
+- Ollama support is NOT being removed. Both backends coexist indefinitely.
+- Registration is idempotent. Running `herd-tune` again updates the node entry.
+- For llama-server nodes, model loading is static (specified at llama-server launch) vs Ollama's dynamic model loading. Herd needs to know this distinction for model routing.
+- llama-server's prompt cache feature is highly relevant for VALOR operatives — repeated system prompts get cached, dramatically reducing TTFT on subsequent turns.
+- Blackwell NVIDIA GPUs (RTX 5000-series) REQUIRE CUDA 13.x builds. CUDA 12.x silently falls back to CPU. herd-tune must detect this.
+- Intel SYCL backend is functional but has rough edges (flash attention bugs on Xe2, volunteer-maintained). Treat as beta tier in herd-tune.
+- The scripts should detect the backend URL on the local machine and prefer Tailscale IP > LAN IP > localhost for the `backend_url` field.

--- a/herd.yaml.example
+++ b/herd.yaml.example
@@ -93,6 +93,20 @@ backends:
       - "gpu"
       - "low-vram"
 
+  # llama-server backend example (llama.cpp):
+  # llama-server backends use OpenAI-compatible endpoints for health checks (/health)
+  # and model discovery (/v1/models). hot_models is ignored (model set at server start).
+  #
+  # - name: "citadel-llama"
+  #   url: "http://citadel:8090"      # llama-server listen address
+  #   backend: "llama-server"          # Backend type: "ollama" (default) or "llama-server"
+  #   priority: 100
+  #   tags:
+  #     - "gpu"
+  #     - "high-vram"
+  #   # health_check_path defaults to /health for llama-server (vs / for ollama)
+  #   # Model discovery uses /v1/models instead of /api/tags
+
 # === CIRCUIT BREAKER ===
 # Automatically stops routing to failing backends and probes them for recovery.
 

--- a/scripts/herd-tune.ps1
+++ b/scripts/herd-tune.ps1
@@ -1,25 +1,45 @@
 <#
 .SYNOPSIS
-    herd-tune — Detect GPU/VRAM/RAM, configure Ollama, and register with Herd.
+    herd-tune -- Detect GPU/VRAM/RAM, configure backend, and register with Herd.
 .DESCRIPTION
-    Run on any Windows machine with Ollama installed to auto-detect hardware,
-    apply recommended Ollama environment variables, and register with a Herd instance.
+    Run on any Windows machine to auto-detect hardware, set up either Ollama or
+    llama-server as the inference backend, and register with a Herd instance.
 .PARAMETER Apply
     Apply recommended OLLAMA_* environment variables and restart the Ollama service.
-    Requires administrator privileges.
+    Requires administrator privileges. Only used with Ollama backend.
 .PARAMETER Herd
     Override the Herd endpoint URL (default: baked in at download time).
+.PARAMETER Backend
+    Backend type: ollama, llama-server, auto (default: auto).
+    auto: if Ollama is running on :11434, use it; otherwise set up llama-server.
+.PARAMETER Port
+    llama-server listen port (default: 8090).
+.PARAMETER Context
+    llama-server context length (default: 4096, auto-adjusted by VRAM).
+.PARAMETER Model
+    Path to GGUF model file for llama-server.
+.PARAMETER EnrollmentKey
+    Enrollment key for node registration.
+.PARAMETER Daemon
+    Keep herd-tune resident with HTTP control API (stretch goal, not yet implemented).
 #>
 [CmdletBinding()]
 param(
     [switch]$Apply,
-    [string]$Herd
+    [string]$Herd,
+    [ValidateSet("ollama", "llama-server", "auto")]
+    [string]$Backend = "auto",
+    [int]$Port = 8090,
+    [int]$Context = 4096,
+    [string]$Model = "",
+    [string]$EnrollmentKey,
+    [switch]$Daemon
 )
 
-# ── Herd Registration (auto-configured on download) ──
+# -- Herd Registration (auto-configured on download) --
 $HerdEndpoint = "%%HERD_ENDPOINT%%"
-$EnrollmentKey = "%%ENROLLMENT_KEY%%"
-$HerdTuneVersion = "0.8.0"
+$BakedEnrollmentKey = "%%ENROLLMENT_KEY%%"
+$HerdTuneVersion = "1.0.0"
 
 # -Herd parameter overrides the baked-in endpoint.
 # Also check HERD_URL env var as fallback (useful for containers/CI).
@@ -29,44 +49,143 @@ if ($Herd) {
     $HerdEndpoint = $env:HERD_URL
 }
 
-# ── Require admin only when -Apply is used ──
+# -EnrollmentKey parameter overrides baked-in key
+if ($EnrollmentKey) {
+    $BakedEnrollmentKey = $EnrollmentKey
+}
+
+# -- Require admin only when -Apply is used --
 if ($Apply) {
     $currentPrincipal = New-Object Security.Principal.WindowsPrincipal([Security.Principal.WindowsIdentity]::GetCurrent())
     if (-not $currentPrincipal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
         # Re-launch elevated, forwarding arguments
-        $argList = "-ExecutionPolicy Bypass -File `"$PSCommandPath`" -Apply"
+        $argList = "-ExecutionPolicy Bypass -File `"$PSCommandPath`" -Apply -Backend `"$Backend`""
         if ($HerdEndpoint -and $HerdEndpoint -ne '%%HERD_ENDPOINT%%') {
             $argList += " -Herd `"$HerdEndpoint`""
         }
+        if ($BakedEnrollmentKey -and $BakedEnrollmentKey -ne '%%ENROLLMENT_KEY%%') {
+            $argList += " -EnrollmentKey `"$BakedEnrollmentKey`""
+        }
+        if ($Port -ne 8090) { $argList += " -Port $Port" }
+        if ($Context -ne 4096) { $argList += " -Context $Context" }
+        if ($Model) { $argList += " -Model `"$Model`"" }
         Start-Process powershell.exe -Verb RunAs -ArgumentList $argList -Wait
         exit $LASTEXITCODE
     }
 }
 
-# ── Detect GPU ──
-function Get-GpuInfo {
-    # Try nvidia-smi first
+# ======================================================================
+# GPU VENDOR DETECTION
+# ======================================================================
+
+function Get-GpuDetailed {
+    $result = @{
+        Vendor          = "none"
+        Model           = ""
+        Backend         = "cpu"
+        DriverVersion   = ""
+        CudaVersion     = ""
+        ComputeCap      = ""
+        CudaMajor       = 0
+        VramMb          = 0
+        IsBlackwell     = $false
+    }
+
+    # -- Try NVIDIA first --
     try {
-        $smiOutput = & nvidia-smi --query-gpu=name,memory.total --format=csv,noheader,nounits 2>$null
+        $smiOutput = & nvidia-smi --query-gpu=name,memory.total,driver_version --format=csv,noheader,nounits 2>$null
         if ($LASTEXITCODE -eq 0 -and $smiOutput) {
             $parts = $smiOutput.Split(',').Trim()
-            return @{ Name = $parts[0]; VramMb = [int]$parts[1] }
+            $result.Vendor = "nvidia"
+            $result.Model = $parts[0]
+            $result.VramMb = [int]$parts[1]
+            $result.DriverVersion = $parts[2]
+            $result.Backend = "cuda"
+
+            # Get compute capability
+            try {
+                $ccOutput = & nvidia-smi --query-gpu=compute_cap --format=csv,noheader 2>$null
+                if ($LASTEXITCODE -eq 0 -and $ccOutput) {
+                    $result.ComputeCap = $ccOutput.Trim()
+                }
+            } catch {}
+
+            # Get CUDA version from nvidia-smi header
+            try {
+                $smiHeader = & nvidia-smi 2>$null
+                if ($smiHeader) {
+                    $headerText = $smiHeader | Out-String
+                    if ($headerText -match 'CUDA Version:\s*([\d.]+)') {
+                        $result.CudaVersion = $Matches[1]
+                    }
+                }
+            } catch {}
+
+            # Determine CUDA major version based on compute capability
+            # Blackwell (RTX 5000-series) has compute capability >= 12.0
+            if ($result.ComputeCap) {
+                $ccMajor = [int]($result.ComputeCap.Split('.')[0])
+                if ($ccMajor -ge 12) {
+                    $result.CudaMajor = 13
+                    $result.IsBlackwell = $true
+                } else {
+                    $result.CudaMajor = 12
+                }
+            } else {
+                $result.CudaMajor = 12
+            }
+
+            return $result
         }
     } catch {}
 
-    # WMI fallback
+    # -- Try AMD (WMI-based on Windows) --
     try {
-        $gpu = Get-CimInstance -ClassName Win32_VideoController | Sort-Object AdapterRAM -Descending | Select-Object -First 1
-        if ($gpu) {
-            $vram = [math]::Round($gpu.AdapterRAM / 1MB)
-            return @{ Name = $gpu.Name; VramMb = $vram }
+        $amdGpu = Get-CimInstance -ClassName Win32_VideoController | Where-Object {
+            $_.Name -match 'AMD|Radeon'
+        } | Sort-Object AdapterRAM -Descending | Select-Object -First 1
+
+        if ($amdGpu) {
+            $result.Vendor = "amd"
+            $result.Model = $amdGpu.Name
+            $result.Backend = "rocm"
+            $result.VramMb = [math]::Round($amdGpu.AdapterRAM / 1MB)
+            $result.DriverVersion = $amdGpu.DriverVersion
+            return $result
         }
     } catch {}
 
-    return @{ Name = $null; VramMb = 0 }
+    # -- Try Intel (WMI for Arc GPUs) --
+    try {
+        $intelGpu = Get-CimInstance -ClassName Win32_VideoController | Where-Object {
+            $_.Name -match 'Intel.*Arc|Intel.*Xe'
+        } | Sort-Object AdapterRAM -Descending | Select-Object -First 1
+
+        if ($intelGpu) {
+            $result.Vendor = "intel"
+            $result.Model = $intelGpu.Name
+            $result.Backend = "sycl"
+            $result.VramMb = [math]::Round($intelGpu.AdapterRAM / 1MB)
+            $result.DriverVersion = $intelGpu.DriverVersion
+            return $result
+        }
+    } catch {}
+
+    # -- Fallback: any GPU via WMI --
+    try {
+        $anyGpu = Get-CimInstance -ClassName Win32_VideoController | Sort-Object AdapterRAM -Descending | Select-Object -First 1
+        if ($anyGpu) {
+            $result.Model = $anyGpu.Name
+            $result.VramMb = [math]::Round($anyGpu.AdapterRAM / 1MB)
+            $result.DriverVersion = $anyGpu.DriverVersion
+            $result.Backend = "vulkan"
+        }
+    } catch {}
+
+    return $result
 }
 
-# ── Detect RAM ──
+# -- Detect RAM --
 function Get-RamMb {
     try {
         $os = Get-CimInstance -ClassName Win32_OperatingSystem
@@ -76,16 +195,14 @@ function Get-RamMb {
     }
 }
 
-# ── Detect Ollama ──
+# -- Detect Ollama --
 function Get-OllamaInfo {
     $ollamaUrl = "http://localhost:11434"
 
-    # Check if Ollama is running
     try {
         $version = Invoke-RestMethod -Uri "$ollamaUrl/api/version" -TimeoutSec 5
         $ollamaVersion = $version.version
     } catch {
-        Write-Warning "Ollama is not running at $ollamaUrl"
         return $null
     }
 
@@ -105,27 +222,47 @@ function Get-OllamaInfo {
         $modelsAvailable = 0
     }
 
-    # Determine best reachable URL (prefer LAN IP over localhost)
-    $bestUrl = $ollamaUrl
+    return @{
+        OllamaVersion   = $ollamaVersion
+        ModelsLoaded     = $modelsLoaded
+        ModelsAvailable  = $modelsAvailable
+    }
+}
+
+# -- IP Detection (Tailscale > LAN > localhost) --
+function Get-BestIp {
+    # Try Tailscale IP first (100.x.y.z)
+    try {
+        $tsIp = & tailscale ip -4 2>$null
+        if ($LASTEXITCODE -eq 0 -and $tsIp) {
+            return $tsIp.Trim()
+        }
+    } catch {}
+
+    # Check for Tailscale network adapter
+    try {
+        $tsAdapter = Get-NetIPAddress -AddressFamily IPv4 | Where-Object {
+            $_.IPAddress -match '^100\.'
+        } | Select-Object -First 1
+        if ($tsAdapter) {
+            return $tsAdapter.IPAddress
+        }
+    } catch {}
+
+    # LAN IP
     try {
         $adapters = Get-NetIPAddress -AddressFamily IPv4 | Where-Object {
             $_.IPAddress -ne '127.0.0.1' -and $_.PrefixOrigin -ne 'WellKnown'
         } | Sort-Object -Property InterfaceIndex
         if ($adapters) {
-            $lanIp = $adapters[0].IPAddress
-            $bestUrl = "http://${lanIp}:11434"
+            return $adapters[0].IPAddress
         }
     } catch {}
 
-    return @{
-        OllamaUrl      = $bestUrl
-        OllamaVersion  = $ollamaVersion
-        ModelsLoaded   = $modelsLoaded
-        ModelsAvailable = $modelsAvailable
-    }
+    return "127.0.0.1"
 }
 
-# ── Calculate recommended config ──
+# -- Calculate recommended Ollama config --
 function Get-RecommendedConfig {
     param([int]$VramMb)
 
@@ -135,28 +272,24 @@ function Get-RecommendedConfig {
     }
 
     if ($VramMb -ge 24576) {
-        # 24GB+ VRAM (RTX 4090, 5090, A5000, etc.)
         $config.num_parallel    = 8
         $config.max_loaded_models = 4
         $config.max_queue       = 1024
         $config.keep_alive      = "30m"
         $config.context_length  = 16384
     } elseif ($VramMb -ge 12288) {
-        # 12-24GB VRAM (RTX 3080, 4070 Ti, etc.)
         $config.num_parallel    = 4
         $config.max_loaded_models = 2
         $config.max_queue       = 512
         $config.keep_alive      = "15m"
         $config.context_length  = 8192
     } elseif ($VramMb -ge 8192) {
-        # 8-12GB VRAM (RTX 3070, 4060, etc.)
         $config.num_parallel    = 2
         $config.max_loaded_models = 1
         $config.max_queue       = 256
         $config.keep_alive      = "10m"
         $config.context_length  = 4096
     } else {
-        # < 8GB VRAM
         $config.num_parallel    = 1
         $config.max_loaded_models = 1
         $config.max_queue       = 128
@@ -167,20 +300,20 @@ function Get-RecommendedConfig {
     return $config
 }
 
-# ── Apply Ollama config ──
+# -- Apply Ollama config --
 function Set-OllamaConfig {
     param($Config)
 
     Write-Host "`n=== Applying Ollama Configuration ===" -ForegroundColor Cyan
 
     $envVars = @{
-        "OLLAMA_NUM_PARALLEL"     = $Config.num_parallel
+        "OLLAMA_NUM_PARALLEL"      = $Config.num_parallel
         "OLLAMA_MAX_LOADED_MODELS" = $Config.max_loaded_models
-        "OLLAMA_MAX_QUEUE"        = $Config.max_queue
-        "OLLAMA_KEEP_ALIVE"       = $Config.keep_alive
-        "OLLAMA_FLASH_ATTENTION"  = if ($Config.flash_attention) { "1" } else { "0" }
-        "OLLAMA_KV_CACHE_TYPE"    = $Config.kv_cache_type
-        "OLLAMA_CONTEXT_LENGTH"   = $Config.context_length
+        "OLLAMA_MAX_QUEUE"         = $Config.max_queue
+        "OLLAMA_KEEP_ALIVE"        = $Config.keep_alive
+        "OLLAMA_FLASH_ATTENTION"   = if ($Config.flash_attention) { "1" } else { "0" }
+        "OLLAMA_KV_CACHE_TYPE"     = $Config.kv_cache_type
+        "OLLAMA_CONTEXT_LENGTH"    = $Config.context_length
     }
 
     foreach ($kv in $envVars.GetEnumerator()) {
@@ -199,7 +332,10 @@ function Set-OllamaConfig {
     }
 }
 
-# ── Main ──
+# ======================================================================
+# MAIN
+# ======================================================================
+
 Write-Host @"
 
   _               _       _
@@ -207,54 +343,301 @@ Write-Host @"
  | ' \/ -_) '_/ _`` | |___| _| || | ' \/ -_)
  |_||_\___|_| \__,_|     \__|\_,_|_||_\___|
 
-  GPU Detection & Ollama Configuration
+  GPU Detection & Backend Configuration
   Version $HerdTuneVersion
 
 "@ -ForegroundColor Cyan
 
-# Detect hardware
+# -- Hardware Detection --
 Write-Host "=== Hardware Detection ===" -ForegroundColor Cyan
 
-$gpu = Get-GpuInfo
+$gpu = Get-GpuDetailed
 $ramMb = Get-RamMb
 
-Write-Host "  GPU:  $($gpu.Name ?? 'Not detected')"
-Write-Host "  VRAM: $($gpu.VramMb) MB"
-Write-Host "  RAM:  $ramMb MB"
+Write-Host "  GPU Vendor: $($gpu.Vendor)" -ForegroundColor $(if ($gpu.Vendor -ne 'none') { 'Green' } else { 'Yellow' })
+Write-Host "  GPU Model:  $(if ($gpu.Model) { $gpu.Model } else { 'Not detected' })"
+Write-Host "  VRAM:       $($gpu.VramMb) MB"
+Write-Host "  RAM:        $ramMb MB"
 
-# Detect Ollama
-Write-Host "`n=== Ollama Detection ===" -ForegroundColor Cyan
-$ollama = Get-OllamaInfo
-if (-not $ollama) {
-    Write-Error "Ollama is not running. Please start Ollama and try again."
-    exit 1
-}
+if ($gpu.Vendor -eq 'nvidia') {
+    Write-Host "  Driver:     $($gpu.DriverVersion)"
+    Write-Host "  CUDA:       $($gpu.CudaVersion)"
+    Write-Host "  Compute:    $($gpu.ComputeCap)"
 
-Write-Host "  URL:      $($ollama.OllamaUrl)"
-Write-Host "  Version:  $($ollama.OllamaVersion)"
-Write-Host "  Models:   $($ollama.ModelsAvailable) available, $($ollama.ModelsLoaded.Count) loaded"
-
-# Calculate config
-$config = Get-RecommendedConfig -VramMb $gpu.VramMb
-
-Write-Host "`n=== Recommended Configuration ===" -ForegroundColor Cyan
-$config.GetEnumerator() | ForEach-Object { Write-Host "  $($_.Key): $($_.Value)" }
-
-$configApplied = $false
-if ($Apply) {
-    Set-OllamaConfig -Config $config
-    $configApplied = $true
+    if ($gpu.IsBlackwell) {
+        Write-Host ""
+        Write-Host "  +==============================================================+" -ForegroundColor Yellow
+        Write-Host "  |  BLACKWELL GPU DETECTED (compute capability $($gpu.ComputeCap))       |" -ForegroundColor Yellow
+        Write-Host "  |                                                              |" -ForegroundColor Yellow
+        Write-Host "  |  This GPU REQUIRES CUDA 13.x builds of llama-server.         |" -ForegroundColor Yellow
+        Write-Host "  |  CUDA 12.x will silently fall back to CPU (~10x slower).     |" -ForegroundColor Yellow
+        Write-Host "  |  herd-tune will select the correct cu13 binary.              |" -ForegroundColor Yellow
+        Write-Host "  +==============================================================+" -ForegroundColor Yellow
+        Write-Host ""
+    } else {
+        Write-Host "  Binary:     CUDA 12.x"
+    }
+} elseif ($gpu.Vendor -eq 'amd') {
+    Write-Host "  Backend:    ROCm/HIP"
+} elseif ($gpu.Vendor -eq 'intel') {
+    Write-Host "  Backend:    SYCL"
 } else {
-    Write-Host "`nRun with -Apply to set these environment variables and restart Ollama." -ForegroundColor Yellow
+    Write-Host "  Backend:    Vulkan (universal fallback)" -ForegroundColor Yellow
+    $gpu.Backend = "vulkan"
 }
 
-# Generate stable machine ID (survives hostname changes)
+# -- Backend Selection --
+$resolvedBackend = $Backend
+if ($Backend -eq "auto") {
+    try {
+        $null = Invoke-RestMethod -Uri "http://localhost:11434/api/version" -TimeoutSec 3
+        $resolvedBackend = "ollama"
+        Write-Host "`n  Auto-detected: Ollama is running on :11434" -ForegroundColor Cyan
+    } catch {
+        $resolvedBackend = "llama-server"
+        Write-Host "`n  Auto-detected: Ollama not found, will set up llama-server" -ForegroundColor Cyan
+    }
+}
+
+Write-Host "`n=== Backend: $resolvedBackend ===" -ForegroundColor Cyan
+
+# -- Shared state --
+$backendVersion = ""
+$backendUrl = ""
+$backendPort = 0
+$configApplied = $false
+$ollamaInfo = $null
+$config = $null
+$llamaBuildNumber = ""
+$capabilities = @()
+$modelPaths = @()
+$modelsLoaded = @()
+$maxContextLen = 2048
+
+# ======================================================================
+# OLLAMA BACKEND
+# ======================================================================
+
+if ($resolvedBackend -eq "ollama") {
+    $ollamaInfo = Get-OllamaInfo
+    if (-not $ollamaInfo) {
+        Write-Error "Ollama is not running. Please start Ollama and try again."
+        exit 1
+    }
+
+    Write-Host "  URL:      http://localhost:11434"
+    Write-Host "  Version:  $($ollamaInfo.OllamaVersion)"
+    Write-Host "  Models:   $($ollamaInfo.ModelsAvailable) available, $($ollamaInfo.ModelsLoaded.Count) loaded"
+
+    $config = Get-RecommendedConfig -VramMb $gpu.VramMb
+
+    Write-Host "`n=== Recommended Configuration ===" -ForegroundColor Cyan
+    $config.GetEnumerator() | ForEach-Object { Write-Host "  $($_.Key): $($_.Value)" }
+
+    if ($Apply) {
+        Set-OllamaConfig -Config $config
+        $configApplied = $true
+    } else {
+        Write-Host "`nRun with -Apply to set these environment variables and restart Ollama." -ForegroundColor Yellow
+    }
+
+    $backendVersion = $ollamaInfo.OllamaVersion
+    $backendPort = 11434
+    $modelsLoaded = $ollamaInfo.ModelsLoaded
+    $maxContextLen = $config.context_length
+}
+
+# ======================================================================
+# LLAMA-SERVER BACKEND
+# ======================================================================
+
+if ($resolvedBackend -eq "llama-server") {
+    $herdDir = Join-Path $env:USERPROFILE ".herd"
+    $binDir = Join-Path $herdDir "bin"
+    if (-not (Test-Path $binDir)) {
+        New-Item -ItemType Directory -Path $binDir -Force | Out-Null
+    }
+
+    Write-Host "`n=== llama-server Binary Download ===" -ForegroundColor Cyan
+
+    # Determine correct asset pattern based on GPU vendor
+    $assetPattern = ""
+    switch ($gpu.Vendor) {
+        "nvidia" {
+            if ($gpu.CudaMajor -ge 13) {
+                $assetPattern = "bin-win-cuda-cu13"
+            } else {
+                $assetPattern = "bin-win-cuda-cu12"
+            }
+        }
+        "amd" {
+            $assetPattern = "bin-win-hip"
+        }
+        "intel" {
+            $assetPattern = "bin-win-sycl"
+        }
+        default {
+            $assetPattern = "bin-win-vulkan"
+        }
+    }
+
+    Write-Host "  GPU Vendor:     $($gpu.Vendor)"
+    Write-Host "  Asset pattern:  $assetPattern"
+
+    # Query latest release from llama.cpp GitHub
+    Write-Host "  Querying llama.cpp releases..."
+    try {
+        $releaseData = Invoke-RestMethod -Uri "https://api.github.com/repos/ggml-org/llama.cpp/releases/latest" -TimeoutSec 30
+    } catch {
+        Write-Error "Could not fetch llama.cpp releases from GitHub API: $_"
+        Write-Host "  Check your internet connection or try again later."
+        Write-Host "  You can also manually download from: https://github.com/ggml-org/llama.cpp/releases"
+        exit 1
+    }
+
+    $llamaTag = $releaseData.tag_name
+    $llamaBuildNumber = $llamaTag
+    Write-Host "  Latest release: $llamaTag"
+
+    # Find matching asset
+    $matchingAsset = $releaseData.assets | Where-Object {
+        $_.name -like "*$assetPattern*" -and $_.name -like "*.zip"
+    } | Select-Object -First 1
+
+    if (-not $matchingAsset) {
+        Write-Error "No matching binary found for pattern '$assetPattern'."
+        Write-Host "  Available assets:" -ForegroundColor Yellow
+        $releaseData.assets | ForEach-Object { Write-Host "    $($_.name)" }
+        exit 1
+    }
+
+    $downloadUrl = $matchingAsset.browser_download_url
+    $archiveName = $matchingAsset.name
+    $archivePath = Join-Path $binDir $archiveName
+
+    Write-Host "  Downloading:    $archiveName"
+    Write-Host "  To:             $binDir"
+
+    # Download with progress
+    $ProgressPreference = 'Continue'
+    try {
+        Invoke-WebRequest -Uri $downloadUrl -OutFile $archivePath -UseBasicParsing
+    } catch {
+        Write-Error "Download failed: $_"
+        exit 1
+    }
+
+    # Extract zip
+    Write-Host "  Extracting..."
+    try {
+        Expand-Archive -Path $archivePath -DestinationPath $binDir -Force
+        Remove-Item $archivePath -Force
+    } catch {
+        Write-Error "Extraction failed: $_"
+        exit 1
+    }
+
+    # Find llama-server.exe
+    $llamaServerBin = Get-ChildItem -Path $binDir -Recurse -Filter "llama-server.exe" | Select-Object -First 1
+    if (-not $llamaServerBin) {
+        Write-Error "llama-server.exe not found after extraction."
+        Write-Host "  Contents of ${binDir}:" -ForegroundColor Yellow
+        Get-ChildItem $binDir -Recurse | ForEach-Object { Write-Host "    $($_.FullName)" }
+        exit 1
+    }
+
+    $llamaServerPath = $llamaServerBin.FullName
+    Write-Host "  llama-server installed: $llamaServerPath" -ForegroundColor Green
+
+    # -- VRAM-based context estimation --
+    if ($Context -eq 4096 -and $gpu.VramMb -gt 0) {
+        if ($gpu.VramMb -ge 24576) {
+            $Context = 16384
+        } elseif ($gpu.VramMb -ge 16384) {
+            $Context = 8192
+        } elseif ($gpu.VramMb -ge 8192) {
+            $Context = 4096
+        } else {
+            $Context = 2048
+        }
+        Write-Host "  Context auto-set to $Context based on $($gpu.VramMb) MB VRAM"
+    }
+
+    $maxContextLen = $Context
+
+    # -- Generate launch config --
+    $confFile = Join-Path $herdDir "llama-server.conf"
+    $modelFlag = ""
+    if ($Model) {
+        $modelFlag = "--model `"$Model`""
+        $modelPaths = @($Model)
+    }
+
+    $timestamp = Get-Date -Format 'o'
+    $confLines = @(
+        "# llama-server launch configuration",
+        "# Generated by herd-tune $HerdTuneVersion on $timestamp",
+        "#",
+        "# Start command:",
+        "#   $llamaServerPath -ngl 99 -c $Context --port $Port $modelFlag",
+        "#",
+        "LLAMA_SERVER_BIN=$llamaServerPath",
+        "LLAMA_SERVER_PORT=$Port",
+        "LLAMA_SERVER_CTX=$Context",
+        "LLAMA_SERVER_NGL=99",
+        "GPU_VENDOR=$($gpu.Vendor)",
+        "GPU_BACKEND=$($gpu.Backend)",
+        "GPU_MODEL=$($gpu.Model)",
+        "VRAM_MB=$($gpu.VramMb)",
+        "MODEL_PATH=$Model",
+        "BUILD=$llamaBuildNumber"
+    )
+    $confContent = $confLines -join "`n"
+    Set-Content -Path $confFile -Value $confContent -Encoding UTF8
+    Write-Host "  Launch config written: $confFile" -ForegroundColor Green
+
+    Write-Host ""
+    Write-Host "  To start llama-server:"
+    Write-Host "    $llamaServerPath -ngl 99 -c $Context --port $Port $modelFlag"
+
+    $backendVersion = $llamaBuildNumber
+    $backendPort = $Port
+
+    # Build capabilities
+    switch ($gpu.Backend) {
+        "cuda"   { $capabilities += "cuda" }
+        "rocm"   { $capabilities += "rocm" }
+        "sycl"   { $capabilities += "sycl" }
+        "vulkan" { $capabilities += "vulkan" }
+    }
+    if ($gpu.Backend -in @("cuda", "rocm")) {
+        $capabilities += "flash_attn"
+    }
+}
+
+# ======================================================================
+# IP DETECTION (Tailscale > LAN > localhost)
+# ======================================================================
+
+$bestIp = Get-BestIp
+
+if ($resolvedBackend -eq "ollama") {
+    $backendUrl = "http://${bestIp}:11434"
+} else {
+    $backendUrl = "http://${bestIp}:${Port}"
+}
+
+Write-Host "`n  Best reachable URL: $backendUrl" -ForegroundColor Cyan
+
+# ======================================================================
+# GENERATE STABLE MACHINE ID
+# ======================================================================
+
 $machineId = $null
 try {
     $sid = (Get-CimInstance -ClassName Win32_UserAccount -Filter "LocalAccount=True" -ErrorAction SilentlyContinue |
         Select-Object -First 1).SID
     if ($sid) {
-        # Strip the per-user RID to get the machine SID
         $machineSid = $sid -replace '-\d+$'
         $sha = [System.Security.Cryptography.SHA256]::Create()
         $bytes = [System.Text.Encoding]::UTF8.GetBytes($machineSid)
@@ -263,7 +646,10 @@ try {
     }
 } catch {}
 
-# Register with Herd
+# ======================================================================
+# REGISTER WITH HERD
+# ======================================================================
+
 $regEndpoint = $null
 if ($HerdEndpoint -and $HerdEndpoint -notmatch 'HERD_ENDPOINT') {
     $regEndpoint = $HerdEndpoint
@@ -271,28 +657,62 @@ if ($HerdEndpoint -and $HerdEndpoint -notmatch 'HERD_ENDPOINT') {
 
 if ($regEndpoint) {
     $regUrl = "$regEndpoint/api/nodes/register"
-    if ($EnrollmentKey -and $EnrollmentKey -notmatch 'ENROLLMENT_KEY') {
-        $regUrl += "?enrollment_key=$EnrollmentKey"
+    if ($BakedEnrollmentKey -and $BakedEnrollmentKey -notmatch 'ENROLLMENT_KEY') {
+        $regUrl += "?enrollment_key=$BakedEnrollmentKey"
     }
 
     Write-Host "`n=== Registering with Herd ===" -ForegroundColor Cyan
     Write-Host "  Endpoint: $regEndpoint"
 
-    $payloadObj = @{
-        hostname          = $env:COMPUTERNAME.ToLower()
-        ollama_url        = $ollama.OllamaUrl
-        gpu               = $gpu.Name
-        vram_mb           = $gpu.VramMb
-        ram_mb            = $ramMb
-        ollama_version    = $ollama.OllamaVersion
-        models_available  = $ollama.ModelsAvailable
-        models_loaded     = $ollama.ModelsLoaded
-        recommended_config = $config
-        config_applied    = $configApplied
-        herd_tune_version = $HerdTuneVersion
-        os                = "windows"
-        registered_at     = (Get-Date -Format "o")
+    if ($resolvedBackend -eq "ollama") {
+        $payloadObj = @{
+            hostname           = $env:COMPUTERNAME.ToLower()
+            backend            = "ollama"
+            backend_version    = $ollamaInfo.OllamaVersion
+            backend_url        = $backendUrl
+            backend_port       = 11434
+            gpu_vendor         = $gpu.Vendor
+            gpu_model          = $gpu.Model
+            gpu_backend        = $gpu.Backend
+            gpu_driver_version = $gpu.DriverVersion
+            cuda_version       = $gpu.CudaVersion
+            vram_mb            = $gpu.VramMb
+            ram_mb             = $ramMb
+            ollama_version     = $ollamaInfo.OllamaVersion
+            models_available   = $ollamaInfo.ModelsAvailable
+            models_loaded      = $ollamaInfo.ModelsLoaded
+            recommended_config = $config
+            config_applied     = $configApplied
+            max_context_len    = $maxContextLen
+            capabilities       = $capabilities
+            herd_tune_version  = $HerdTuneVersion
+            os                 = "windows"
+            registered_at      = (Get-Date -Format "o")
+        }
+    } else {
+        $payloadObj = @{
+            hostname           = $env:COMPUTERNAME.ToLower()
+            backend            = "llama-server"
+            backend_version    = $llamaBuildNumber
+            backend_url        = $backendUrl
+            backend_port       = $Port
+            gpu_vendor         = $gpu.Vendor
+            gpu_model          = $gpu.Model
+            gpu_backend        = $gpu.Backend
+            gpu_driver_version = $gpu.DriverVersion
+            cuda_version       = $gpu.CudaVersion
+            vram_mb            = $gpu.VramMb
+            ram_mb             = $ramMb
+            models_loaded      = @()
+            model_paths        = $modelPaths
+            capabilities       = $capabilities
+            max_context_len    = $maxContextLen
+            herd_tune_version  = $HerdTuneVersion
+            os                 = "windows"
+            registered_at      = (Get-Date -Format "o")
+        }
     }
+
     if ($machineId) { $payloadObj.node_id = $machineId }
     $payload = $payloadObj | ConvertTo-Json -Depth 3
 
@@ -303,10 +723,23 @@ if ($regEndpoint) {
         Write-Host "  $($response.message)" -ForegroundColor Green
     } catch {
         Write-Warning "Registration failed: $_"
-        Write-Host "  You can register manually later by re-running this script with -Herd <url>"
+        Write-Host "  You can register manually later by re-running this script with -Herd [url]"
     }
 } else {
-    Write-Host "`nNo Herd endpoint configured. Run with -Herd <url> to register." -ForegroundColor Yellow
+    Write-Host "`nNo Herd endpoint configured. Run with -Herd [url] to register." -ForegroundColor Yellow
 }
 
-Write-Host "`nDone!" -ForegroundColor Green
+# -- Daemon mode stub --
+if ($Daemon) {
+    Write-Host ""
+    Write-Host "NOTE: Daemon mode (-Daemon) is not yet implemented." -ForegroundColor Yellow
+    Write-Host "  Daemon mode will keep herd-tune resident with an HTTP control API for:"
+    Write-Host "    POST /download-model  -- download a GGUF from HuggingFace"
+    Write-Host "    POST /restart         -- restart llama-server"
+    Write-Host "    GET  /status          -- current status"
+    Write-Host '  Without daemon mode, dashboard control plane features (remote model download,'
+    Write-Host '  llama-server restart) will not work for llama-server nodes.'
+}
+
+Write-Host ""
+Write-Host 'Done!' -ForegroundColor Green

--- a/scripts/herd-tune.sh
+++ b/scripts/herd-tune.sh
@@ -4,10 +4,23 @@ set -euo pipefail
 # ── Herd Registration (auto-configured on download) ──
 HERD_ENDPOINT="%%HERD_ENDPOINT%%"
 ENROLLMENT_KEY="%%ENROLLMENT_KEY%%"
-HERD_TUNE_VERSION="0.8.0"
+HERD_TUNE_VERSION="1.0.0"
 APPLY=false
+BACKEND="auto"
+LLAMA_SERVER_PORT=8090
+LLAMA_SERVER_CTX=4096
+MODEL_PATH=""
+DAEMON_MODE=false
 
-# Parse args
+# ── Colors ──
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+# ── Parse args ──
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --apply) APPLY=true; shift ;;
@@ -15,16 +28,43 @@ while [[ $# -gt 0 ]]; do
         --herd=*) HERD_ENDPOINT="${1#*=}"; shift ;;
         --enrollment-key) ENROLLMENT_KEY="$2"; shift 2 ;;
         --enrollment-key=*) ENROLLMENT_KEY="${1#*=}"; shift ;;
+        --backend) BACKEND="$2"; shift 2 ;;
+        --backend=*) BACKEND="${1#*=}"; shift ;;
+        --port) LLAMA_SERVER_PORT="$2"; shift 2 ;;
+        --port=*) LLAMA_SERVER_PORT="${1#*=}"; shift ;;
+        --context) LLAMA_SERVER_CTX="$2"; shift 2 ;;
+        --context=*) LLAMA_SERVER_CTX="${1#*=}"; shift ;;
+        --model) MODEL_PATH="$2"; shift 2 ;;
+        --model=*) MODEL_PATH="${1#*=}"; shift ;;
+        --daemon) DAEMON_MODE=true; shift ;;
         -h|--help)
-            echo "Usage: $0 [--apply] [--herd URL] [--enrollment-key KEY]"
-            echo "  --apply           Apply recommended OLLAMA_* env vars and restart Ollama"
-            echo "  --herd            Herd endpoint URL for registration"
-            echo "  --enrollment-key  Enrollment key for node registration"
+            echo "Usage: $0 [OPTIONS]"
+            echo ""
+            echo "Options:"
+            echo "  --apply              Apply recommended OLLAMA_* env vars and restart Ollama"
+            echo "  --herd URL           Herd endpoint URL for registration"
+            echo "  --enrollment-key KEY Enrollment key for node registration"
+            echo "  --backend TYPE       Backend type: ollama, llama-server, auto (default: auto)"
+            echo "  --port PORT          llama-server port (default: 8090)"
+            echo "  --context SIZE       llama-server context length (default: 4096)"
+            echo "  --model PATH         Path to GGUF model file for llama-server"
+            echo "  --daemon             Keep herd-tune resident with HTTP control API (stretch goal)"
+            echo ""
+            echo "Backend modes:"
+            echo "  auto          If Ollama is running on :11434, use it; otherwise set up llama-server"
+            echo "  ollama        Probe and configure existing Ollama installation"
+            echo "  llama-server  Download and configure llama-server binary"
             exit 0
             ;;
         *) echo "Unknown option: $1"; exit 1 ;;
     esac
 done
+
+# Validate --backend
+case "$BACKEND" in
+    ollama|llama-server|auto) ;;
+    *) echo "ERROR: Invalid --backend value '$BACKEND'. Must be: ollama, llama-server, auto"; exit 1 ;;
+esac
 
 echo ""
 echo "  _               _       _"
@@ -32,43 +72,247 @@ echo " | |_  ___ _ _ __| |  ___| |_ _  _ _ _  ___"
 echo " | ' \/ -_) '_/ _\` | |___| _| || | ' \/ -_)"
 echo " |_||_\___|_| \__,_|     \__|\_,_|_||_\___|"
 echo ""
-echo "  GPU Detection & Ollama Configuration"
-echo "  Version $HERD_TUNE_VERSION"
+echo "  GPU Detection & Backend Configuration"
+echo -e "  Version ${CYAN}${HERD_TUNE_VERSION}${NC}"
 echo ""
 
-# ── Detect GPU ──
-echo "=== Hardware Detection ==="
-GPU_NAME=""
+# ══════════════════════════════════════════════════════════════════════
+# GPU VENDOR DETECTION
+# ══════════════════════════════════════════════════════════════════════
+
+GPU_VENDOR="none"
+GPU_MODEL=""
+GPU_BACKEND="cpu"
+GPU_DRIVER_VERSION=""
+CUDA_VERSION=""
+COMPUTE_CAP=""
+CUDA_MAJOR=0
 VRAM_MB=0
 
-if command -v nvidia-smi &>/dev/null; then
-    GPU_INFO=$(nvidia-smi --query-gpu=name,memory.total --format=csv,noheader,nounits 2>/dev/null || true)
-    if [ -n "$GPU_INFO" ]; then
-        GPU_NAME=$(echo "$GPU_INFO" | head -1 | cut -d',' -f1 | xargs)
-        VRAM_MB=$(echo "$GPU_INFO" | head -1 | cut -d',' -f2 | xargs)
+detect_nvidia() {
+    if ! command -v nvidia-smi &>/dev/null; then
+        return 1
     fi
+
+    # Query GPU name, VRAM, driver version
+    local gpu_info
+    gpu_info=$(nvidia-smi --query-gpu=name,memory.total,driver_version --format=csv,noheader,nounits 2>/dev/null || true)
+    if [ -z "$gpu_info" ]; then
+        return 1
+    fi
+
+    GPU_VENDOR="nvidia"
+    GPU_MODEL=$(echo "$gpu_info" | head -1 | cut -d',' -f1 | xargs)
+    VRAM_MB=$(echo "$gpu_info" | head -1 | cut -d',' -f2 | xargs)
+    GPU_DRIVER_VERSION=$(echo "$gpu_info" | head -1 | cut -d',' -f3 | xargs)
+
+    # Query compute capability
+    COMPUTE_CAP=$(nvidia-smi --query-gpu=compute_cap --format=csv,noheader 2>/dev/null | head -1 | xargs || true)
+
+    # Parse CUDA version from nvidia-smi header
+    CUDA_VERSION=$(nvidia-smi 2>/dev/null | grep -oP 'CUDA Version: \K[0-9.]+' || true)
+
+    # Determine CUDA major version needed based on compute capability
+    # Blackwell (RTX 5000-series) has compute capability >= 12.0 and requires CUDA 13.x
+    if [ -n "$COMPUTE_CAP" ]; then
+        local cc_major
+        cc_major=$(echo "$COMPUTE_CAP" | cut -d'.' -f1)
+        if [ "$cc_major" -ge 12 ] 2>/dev/null; then
+            CUDA_MAJOR=13
+            GPU_BACKEND="cuda"
+            echo ""
+            echo -e "  ${BOLD}${YELLOW}╔══════════════════════════════════════════════════════════════╗${NC}"
+            echo -e "  ${BOLD}${YELLOW}║  BLACKWELL GPU DETECTED (compute capability ${COMPUTE_CAP})       ║${NC}"
+            echo -e "  ${BOLD}${YELLOW}║                                                              ║${NC}"
+            echo -e "  ${BOLD}${YELLOW}║  This GPU REQUIRES CUDA 13.x builds of llama-server.         ║${NC}"
+            echo -e "  ${BOLD}${YELLOW}║  CUDA 12.x will silently fall back to CPU (~10x slower).     ║${NC}"
+            echo -e "  ${BOLD}${YELLOW}║  herd-tune will select the correct cu13 binary.              ║${NC}"
+            echo -e "  ${BOLD}${YELLOW}╚══════════════════════════════════════════════════════════════╝${NC}"
+            echo ""
+        else
+            CUDA_MAJOR=12
+            GPU_BACKEND="cuda"
+        fi
+    else
+        # Fallback: assume CUDA 12 if we can't read compute capability
+        CUDA_MAJOR=12
+        GPU_BACKEND="cuda"
+    fi
+
+    return 0
+}
+
+detect_amd() {
+    # Try rocm-smi first
+    if command -v rocm-smi &>/dev/null; then
+        local rocm_info
+        rocm_info=$(rocm-smi --showproductname --csv 2>/dev/null || true)
+        if [ -n "$rocm_info" ]; then
+            GPU_VENDOR="amd"
+            GPU_BACKEND="rocm"
+            # Parse product name from CSV output (skip header)
+            GPU_MODEL=$(echo "$rocm_info" | tail -n +2 | head -1 | cut -d',' -f2 | xargs 2>/dev/null || echo "AMD GPU")
+
+            # Get VRAM
+            local vram_info
+            vram_info=$(rocm-smi --showmeminfo vram --csv 2>/dev/null || true)
+            if [ -n "$vram_info" ]; then
+                # Total VRAM is in bytes, convert to MB
+                local vram_bytes
+                vram_bytes=$(echo "$vram_info" | tail -n +2 | head -1 | grep -oP '\d+' | head -1 || echo "0")
+                VRAM_MB=$(( vram_bytes / 1048576 ))
+            fi
+
+            # Get GPU arch via rocminfo
+            if command -v rocminfo &>/dev/null; then
+                local arch
+                arch=$(rocminfo 2>/dev/null | grep -oP 'gfx\d+' | head -1 || true)
+                if [ -n "$arch" ]; then
+                    GPU_MODEL="${GPU_MODEL} (${arch})"
+                fi
+            fi
+
+            return 0
+        fi
+    fi
+
+    # Try hipconfig
+    if command -v hipconfig &>/dev/null; then
+        GPU_VENDOR="amd"
+        GPU_BACKEND="rocm"
+        GPU_MODEL=$(hipconfig --platform 2>/dev/null || echo "AMD GPU")
+        return 0
+    fi
+
+    # Check lspci for AMD GPUs
+    if command -v lspci &>/dev/null; then
+        local amd_gpu
+        amd_gpu=$(lspci 2>/dev/null | grep -i 'VGA\|3D' | grep -i 'AMD\|Radeon' | head -1 || true)
+        if [ -n "$amd_gpu" ]; then
+            GPU_VENDOR="amd"
+            GPU_BACKEND="rocm"
+            GPU_MODEL=$(echo "$amd_gpu" | sed 's/.*: //')
+            return 0
+        fi
+    fi
+
+    return 1
+}
+
+detect_intel() {
+    # Try sycl-ls
+    if command -v sycl-ls &>/dev/null; then
+        local sycl_info
+        sycl_info=$(sycl-ls 2>/dev/null || true)
+        if echo "$sycl_info" | grep -qi 'intel\|level_zero'; then
+            GPU_VENDOR="intel"
+            GPU_BACKEND="sycl"
+            GPU_MODEL=$(echo "$sycl_info" | grep -i 'intel' | head -1 | xargs || echo "Intel GPU")
+            return 0
+        fi
+    fi
+
+    # Check lspci for Intel discrete GPUs (Arc)
+    if command -v lspci &>/dev/null; then
+        local intel_gpu
+        intel_gpu=$(lspci 2>/dev/null | grep -i 'VGA\|3D' | grep -i 'Intel.*Arc\|Intel.*Xe' | head -1 || true)
+        if [ -n "$intel_gpu" ]; then
+            GPU_VENDOR="intel"
+            GPU_BACKEND="sycl"
+            GPU_MODEL=$(echo "$intel_gpu" | sed 's/.*: //')
+            return 0
+        fi
+    fi
+
+    return 1
+}
+
+echo -e "${CYAN}=== Hardware Detection ===${NC}"
+
+# Try GPU detection in order: NVIDIA > AMD > Intel > fallback
+if detect_nvidia; then
+    echo -e "  GPU Vendor: ${GREEN}NVIDIA${NC}"
+    echo "  GPU Model:  $GPU_MODEL"
+    echo "  VRAM:       ${VRAM_MB} MB"
+    echo "  Driver:     $GPU_DRIVER_VERSION"
+    echo "  CUDA:       $CUDA_VERSION"
+    echo "  Compute:    $COMPUTE_CAP"
+    if [ "$CUDA_MAJOR" -eq 13 ]; then
+        echo -e "  Binary:     ${YELLOW}CUDA 13.x required (Blackwell)${NC}"
+    else
+        echo "  Binary:     CUDA 12.x"
+    fi
+elif detect_amd; then
+    echo -e "  GPU Vendor: ${GREEN}AMD${NC}"
+    echo "  GPU Model:  $GPU_MODEL"
+    echo "  VRAM:       ${VRAM_MB} MB"
+    echo "  Backend:    ROCm"
+elif detect_intel; then
+    echo -e "  GPU Vendor: ${GREEN}Intel${NC}"
+    echo "  GPU Model:  $GPU_MODEL"
+    echo "  Backend:    SYCL"
+else
+    echo -e "  GPU Vendor: ${YELLOW}None detected${NC}"
+    echo "  Backend:    Vulkan (universal fallback)"
+    GPU_BACKEND="vulkan"
 fi
 
 # Detect RAM
 RAM_MB=$(free -m 2>/dev/null | awk '/^Mem:/{print $2}' || echo 0)
+echo "  RAM:        ${RAM_MB} MB"
 
-echo "  GPU:  ${GPU_NAME:-Not detected}"
-echo "  VRAM: ${VRAM_MB} MB"
-echo "  RAM:  ${RAM_MB} MB"
+# ══════════════════════════════════════════════════════════════════════
+# BACKEND SELECTION
+# ══════════════════════════════════════════════════════════════════════
 
-# ── Detect Ollama ──
-echo ""
-echo "=== Ollama Detection ==="
-OLLAMA_URL="http://localhost:11434"
-
-OLLAMA_VERSION=$(curl -sf "${OLLAMA_URL}/api/version" 2>/dev/null | grep -o '"version":"[^"]*"' | cut -d'"' -f4 || true)
-if [ -z "$OLLAMA_VERSION" ]; then
-    echo "ERROR: Ollama is not running at ${OLLAMA_URL}"
-    exit 1
+RESOLVED_BACKEND="$BACKEND"
+if [ "$BACKEND" = "auto" ]; then
+    # Check if Ollama is running on port 11434
+    if curl -sf "http://localhost:11434/api/version" --connect-timeout 3 &>/dev/null; then
+        RESOLVED_BACKEND="ollama"
+        echo ""
+        echo -e "  ${CYAN}Auto-detected: Ollama is running on :11434${NC}"
+    else
+        RESOLVED_BACKEND="llama-server"
+        echo ""
+        echo -e "  ${CYAN}Auto-detected: Ollama not found, will set up llama-server${NC}"
+    fi
 fi
 
-# Get loaded models
-MODELS_LOADED=$(curl -sf "${OLLAMA_URL}/api/ps" 2>/dev/null | python3 -c "
+echo ""
+echo -e "${CYAN}=== Backend: ${BOLD}${RESOLVED_BACKEND}${NC} ==="
+
+# ══════════════════════════════════════════════════════════════════════
+# OLLAMA BACKEND
+# ══════════════════════════════════════════════════════════════════════
+
+OLLAMA_VERSION=""
+OLLAMA_URL=""
+MODELS_LOADED="[]"
+MODELS_AVAILABLE=0
+BACKEND_VERSION=""
+BACKEND_URL=""
+BACKEND_PORT=0
+CONFIG_APPLIED=false
+
+# Recommended config vars (used by both paths)
+NUM_PARALLEL=1
+MAX_LOADED=1
+MAX_QUEUE=128
+KEEP_ALIVE="5m"
+CTX_LEN=2048
+
+if [ "$RESOLVED_BACKEND" = "ollama" ]; then
+    OLLAMA_URL="http://localhost:11434"
+
+    OLLAMA_VERSION=$(curl -sf "${OLLAMA_URL}/api/version" 2>/dev/null | grep -o '"version":"[^"]*"' | cut -d'"' -f4 || true)
+    if [ -z "$OLLAMA_VERSION" ]; then
+        echo -e "${RED}ERROR: Ollama is not running at ${OLLAMA_URL}${NC}"
+        exit 1
+    fi
+
+    # Get loaded models
+    MODELS_LOADED=$(curl -sf "${OLLAMA_URL}/api/ps" 2>/dev/null | python3 -c "
 import sys, json
 try:
     data = json.load(sys.stdin)
@@ -77,8 +321,8 @@ try:
 except: print('[]')
 " 2>/dev/null || echo '[]')
 
-# Get available model count
-MODELS_AVAILABLE=$(curl -sf "${OLLAMA_URL}/api/tags" 2>/dev/null | python3 -c "
+    # Get available model count
+    MODELS_AVAILABLE=$(curl -sf "${OLLAMA_URL}/api/tags" 2>/dev/null | python3 -c "
 import sys, json
 try:
     data = json.load(sys.stdin)
@@ -86,50 +330,42 @@ try:
 except: print(0)
 " 2>/dev/null || echo 0)
 
-# Determine best reachable URL (prefer LAN IP over localhost)
-BEST_URL="$OLLAMA_URL"
-LAN_IP=$(hostname -I 2>/dev/null | awk '{print $1}' || true)
-if [ -n "$LAN_IP" ]; then
-    BEST_URL="http://${LAN_IP}:11434"
-fi
+    echo "  URL:      ${OLLAMA_URL}"
+    echo "  Version:  ${OLLAMA_VERSION}"
+    echo "  Models:   ${MODELS_AVAILABLE} available"
 
-echo "  URL:      ${BEST_URL}"
-echo "  Version:  ${OLLAMA_VERSION}"
-echo "  Models:   ${MODELS_AVAILABLE} available"
+    # Calculate recommended config based on VRAM
+    if [ "$VRAM_MB" -ge 24576 ]; then
+        NUM_PARALLEL=8; MAX_LOADED=4; MAX_QUEUE=1024; KEEP_ALIVE="30m"; CTX_LEN=16384
+    elif [ "$VRAM_MB" -ge 12288 ]; then
+        NUM_PARALLEL=4; MAX_LOADED=2; MAX_QUEUE=512; KEEP_ALIVE="15m"; CTX_LEN=8192
+    elif [ "$VRAM_MB" -ge 8192 ]; then
+        NUM_PARALLEL=2; MAX_LOADED=1; MAX_QUEUE=256; KEEP_ALIVE="10m"; CTX_LEN=4096
+    fi
 
-# ── Calculate recommended config ──
-echo ""
-echo "=== Recommended Configuration ==="
-
-if [ "$VRAM_MB" -ge 24576 ]; then
-    NUM_PARALLEL=8; MAX_LOADED=4; MAX_QUEUE=1024; KEEP_ALIVE="30m"; CTX_LEN=16384
-elif [ "$VRAM_MB" -ge 12288 ]; then
-    NUM_PARALLEL=4; MAX_LOADED=2; MAX_QUEUE=512; KEEP_ALIVE="15m"; CTX_LEN=8192
-elif [ "$VRAM_MB" -ge 8192 ]; then
-    NUM_PARALLEL=2; MAX_LOADED=1; MAX_QUEUE=256; KEEP_ALIVE="10m"; CTX_LEN=4096
-else
-    NUM_PARALLEL=1; MAX_LOADED=1; MAX_QUEUE=128; KEEP_ALIVE="5m"; CTX_LEN=2048
-fi
-
-echo "  num_parallel:     $NUM_PARALLEL"
-echo "  max_loaded_models: $MAX_LOADED"
-echo "  max_queue:        $MAX_QUEUE"
-echo "  keep_alive:       $KEEP_ALIVE"
-echo "  flash_attention:  true"
-echo "  kv_cache_type:    q8_0"
-echo "  context_length:   $CTX_LEN"
-
-# ── Apply config ──
-CONFIG_APPLIED=false
-if [ "$APPLY" = true ]; then
     echo ""
-    echo "=== Applying Ollama Configuration ==="
+    echo -e "${CYAN}=== Recommended Configuration ===${NC}"
+    echo "  num_parallel:      $NUM_PARALLEL"
+    echo "  max_loaded_models: $MAX_LOADED"
+    echo "  max_queue:         $MAX_QUEUE"
+    echo "  keep_alive:        $KEEP_ALIVE"
+    echo "  flash_attention:   true"
+    echo "  kv_cache_type:     q8_0"
+    echo "  context_length:    $CTX_LEN"
 
-    # Write to /etc/environment or systemd override
-    OLLAMA_ENV_FILE="/etc/systemd/system/ollama.service.d/override.conf"
-    mkdir -p "$(dirname "$OLLAMA_ENV_FILE")"
+    # Apply config
+    if [ "$APPLY" = true ]; then
+        echo ""
+        echo -e "${CYAN}=== Applying Ollama Configuration ===${NC}"
 
-    cat > "$OLLAMA_ENV_FILE" << ENVEOF
+        OLLAMA_ENV_FILE="/etc/systemd/system/ollama.service.d/override.conf"
+        mkdir -p "$(dirname "$OLLAMA_ENV_FILE")" 2>/dev/null || {
+            echo -e "${YELLOW}WARNING: Cannot create systemd override directory (not root?). Skipping apply.${NC}"
+            APPLY=false
+        }
+
+        if [ "$APPLY" = true ]; then
+            cat > "$OLLAMA_ENV_FILE" << ENVEOF
 [Service]
 Environment="OLLAMA_NUM_PARALLEL=${NUM_PARALLEL}"
 Environment="OLLAMA_MAX_LOADED_MODELS=${MAX_LOADED}"
@@ -140,21 +376,265 @@ Environment="OLLAMA_KV_CACHE_TYPE=q8_0"
 Environment="OLLAMA_CONTEXT_LENGTH=${CTX_LEN}"
 ENVEOF
 
-    echo "  Wrote ${OLLAMA_ENV_FILE}"
+            echo "  Wrote ${OLLAMA_ENV_FILE}"
 
-    # Restart Ollama
-    echo "  Restarting Ollama service..."
-    systemctl daemon-reload
-    systemctl restart ollama
-    sleep 3
-    echo "  Ollama service restarted."
-    CONFIG_APPLIED=true
-else
-    echo ""
-    echo "Run with --apply to set these environment variables and restart Ollama."
+            echo "  Restarting Ollama service..."
+            systemctl daemon-reload
+            systemctl restart ollama
+            sleep 3
+            echo -e "  ${GREEN}Ollama service restarted.${NC}"
+            CONFIG_APPLIED=true
+        fi
+    else
+        echo ""
+        echo "Run with --apply to set these environment variables and restart Ollama."
+    fi
+
+    BACKEND_VERSION="$OLLAMA_VERSION"
+    BACKEND_PORT=11434
+
+    # Determine best reachable URL
+    BEST_URL="$OLLAMA_URL"
 fi
 
-# ── Generate stable machine ID ──
+# ══════════════════════════════════════════════════════════════════════
+# LLAMA-SERVER BACKEND
+# ══════════════════════════════════════════════════════════════════════
+
+LLAMA_BUILD_NUMBER=""
+CAPABILITIES="[]"
+MODEL_PATHS="[]"
+
+if [ "$RESOLVED_BACKEND" = "llama-server" ]; then
+    HERD_DIR="$HOME/.herd"
+    BIN_DIR="${HERD_DIR}/bin"
+    mkdir -p "$BIN_DIR"
+
+    echo ""
+    echo -e "${CYAN}=== llama-server Binary Download ===${NC}"
+
+    # Determine correct asset pattern based on GPU vendor
+    ASSET_PATTERN=""
+    case "$GPU_VENDOR" in
+        nvidia)
+            if [ "$CUDA_MAJOR" -ge 13 ]; then
+                ASSET_PATTERN="bin-ubuntu-x64-cuda-cu13"
+            else
+                ASSET_PATTERN="bin-ubuntu-x64-cuda-cu12"
+            fi
+            ;;
+        amd)
+            ASSET_PATTERN="bin-ubuntu-x64-rocm"
+            ;;
+        *)
+            # Intel SYCL has no reliable pre-built Linux binary; use Vulkan as fallback
+            ASSET_PATTERN="bin-ubuntu-x64-vulkan" # Vulkan fallback if available, else CPU
+            if [ "$GPU_VENDOR" = "intel" ]; then
+                echo -e "  ${YELLOW}NOTE: No pre-built SYCL Linux binaries available.${NC}"
+                echo -e "  ${YELLOW}Using Vulkan fallback. For best Intel GPU performance, build from source with -DGGML_SYCL=ON${NC}"
+            fi
+            ;;
+    esac
+
+    echo "  GPU Vendor:     $GPU_VENDOR"
+    echo "  Asset pattern:  $ASSET_PATTERN"
+
+    # Query latest release from llama.cpp GitHub
+    echo "  Querying llama.cpp releases..."
+    RELEASE_JSON=$(curl -sf "https://api.github.com/repos/ggml-org/llama.cpp/releases/latest" 2>/dev/null || true)
+
+    if [ -z "$RELEASE_JSON" ]; then
+        echo -e "${RED}ERROR: Could not fetch llama.cpp releases from GitHub API.${NC}"
+        echo "  Check your internet connection or try again later."
+        echo "  You can also manually download from: https://github.com/ggml-org/llama.cpp/releases"
+        exit 1
+    fi
+
+    # Extract tag name (build number)
+    LLAMA_TAG=$(echo "$RELEASE_JSON" | python3 -c "
+import sys, json
+try:
+    data = json.load(sys.stdin)
+    print(data.get('tag_name', ''))
+except: pass
+" 2>/dev/null || true)
+
+    LLAMA_BUILD_NUMBER="$LLAMA_TAG"
+    echo "  Latest release: $LLAMA_TAG"
+
+    # Find matching asset URL
+    DOWNLOAD_URL=$(echo "$RELEASE_JSON" | python3 -c "
+import sys, json
+pattern = '$ASSET_PATTERN'
+try:
+    data = json.load(sys.stdin)
+    for asset in data.get('assets', []):
+        name = asset['name']
+        if pattern in name and name.endswith('.tar.gz'):
+            print(asset['browser_download_url'])
+            break
+except: pass
+" 2>/dev/null || true)
+
+    if [ -z "$DOWNLOAD_URL" ]; then
+        echo -e "${RED}ERROR: No matching binary found for pattern '${ASSET_PATTERN}'.${NC}"
+        echo "  Available assets can be checked at: https://github.com/ggml-org/llama.cpp/releases/latest"
+        exit 1
+    fi
+
+    ARCHIVE_NAME=$(basename "$DOWNLOAD_URL")
+    ARCHIVE_PATH="${BIN_DIR}/${ARCHIVE_NAME}"
+
+    echo "  Downloading:    $ARCHIVE_NAME"
+    echo "  To:             $BIN_DIR"
+
+    # Download with progress
+    if command -v wget &>/dev/null; then
+        wget --progress=bar:force -O "$ARCHIVE_PATH" "$DOWNLOAD_URL" 2>&1
+    else
+        curl -L --progress-bar -o "$ARCHIVE_PATH" "$DOWNLOAD_URL"
+    fi
+
+    echo "  Extracting..."
+    tar -xzf "$ARCHIVE_PATH" -C "$BIN_DIR"
+    rm -f "$ARCHIVE_PATH"
+
+    # Find the llama-server binary in extracted files
+    LLAMA_SERVER_BIN=$(find "$BIN_DIR" -name 'llama-server' -type f 2>/dev/null | head -1 || true)
+    if [ -z "$LLAMA_SERVER_BIN" ]; then
+        # May be in a subdirectory
+        LLAMA_SERVER_BIN=$(find "$BIN_DIR" -name 'llama-server' 2>/dev/null | head -1 || true)
+    fi
+
+    if [ -z "$LLAMA_SERVER_BIN" ]; then
+        echo -e "${RED}ERROR: llama-server binary not found after extraction.${NC}"
+        echo "  Contents of $BIN_DIR:"
+        ls -la "$BIN_DIR" 2>/dev/null || true
+        exit 1
+    fi
+
+    chmod +x "$LLAMA_SERVER_BIN"
+    echo -e "  ${GREEN}llama-server installed: $LLAMA_SERVER_BIN${NC}"
+
+    # ── VRAM-based context estimation ──
+    # Each 1K context ~ 0.5GB VRAM for a 7B model. Be conservative.
+    if [ "$LLAMA_SERVER_CTX" -eq 4096 ] && [ "$VRAM_MB" -gt 0 ]; then
+        if [ "$VRAM_MB" -ge 24576 ]; then
+            LLAMA_SERVER_CTX=16384
+        elif [ "$VRAM_MB" -ge 16384 ]; then
+            LLAMA_SERVER_CTX=8192
+        elif [ "$VRAM_MB" -ge 8192 ]; then
+            LLAMA_SERVER_CTX=4096
+        else
+            LLAMA_SERVER_CTX=2048
+        fi
+        echo "  Context auto-set to ${LLAMA_SERVER_CTX} based on ${VRAM_MB} MB VRAM"
+    fi
+
+    CTX_LEN=$LLAMA_SERVER_CTX
+
+    # ── Generate launch config ──
+    CONF_FILE="${HERD_DIR}/llama-server.conf"
+    MODEL_FLAG=""
+    if [ -n "$MODEL_PATH" ]; then
+        MODEL_FLAG="--model ${MODEL_PATH}"
+        MODEL_PATHS="[\"${MODEL_PATH}\"]"
+    fi
+
+    cat > "$CONF_FILE" << CONFEOF
+# llama-server launch configuration
+# Generated by herd-tune $HERD_TUNE_VERSION on $(date -u +"%Y-%m-%dT%H:%M:%SZ")
+#
+# Start command:
+#   $LLAMA_SERVER_BIN -ngl 99 -c $LLAMA_SERVER_CTX --port $LLAMA_SERVER_PORT $MODEL_FLAG
+#
+LLAMA_SERVER_BIN=$LLAMA_SERVER_BIN
+LLAMA_SERVER_PORT=$LLAMA_SERVER_PORT
+LLAMA_SERVER_CTX=$LLAMA_SERVER_CTX
+LLAMA_SERVER_NGL=99
+GPU_VENDOR=$GPU_VENDOR
+GPU_BACKEND=$GPU_BACKEND
+GPU_MODEL=$GPU_MODEL
+VRAM_MB=$VRAM_MB
+MODEL_PATH=$MODEL_PATH
+BUILD=$LLAMA_BUILD_NUMBER
+CONFEOF
+
+    echo -e "  ${GREEN}Launch config written: $CONF_FILE${NC}"
+    echo ""
+    echo "  To start llama-server:"
+    echo "    $LLAMA_SERVER_BIN -ngl 99 -c $LLAMA_SERVER_CTX --port $LLAMA_SERVER_PORT $MODEL_FLAG"
+
+    BACKEND_VERSION="$LLAMA_BUILD_NUMBER"
+    BACKEND_PORT=$LLAMA_SERVER_PORT
+
+    # Build capabilities list
+    CAPS=()
+    case "$GPU_BACKEND" in
+        cuda)  CAPS+=("cuda") ;;
+        rocm)  CAPS+=("rocm") ;;
+        sycl)  CAPS+=("sycl") ;;
+        vulkan) CAPS+=("vulkan") ;;
+    esac
+    # llama-server supports flash attention by default on CUDA
+    if [ "$GPU_BACKEND" = "cuda" ] || [ "$GPU_BACKEND" = "rocm" ]; then
+        CAPS+=("flash_attn")
+    fi
+    CAPABILITIES=$(printf '%s\n' "${CAPS[@]}" | python3 -c "
+import sys, json
+print(json.dumps([l.strip() for l in sys.stdin if l.strip()]))
+" 2>/dev/null || echo '[]')
+fi
+
+# ══════════════════════════════════════════════════════════════════════
+# IP DETECTION (Tailscale > LAN > localhost)
+# ══════════════════════════════════════════════════════════════════════
+
+detect_best_ip() {
+    # Prefer Tailscale IP (100.x.y.z range)
+    if command -v tailscale &>/dev/null; then
+        local ts_ip
+        ts_ip=$(tailscale ip -4 2>/dev/null || true)
+        if [ -n "$ts_ip" ]; then
+            echo "$ts_ip"
+            return
+        fi
+    fi
+
+    # Try to find Tailscale IP from interface
+    local ts_iface_ip
+    ts_iface_ip=$(ip addr show 2>/dev/null | grep -oP '100\.\d+\.\d+\.\d+' | head -1 || true)
+    if [ -n "$ts_iface_ip" ]; then
+        echo "$ts_iface_ip"
+        return
+    fi
+
+    # LAN IP
+    local lan_ip
+    lan_ip=$(hostname -I 2>/dev/null | awk '{print $1}' || true)
+    if [ -n "$lan_ip" ]; then
+        echo "$lan_ip"
+        return
+    fi
+
+    echo "127.0.0.1"
+}
+
+BEST_IP=$(detect_best_ip)
+
+if [ "$RESOLVED_BACKEND" = "ollama" ]; then
+    BACKEND_URL="http://${BEST_IP}:11434"
+else
+    BACKEND_URL="http://${BEST_IP}:${LLAMA_SERVER_PORT}"
+fi
+
+echo ""
+echo -e "  ${CYAN}Best reachable URL: ${BACKEND_URL}${NC}"
+
+# ══════════════════════════════════════════════════════════════════════
+# GENERATE STABLE MACHINE ID
+# ══════════════════════════════════════════════════════════════════════
+
 NODE_ID=""
 if [ -f /etc/machine-id ]; then
     NODE_ID=$(cat /etc/machine-id)
@@ -165,10 +645,13 @@ else
     NODE_ID=$(echo -n "${MAC}$(hostname)" | sha256sum | cut -d' ' -f1 | head -c 32)
 fi
 
-# ── Register with Herd ──
+# ══════════════════════════════════════════════════════════════════════
+# REGISTER WITH HERD
+# ══════════════════════════════════════════════════════════════════════
+
 if [ -n "$HERD_ENDPOINT" ] && [ "$HERD_ENDPOINT" != '%%HERD_ENDPOINT%%' ]; then
     echo ""
-    echo "=== Registering with Herd ==="
+    echo -e "${CYAN}=== Registering with Herd ===${NC}"
     echo "  Endpoint: ${HERD_ENDPOINT}"
 
     REG_URL="${HERD_ENDPOINT}/api/nodes/register"
@@ -183,12 +666,21 @@ if [ -n "$HERD_ENDPOINT" ] && [ "$HERD_ENDPOINT" != '%%HERD_ENDPOINT%%' ]; then
         NODE_ID_JSON="\"node_id\": \"${NODE_ID}\","
     fi
 
-    PAYLOAD=$(cat << JSONEOF
+    # Build the appropriate JSON payload based on backend type
+    if [ "$RESOLVED_BACKEND" = "ollama" ]; then
+        PAYLOAD=$(cat << JSONEOF
 {
   ${NODE_ID_JSON}
   "hostname": "${HOSTNAME_VAL}",
-  "ollama_url": "${BEST_URL}",
-  "gpu": "${GPU_NAME}",
+  "backend": "ollama",
+  "backend_version": "${OLLAMA_VERSION}",
+  "backend_url": "${BACKEND_URL}",
+  "backend_port": 11434,
+  "gpu_vendor": "${GPU_VENDOR}",
+  "gpu_model": "${GPU_MODEL}",
+  "gpu_backend": "${GPU_BACKEND}",
+  "gpu_driver_version": "${GPU_DRIVER_VERSION}",
+  "cuda_version": "${CUDA_VERSION}",
   "vram_mb": ${VRAM_MB},
   "ram_mb": ${RAM_MB},
   "ollama_version": "${OLLAMA_VERSION}",
@@ -204,27 +696,69 @@ if [ -n "$HERD_ENDPOINT" ] && [ "$HERD_ENDPOINT" != '%%HERD_ENDPOINT%%' ]; then
     "context_length": ${CTX_LEN}
   },
   "config_applied": ${CONFIG_APPLIED},
+  "max_context_len": ${CTX_LEN},
+  "capabilities": ${CAPABILITIES:-"[]"},
   "herd_tune_version": "${HERD_TUNE_VERSION}",
   "os": "linux",
   "registered_at": "${REGISTERED_AT}"
 }
 JSONEOF
 )
+    else
+        # llama-server payload
+        PAYLOAD=$(cat << JSONEOF
+{
+  ${NODE_ID_JSON}
+  "hostname": "${HOSTNAME_VAL}",
+  "backend": "llama-server",
+  "backend_version": "${LLAMA_BUILD_NUMBER}",
+  "backend_url": "${BACKEND_URL}",
+  "backend_port": ${LLAMA_SERVER_PORT},
+  "gpu_vendor": "${GPU_VENDOR}",
+  "gpu_model": "${GPU_MODEL}",
+  "gpu_backend": "${GPU_BACKEND}",
+  "gpu_driver_version": "${GPU_DRIVER_VERSION}",
+  "cuda_version": "${CUDA_VERSION}",
+  "vram_mb": ${VRAM_MB},
+  "ram_mb": ${RAM_MB},
+  "models_loaded": [],
+  "model_paths": ${MODEL_PATHS},
+  "capabilities": ${CAPABILITIES},
+  "max_context_len": ${LLAMA_SERVER_CTX},
+  "herd_tune_version": "${HERD_TUNE_VERSION}",
+  "os": "linux",
+  "registered_at": "${REGISTERED_AT}"
+}
+JSONEOF
+)
+    fi
 
     RESPONSE=$(curl -sf -X POST "${REG_URL}" \
         -H "Content-Type: application/json" \
         -d "$PAYLOAD" 2>/dev/null || true)
 
     if [ -n "$RESPONSE" ]; then
-        echo "  Registration successful!"
+        echo -e "  ${GREEN}Registration successful!${NC}"
         echo "  $RESPONSE"
     else
-        echo "  WARNING: Registration failed. You can register later with --herd <url>"
+        echo -e "  ${YELLOW}WARNING: Registration failed. You can register later with --herd <url>${NC}"
     fi
 else
     echo ""
     echo "No Herd endpoint configured. Run with --herd <url> to register."
 fi
 
+# ── Daemon mode stub ──
+if [ "$DAEMON_MODE" = true ]; then
+    echo ""
+    echo -e "${YELLOW}NOTE: Daemon mode (--daemon) is not yet implemented.${NC}"
+    echo "  Daemon mode will keep herd-tune resident with an HTTP control API for:"
+    echo "    POST /download-model  — download a GGUF from HuggingFace"
+    echo "    POST /restart         — restart llama-server"
+    echo "    GET  /status          — current status"
+    echo "  Without daemon mode, dashboard control plane features (remote model download,"
+    echo "  llama-server restart) will not work for llama-server nodes."
+fi
+
 echo ""
-echo "Done!"
+echo -e "${GREEN}Done!${NC}"

--- a/src/agent/audit.rs
+++ b/src/agent/audit.rs
@@ -185,7 +185,11 @@ impl AgentAudit {
             }
             temp.flush()?;
             std::fs::rename(&temp_path, &self.log_path)?;
-            tracing::info!("Audit log cleanup: removed {} old entries, kept {}", removed, kept_lines.len());
+            tracing::info!(
+                "Audit log cleanup: removed {} old entries, kept {}",
+                removed,
+                kept_lines.len()
+            );
         }
 
         Ok(removed)

--- a/src/agent/executor.rs
+++ b/src/agent/executor.rs
@@ -128,7 +128,8 @@ impl AgentExecutor {
         user_message: String,
         events: mpsc::Sender<AgentEvent>,
     ) -> Result<String> {
-        self.execute_inner(session, user_message, Some(events)).await
+        self.execute_inner(session, user_message, Some(events))
+            .await
     }
 
     async fn emit(events: &Option<mpsc::Sender<AgentEvent>>, event: AgentEvent) {
@@ -248,8 +249,7 @@ impl AgentExecutor {
                                 )
                                 .await;
 
-                                let result =
-                                    tools::execute_tool(&call.name, &call.arguments).await;
+                                let result = tools::execute_tool(&call.name, &call.arguments).await;
 
                                 Self::emit(
                                     &events,

--- a/src/agent/permissions.rs
+++ b/src/agent/permissions.rs
@@ -70,10 +70,7 @@ impl PermissionEngine {
         for (i, pattern) in self.deny_bash_patterns.iter().enumerate() {
             if pattern.is_match(command) {
                 let raw = &self.deny_bash_raw[i];
-                return PermissionResult::Denied(format!(
-                    "Command matches deny pattern '{}'",
-                    raw
-                ));
+                return PermissionResult::Denied(format!("Command matches deny pattern '{}'", raw));
             }
         }
         PermissionResult::Allowed
@@ -124,15 +121,8 @@ mod tests {
 
     fn restrictive() -> PermissionEngine {
         PermissionEngine::new(&PermissionsConfig {
-            deny_file_patterns: vec![
-                r"\.env$".into(),
-                r"\.ssh".into(),
-                r"/etc/shadow".into(),
-            ],
-            deny_bash_patterns: vec![
-                r"rm\s+-rf\s+/".into(),
-                r"\bsudo\b".into(),
-            ],
+            deny_file_patterns: vec![r"\.env$".into(), r"\.ssh".into(), r"/etc/shadow".into()],
+            deny_bash_patterns: vec![r"rm\s+-rf\s+/".into(), r"\bsudo\b".into()],
             allow_shell_commands: true,
         })
     }

--- a/src/agent/store.rs
+++ b/src/agent/store.rs
@@ -38,7 +38,11 @@ impl SessionStore {
                 match std::fs::read_to_string(&path) {
                     Ok(content) => match serde_json::from_str::<Session>(&content) {
                         Ok(session) => {
-                            tracing::info!("Restored session {} (model: {})", session.id, session.model);
+                            tracing::info!(
+                                "Restored session {} (model: {})",
+                                session.id,
+                                session.model
+                            );
                             locks.insert(session.id.clone(), Arc::new(Mutex::new(())));
                             sessions.insert(session.id.clone(), session);
                         }
@@ -384,7 +388,10 @@ mod tests {
         // Create and populate
         {
             let store = SessionStore::persistent(10, dir.clone()).unwrap();
-            let session = store.create("llama3:8b".into(), Some("test".into())).await.unwrap();
+            let session = store
+                .create("llama3:8b".into(), Some("test".into()))
+                .await
+                .unwrap();
             assert!(dir.join(format!("{}.json", session.id)).exists());
         }
 

--- a/src/agent/tools.rs
+++ b/src/agent/tools.rs
@@ -115,7 +115,11 @@ async fn execute_read_file(args: &serde_json::Value) -> ToolResult {
     match tokio::fs::metadata(path).await {
         Ok(meta) if meta.len() > MAX_READ_BYTES => {
             return ToolResult {
-                content: format!("File too large ({} bytes, max {})", meta.len(), MAX_READ_BYTES),
+                content: format!(
+                    "File too large ({} bytes, max {})",
+                    meta.len(),
+                    MAX_READ_BYTES
+                ),
                 success: false,
             };
         }

--- a/src/agent/types.rs
+++ b/src/agent/types.rs
@@ -93,18 +93,42 @@ mod tests {
 
     #[test]
     fn message_role_serializes_lowercase() {
-        assert_eq!(serde_json::to_string(&MessageRole::System).unwrap(), "\"system\"");
-        assert_eq!(serde_json::to_string(&MessageRole::User).unwrap(), "\"user\"");
-        assert_eq!(serde_json::to_string(&MessageRole::Assistant).unwrap(), "\"assistant\"");
-        assert_eq!(serde_json::to_string(&MessageRole::Tool).unwrap(), "\"tool\"");
+        assert_eq!(
+            serde_json::to_string(&MessageRole::System).unwrap(),
+            "\"system\""
+        );
+        assert_eq!(
+            serde_json::to_string(&MessageRole::User).unwrap(),
+            "\"user\""
+        );
+        assert_eq!(
+            serde_json::to_string(&MessageRole::Assistant).unwrap(),
+            "\"assistant\""
+        );
+        assert_eq!(
+            serde_json::to_string(&MessageRole::Tool).unwrap(),
+            "\"tool\""
+        );
     }
 
     #[test]
     fn message_role_deserializes_lowercase() {
-        assert_eq!(serde_json::from_str::<MessageRole>("\"system\"").unwrap(), MessageRole::System);
-        assert_eq!(serde_json::from_str::<MessageRole>("\"user\"").unwrap(), MessageRole::User);
-        assert_eq!(serde_json::from_str::<MessageRole>("\"assistant\"").unwrap(), MessageRole::Assistant);
-        assert_eq!(serde_json::from_str::<MessageRole>("\"tool\"").unwrap(), MessageRole::Tool);
+        assert_eq!(
+            serde_json::from_str::<MessageRole>("\"system\"").unwrap(),
+            MessageRole::System
+        );
+        assert_eq!(
+            serde_json::from_str::<MessageRole>("\"user\"").unwrap(),
+            MessageRole::User
+        );
+        assert_eq!(
+            serde_json::from_str::<MessageRole>("\"assistant\"").unwrap(),
+            MessageRole::Assistant
+        );
+        assert_eq!(
+            serde_json::from_str::<MessageRole>("\"tool\"").unwrap(),
+            MessageRole::Tool
+        );
     }
 
     #[test]
@@ -117,7 +141,12 @@ mod tests {
 
     #[test]
     fn session_status_roundtrip() {
-        for status in [SessionStatus::Active, SessionStatus::Processing, SessionStatus::Completed, SessionStatus::Error] {
+        for status in [
+            SessionStatus::Active,
+            SessionStatus::Processing,
+            SessionStatus::Completed,
+            SessionStatus::Error,
+        ] {
             let json = serde_json::to_string(&status).unwrap();
             let back: SessionStatus = serde_json::from_str(&json).unwrap();
             assert_eq!(back, status);

--- a/src/agent/ws.rs
+++ b/src/agent/ws.rs
@@ -126,7 +126,10 @@ async fn handle_ws(mut socket: WebSocket, state: AppState, session_id: String) {
         // Spawn executor in background so we can forward events
         let content = ws_msg.content;
         let exec_handle = tokio::spawn(async move {
-            executor.execute_streaming(&mut session, content, tx).await.map(|result| (result, session))
+            executor
+                .execute_streaming(&mut session, content, tx)
+                .await
+                .map(|result| (result, session))
         });
 
         // Forward events to WebSocket and audit log

--- a/src/analytics.rs
+++ b/src/analytics.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::fs::OpenOptions;
 use std::io::{BufRead, BufReader, Write};
 use std::path::PathBuf;
@@ -20,6 +21,18 @@ pub struct RequestLog {
     pub tier: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub classified_by: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tokens_in: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tokens_out: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tokens_per_second: Option<f32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub prompt_eval_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub eval_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub backend_type: Option<String>,
 }
 
 pub struct Analytics {
@@ -68,15 +81,21 @@ impl Analytics {
         let file = std::fs::File::open(&self.log_path)?;
         let reader = BufReader::new(file);
 
-        let mut total_requests = 0;
-        let mut model_counts: std::collections::HashMap<String, u64> =
-            std::collections::HashMap::new();
-        let mut backend_counts: std::collections::HashMap<String, u64> =
-            std::collections::HashMap::new();
-        let _timeline: Vec<(i64, u64)> = Vec::new(); // (timestamp_minute, count)
-        let mut minute_buckets: std::collections::HashMap<i64, u64> =
-            std::collections::HashMap::new();
+        let mut total_requests = 0u64;
+        let mut model_counts: HashMap<String, u64> = HashMap::new();
+        let mut backend_counts: HashMap<String, u64> = HashMap::new();
+        let mut minute_buckets: HashMap<i64, u64> = HashMap::new();
         let mut durations: Vec<u64> = Vec::new();
+
+        // Token tracking
+        let mut total_tokens_in = 0u64;
+        let mut total_tokens_out = 0u64;
+        let mut model_token_counts: HashMap<String, (u64, u64)> = HashMap::new();
+        let mut tps_values: Vec<f32> = Vec::new();
+
+        // Per-backend and per-model durations for latency breakdown
+        let mut backend_durations: HashMap<String, Vec<u64>> = HashMap::new();
+        let mut model_durations: HashMap<String, Vec<u64>> = HashMap::new();
 
         for line in reader.lines() {
             let line = line?;
@@ -99,6 +118,40 @@ impl Analytics {
                     // Durations for percentiles
                     if log.status == "success" {
                         durations.push(log.duration_ms);
+
+                        // Per-backend latency
+                        backend_durations
+                            .entry(log.backend.clone())
+                            .or_default()
+                            .push(log.duration_ms);
+
+                        // Per-model latency
+                        if let Some(model) = &log.model {
+                            model_durations
+                                .entry(model.clone())
+                                .or_default()
+                                .push(log.duration_ms);
+                        }
+                    }
+
+                    // Token aggregation
+                    if let Some(tin) = log.tokens_in {
+                        total_tokens_in += tin as u64;
+                        if let Some(model) = &log.model {
+                            model_token_counts.entry(model.clone()).or_insert((0, 0)).0 +=
+                                tin as u64;
+                        }
+                    }
+                    if let Some(tout) = log.tokens_out {
+                        total_tokens_out += tout as u64;
+                        if let Some(model) = &log.model {
+                            model_token_counts.entry(model.clone()).or_insert((0, 0)).1 +=
+                                tout as u64;
+                        }
+                    }
+
+                    if let Some(tps) = log.tokens_per_second {
+                        tps_values.push(tps);
                     }
                 }
             }
@@ -108,32 +161,56 @@ impl Analytics {
         let mut timeline_vec: Vec<(i64, u64)> = minute_buckets.into_iter().collect();
         timeline_vec.sort_by_key(|(ts, _)| *ts);
 
-        // Calculate percentiles
+        // Calculate overall percentiles
         durations.sort();
-        let p50 = if durations.is_empty() {
-            0
+        let overall = compute_percentiles(&durations);
+
+        // Calculate per-backend latency percentiles
+        let backend_latency: HashMap<String, LatencyPercentiles> = backend_durations
+            .iter_mut()
+            .map(|(k, v)| {
+                v.sort();
+                (k.clone(), compute_percentiles(v))
+            })
+            .collect();
+
+        // Calculate per-model latency percentiles
+        let model_latency: HashMap<String, LatencyPercentiles> = model_durations
+            .iter_mut()
+            .map(|(k, v)| {
+                v.sort();
+                (k.clone(), compute_percentiles(v))
+            })
+            .collect();
+
+        // Average tokens per second
+        let tokens_per_second_avg = if tps_values.is_empty() {
+            0.0
         } else {
-            durations[durations.len() / 2]
+            tps_values.iter().sum::<f32>() / tps_values.len() as f32
         };
-        let p95 = if durations.is_empty() {
-            0
-        } else {
-            durations[(durations.len() * 95) / 100]
-        };
-        let p99 = if durations.is_empty() {
-            0
-        } else {
-            durations[(durations.len() * 99) / 100]
-        };
+
+        // Estimated API cost
+        let estimated_api_cost_usd = model_token_counts
+            .iter()
+            .map(|(model, (tin, tout))| estimate_api_cost(model, *tin, *tout))
+            .sum();
 
         Ok(AnalyticsStats {
             total_requests,
             model_counts,
             backend_counts,
             timeline: timeline_vec,
-            latency_p50: p50,
-            latency_p95: p95,
-            latency_p99: p99,
+            latency_p50: overall.p50,
+            latency_p95: overall.p95,
+            latency_p99: overall.p99,
+            total_tokens_in,
+            total_tokens_out,
+            model_token_counts,
+            backend_latency,
+            model_latency,
+            tokens_per_second_avg,
+            estimated_api_cost_usd,
         })
     }
 
@@ -238,15 +315,90 @@ fn replace_file(from: &std::path::Path, to: &std::path::Path) -> Result<()> {
     Ok(())
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LatencyPercentiles {
+    pub p50: u64,
+    pub p95: u64,
+    pub p99: u64,
+}
+
+/// Extract parameter count (in billions) from a model name.
+/// Looks for a number followed by "b" (case-insensitive), e.g. "llama3:8b", "qwen2-72B".
+/// Returns None if no match found.
+pub fn extract_param_billions(model: &str) -> Option<u64> {
+    let lower = model.to_lowercase();
+    let bytes = lower.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i].is_ascii_digit() {
+            let start = i;
+            while i < bytes.len() && (bytes[i].is_ascii_digit() || bytes[i] == b'.') {
+                i += 1;
+            }
+            if i < bytes.len() && bytes[i] == b'b' {
+                // Check next char is not a letter (avoid matching "bin", "build", etc.)
+                let next_is_letter = i + 1 < bytes.len() && bytes[i + 1].is_ascii_alphabetic();
+                if !next_is_letter {
+                    if let Ok(n) = lower[start..i].parse::<f64>() {
+                        return Some(n as u64);
+                    }
+                }
+            }
+        }
+        i += 1;
+    }
+    None
+}
+
+/// Estimate what the given token usage would cost on a commercial API.
+/// Tier pricing (per million tokens):
+///   <=8B: $0.10 input, $0.30 output
+///   9-32B: $0.25 input, $0.75 output
+///   33B+: $0.50 input, $1.50 output
+pub fn estimate_api_cost(model: &str, tokens_in: u64, tokens_out: u64) -> f32 {
+    let params = extract_param_billions(model);
+    let (cost_in_per_m, cost_out_per_m) = match params {
+        Some(b) if b <= 8 => (0.10_f32, 0.30_f32),
+        Some(b) if b <= 32 => (0.25_f32, 0.75_f32),
+        Some(_) => (0.50_f32, 1.50_f32),
+        None => (0.25_f32, 0.75_f32), // default to middle tier
+    };
+    (tokens_in as f32 * cost_in_per_m / 1_000_000.0)
+        + (tokens_out as f32 * cost_out_per_m / 1_000_000.0)
+}
+
+/// Compute p50/p95/p99 from a sorted slice of durations.
+pub fn compute_percentiles(sorted: &[u64]) -> LatencyPercentiles {
+    if sorted.is_empty() {
+        return LatencyPercentiles {
+            p50: 0,
+            p95: 0,
+            p99: 0,
+        };
+    }
+    LatencyPercentiles {
+        p50: sorted[sorted.len() / 2],
+        p95: sorted[(sorted.len() * 95) / 100],
+        p99: sorted[(sorted.len() * 99) / 100],
+    }
+}
+
 #[derive(Debug, Serialize)]
 pub struct AnalyticsStats {
     pub total_requests: u64,
-    pub model_counts: std::collections::HashMap<String, u64>,
-    pub backend_counts: std::collections::HashMap<String, u64>,
+    pub model_counts: HashMap<String, u64>,
+    pub backend_counts: HashMap<String, u64>,
     pub timeline: Vec<(i64, u64)>, // (timestamp, count)
     pub latency_p50: u64,
     pub latency_p95: u64,
     pub latency_p99: u64,
+    pub total_tokens_in: u64,
+    pub total_tokens_out: u64,
+    pub model_token_counts: HashMap<String, (u64, u64)>, // model -> (in, out)
+    pub backend_latency: HashMap<String, LatencyPercentiles>,
+    pub model_latency: HashMap<String, LatencyPercentiles>,
+    pub tokens_per_second_avg: f32,
+    pub estimated_api_cost_usd: f32,
 }
 
 #[cfg(test)]
@@ -266,6 +418,12 @@ mod tests {
             request_id: Some("abc-123".into()),
             tier: None,
             classified_by: None,
+            tokens_in: None,
+            tokens_out: None,
+            tokens_per_second: None,
+            prompt_eval_ms: None,
+            eval_ms: None,
+            backend_type: None,
         };
         let json = serde_json::to_string(&log).unwrap();
         assert!(json.contains("abc-123"));
@@ -283,6 +441,12 @@ mod tests {
             request_id: None,
             tier: None,
             classified_by: None,
+            tokens_in: None,
+            tokens_out: None,
+            tokens_per_second: None,
+            prompt_eval_ms: None,
+            eval_ms: None,
+            backend_type: None,
         };
         let json = serde_json::to_string(&log).unwrap();
         assert!(!json.contains("request_id"));
@@ -319,11 +483,218 @@ mod tests {
     }
 
     #[test]
+    fn request_log_backward_compat_deserialize_old_format() {
+        // Old JSONL without any of the new token/backend_type fields should still deserialize
+        let json = r#"{"timestamp":1000,"model":"llama3:8b","backend":"gpu1","duration_ms":200,"status":"success","path":"/api/generate"}"#;
+        let log: RequestLog = serde_json::from_str(json).unwrap();
+        assert!(log.tokens_in.is_none());
+        assert!(log.tokens_out.is_none());
+        assert!(log.tokens_per_second.is_none());
+        assert!(log.prompt_eval_ms.is_none());
+        assert!(log.eval_ms.is_none());
+        assert!(log.backend_type.is_none());
+        assert!(log.request_id.is_none());
+        assert!(log.tier.is_none());
+        assert!(log.classified_by.is_none());
+    }
+
+    #[test]
+    fn request_log_new_fields_round_trip() {
+        let log = RequestLog {
+            timestamp: 2000,
+            model: Some("llama3:70b".into()),
+            backend: "gpu2".into(),
+            duration_ms: 500,
+            status: "success".into(),
+            path: "/v1/chat/completions".into(),
+            request_id: Some("req-42".into()),
+            tier: Some("heavy".into()),
+            classified_by: Some("keyword".into()),
+            tokens_in: Some(128),
+            tokens_out: Some(256),
+            tokens_per_second: Some(45.5),
+            prompt_eval_ms: Some(80),
+            eval_ms: Some(420),
+            backend_type: Some("llama-server".into()),
+        };
+        let json = serde_json::to_string(&log).unwrap();
+        let deserialized: RequestLog = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.tokens_in, Some(128));
+        assert_eq!(deserialized.tokens_out, Some(256));
+        assert!((deserialized.tokens_per_second.unwrap() - 45.5).abs() < 0.01);
+        assert_eq!(deserialized.prompt_eval_ms, Some(80));
+        assert_eq!(deserialized.eval_ms, Some(420));
+        assert_eq!(deserialized.backend_type.as_deref(), Some("llama-server"));
+    }
+
+    #[test]
+    fn request_log_new_fields_omitted_when_none() {
+        let log = RequestLog {
+            timestamp: 1000,
+            model: None,
+            backend: "b1".into(),
+            duration_ms: 100,
+            status: "success".into(),
+            path: "/test".into(),
+            request_id: None,
+            tier: None,
+            classified_by: None,
+            tokens_in: None,
+            tokens_out: None,
+            tokens_per_second: None,
+            prompt_eval_ms: None,
+            eval_ms: None,
+            backend_type: None,
+        };
+        let json = serde_json::to_string(&log).unwrap();
+        assert!(!json.contains("tokens_in"));
+        assert!(!json.contains("tokens_out"));
+        assert!(!json.contains("tokens_per_second"));
+        assert!(!json.contains("prompt_eval_ms"));
+        assert!(!json.contains("eval_ms"));
+        assert!(!json.contains("backend_type"));
+    }
+
+    #[test]
+    fn cost_estimation_small_model() {
+        // <=8B: $0.10/M in, $0.30/M out
+        let cost = estimate_api_cost("llama3:8b", 1_000_000, 1_000_000);
+        assert!((cost - 0.40).abs() < 0.001); // 0.10 + 0.30
+    }
+
+    #[test]
+    fn cost_estimation_medium_model() {
+        // 9-32B: $0.25/M in, $0.75/M out
+        let cost = estimate_api_cost("qwen2:14b", 1_000_000, 1_000_000);
+        assert!((cost - 1.0).abs() < 0.001); // 0.25 + 0.75
+    }
+
+    #[test]
+    fn cost_estimation_large_model() {
+        // 33B+: $0.50/M in, $1.50/M out
+        let cost = estimate_api_cost("llama3:70b", 1_000_000, 1_000_000);
+        assert!((cost - 2.0).abs() < 0.001); // 0.50 + 1.50
+    }
+
+    #[test]
+    fn cost_estimation_unknown_model_defaults_to_medium() {
+        let cost = estimate_api_cost("custom-model", 1_000_000, 1_000_000);
+        assert!((cost - 1.0).abs() < 0.001); // middle tier: 0.25 + 0.75
+    }
+
+    #[test]
+    fn extract_param_billions_various_formats() {
+        assert_eq!(extract_param_billions("llama3:8b"), Some(8));
+        assert_eq!(extract_param_billions("qwen2-72B"), Some(72));
+        assert_eq!(extract_param_billions("phi3:3.8b"), Some(3));
+        assert_eq!(extract_param_billions("gemma:2b"), Some(2));
+        assert_eq!(extract_param_billions("custom-model"), None);
+        assert_eq!(extract_param_billions("mistral"), None);
+    }
+
+    #[test]
+    fn latency_percentiles_empty() {
+        let p = compute_percentiles(&[]);
+        assert_eq!(p.p50, 0);
+        assert_eq!(p.p95, 0);
+        assert_eq!(p.p99, 0);
+    }
+
+    #[test]
+    fn latency_percentiles_known_values() {
+        // 100 values: 1..=100
+        let values: Vec<u64> = (1..=100).collect();
+        let p = compute_percentiles(&values);
+        assert_eq!(p.p50, 51); // index 50
+        assert_eq!(p.p95, 96); // index 95
+        assert_eq!(p.p99, 100); // index 99
+    }
+
+    #[test]
+    fn token_aggregation_across_models() {
+        // Simulate what get_stats would compute from multiple logs
+        let logs = vec![
+            RequestLog {
+                timestamp: chrono::Utc::now().timestamp(),
+                model: Some("llama3:8b".into()),
+                backend: "gpu1".into(),
+                duration_ms: 100,
+                status: "success".into(),
+                path: "/v1/chat/completions".into(),
+                request_id: None,
+                tier: None,
+                classified_by: None,
+                tokens_in: Some(100),
+                tokens_out: Some(200),
+                tokens_per_second: Some(40.0),
+                prompt_eval_ms: None,
+                eval_ms: None,
+                backend_type: Some("ollama".into()),
+            },
+            RequestLog {
+                timestamp: chrono::Utc::now().timestamp(),
+                model: Some("llama3:8b".into()),
+                backend: "gpu1".into(),
+                duration_ms: 150,
+                status: "success".into(),
+                path: "/v1/chat/completions".into(),
+                request_id: None,
+                tier: None,
+                classified_by: None,
+                tokens_in: Some(50),
+                tokens_out: Some(100),
+                tokens_per_second: Some(35.0),
+                prompt_eval_ms: None,
+                eval_ms: None,
+                backend_type: Some("ollama".into()),
+            },
+            RequestLog {
+                timestamp: chrono::Utc::now().timestamp(),
+                model: Some("qwen2:14b".into()),
+                backend: "gpu2".into(),
+                duration_ms: 300,
+                status: "success".into(),
+                path: "/v1/chat/completions".into(),
+                request_id: None,
+                tier: None,
+                classified_by: None,
+                tokens_in: Some(200),
+                tokens_out: Some(400),
+                tokens_per_second: Some(50.0),
+                prompt_eval_ms: None,
+                eval_ms: None,
+                backend_type: Some("llama-server".into()),
+            },
+        ];
+
+        // Manually aggregate like get_stats does
+        let mut total_in = 0u64;
+        let mut total_out = 0u64;
+        let mut model_tokens: HashMap<String, (u64, u64)> = HashMap::new();
+        for log in &logs {
+            if let Some(tin) = log.tokens_in {
+                total_in += tin as u64;
+                if let Some(m) = &log.model {
+                    model_tokens.entry(m.clone()).or_insert((0, 0)).0 += tin as u64;
+                }
+            }
+            if let Some(tout) = log.tokens_out {
+                total_out += tout as u64;
+                if let Some(m) = &log.model {
+                    model_tokens.entry(m.clone()).or_insert((0, 0)).1 += tout as u64;
+                }
+            }
+        }
+
+        assert_eq!(total_in, 350);
+        assert_eq!(total_out, 700);
+        assert_eq!(model_tokens["llama3:8b"], (150, 300));
+        assert_eq!(model_tokens["qwen2:14b"], (200, 400));
+    }
+
+    #[test]
     fn replace_file_overwrites_destination() {
-        let base = std::env::temp_dir().join(format!(
-            "herd-analytics-test-{}",
-            std::process::id()
-        ));
+        let base = std::env::temp_dir().join(format!("herd-analytics-test-{}", std::process::id()));
         let _ = std::fs::create_dir_all(&base);
         let from = base.join("from.txt");
         let to = base.join("to.txt");

--- a/src/api/admin.rs
+++ b/src/api/admin.rs
@@ -11,6 +11,8 @@ use serde::{Deserialize, Serialize};
 pub struct AddBackendRequest {
     pub name: String,
     pub url: String,
+    #[serde(default)]
+    pub backend: BackendType,
     #[serde(default = "default_priority")]
     pub priority: u32,
     #[serde(default)]
@@ -42,6 +44,7 @@ pub struct UpdateBackendRequest {
 pub struct BackendResponse {
     pub name: String,
     pub url: String,
+    pub backend: String,
     pub priority: u32,
     pub hot_models: Vec<String>,
     pub model_filter: Option<String>,
@@ -66,6 +69,7 @@ fn backend_to_response(b: &crate::backend::BackendState) -> BackendResponse {
     BackendResponse {
         name: b.config.name.clone(),
         url: b.config.url.clone(),
+        backend: b.config.backend.to_string(),
         priority: b.config.priority,
         hot_models: b.config.hot_models.clone(),
         model_filter: b.config.model_filter.clone(),
@@ -120,7 +124,7 @@ pub async fn add_backend(
     let backend = Backend {
         name: req.name.clone(),
         url: req.url,
-        backend: BackendType::default(),
+        backend: req.backend,
         priority: req.priority,
         hot_models: Vec::new(),
         gpu_hot_url: None,

--- a/src/api/admin.rs
+++ b/src/api/admin.rs
@@ -1,4 +1,4 @@
-use crate::config::Backend;
+use crate::config::{Backend, BackendType};
 use crate::server::AppState;
 use axum::{
     extract::{Path, State},
@@ -120,6 +120,7 @@ pub async fn add_backend(
     let backend = Backend {
         name: req.name.clone(),
         url: req.url,
+        backend: BackendType::default(),
         priority: req.priority,
         hot_models: Vec::new(),
         gpu_hot_url: None,

--- a/src/api/admin.rs
+++ b/src/api/admin.rs
@@ -181,7 +181,10 @@ pub async fn update_backend(
         state.pool.set_vram(&name, vram_mb).await;
         // Re-fetch so the response reflects the override
         backend = state.pool.get(&name).await.ok_or_else(|| {
-            (StatusCode::NOT_FOUND, format!("Backend '{}' not found", name))
+            (
+                StatusCode::NOT_FOUND,
+                format!("Backend '{}' not found", name),
+            )
         })?;
     }
 

--- a/src/api/agent.rs
+++ b/src/api/agent.rs
@@ -57,7 +57,11 @@ pub async fn create_session(
         .await
         .map_err(|e| (StatusCode::CONFLICT, e))?;
 
-    tracing::info!("Created agent session {} (model: {})", session.id, session.model);
+    tracing::info!(
+        "Created agent session {} (model: {})",
+        session.id,
+        session.model
+    );
     state
         .agent_audit
         .log_session_created(&session.id, &session.model)
@@ -65,9 +69,7 @@ pub async fn create_session(
     Ok((StatusCode::CREATED, Json(summarize(&session))))
 }
 
-pub async fn list_sessions(
-    State(state): State<AppState>,
-) -> Json<Vec<SessionSummary>> {
+pub async fn list_sessions(State(state): State<AppState>) -> Json<Vec<SessionSummary>> {
     let sessions = state.session_store.list().await;
     Json(sessions.iter().map(summarize).collect())
 }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,5 +1,6 @@
 pub mod admin;
 pub mod agent;
+pub mod models;
 pub mod nodes;
 pub mod openai;
 pub mod status;

--- a/src/api/models.rs
+++ b/src/api/models.rs
@@ -48,9 +48,15 @@ impl SearchCache {
         None
     }
 
-    /// Store results in cache.
+    /// Store results in cache, evicting expired entries when the map grows large.
     async fn put(&self, key: String, results: Vec<ModelSearchResult>) {
         let mut map = self.entries.write().await;
+        // Evict expired entries if cache is large
+        if map.len() > 100 {
+            let now = Instant::now();
+            let ttl = std::time::Duration::from_secs(300);
+            map.retain(|_, e| now.duration_since(e.created_at) < ttl);
+        }
         map.insert(
             key,
             CacheEntry {
@@ -61,8 +67,7 @@ impl SearchCache {
     }
 }
 
-// Use a lazy-initialized global cache. Adding to AppState would require modifying
-// the struct which other teammates are also touching — a static is simpler.
+// Lazy-initialized global search cache, separate from AppState for simplicity.
 static SEARCH_CACHE: std::sync::OnceLock<SearchCache> = std::sync::OnceLock::new();
 
 fn cache() -> &'static SearchCache {
@@ -107,7 +112,9 @@ pub struct ModelSearchResponse {
 pub struct DownloadRequest {
     pub repo_id: String,
     pub file_name: String,
+    /// Reserved for future llama-server direct download support.
     #[serde(default)]
+    #[allow(dead_code)]
     pub target_path: Option<String>,
 }
 
@@ -218,6 +225,26 @@ fn cache_key(params: &ModelSearchParams) -> String {
     )
 }
 
+fn get_node_or_404(
+    node_db: &crate::nodes::NodeDb,
+    node_id: &str,
+) -> Result<crate::nodes::Node, (StatusCode, Json<serde_json::Value>)> {
+    node_db
+        .get_node(node_id)
+        .map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({"error": format!("Database error: {}", e)})),
+            )
+        })?
+        .ok_or_else(|| {
+            (
+                StatusCode::NOT_FOUND,
+                Json(serde_json::json!({"error": "Node not found"})),
+            )
+        })
+}
+
 // ---------------------------------------------------------------------------
 // GET /api/models/search
 // ---------------------------------------------------------------------------
@@ -287,7 +314,10 @@ pub async fn search_models(
     })?;
 
     // Get registered nodes for VRAM comparison
-    let nodes = state.node_db.list_nodes().unwrap_or_default();
+    let nodes = state.node_db.list_nodes().unwrap_or_else(|e| {
+        tracing::warn!("Failed to list nodes for VRAM compatibility: {}", e);
+        vec![]
+    });
 
     let mut results = Vec::new();
 
@@ -353,11 +383,13 @@ pub async fn search_models(
 }
 
 /// Determine which registered nodes have enough VRAM for the given file size.
+/// Applies a 1.2x safety multiplier to account for KV cache and runtime buffers.
 fn compute_fits_on(nodes: &[crate::nodes::Node], file_size_bytes: u64) -> Vec<String> {
     let file_size_mb = (file_size_bytes as f64 / (1024.0 * 1024.0)).ceil() as u64;
+    let estimated_vram_mb = file_size_mb * 6 / 5; // ~1.2x safety margin for KV cache
     nodes
         .iter()
-        .filter(|n| n.enabled && n.vram_mb as u64 >= file_size_mb)
+        .filter(|n| n.enabled && n.vram_mb as u64 >= estimated_vram_mb)
         .map(|n| n.hostname.clone())
         .collect()
 }
@@ -371,21 +403,7 @@ pub async fn download_model(
     Path(node_id): Path<String>,
     Json(req): Json<DownloadRequest>,
 ) -> Result<Json<DownloadResponse>, (StatusCode, Json<serde_json::Value>)> {
-    let node = state
-        .node_db
-        .get_node(&node_id)
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(serde_json::json!({"error": format!("Database error: {}", e)})),
-            )
-        })?
-        .ok_or_else(|| {
-            (
-                StatusCode::NOT_FOUND,
-                Json(serde_json::json!({"error": "Node not found"})),
-            )
-        })?;
+    let node = get_node_or_404(&state.node_db, &node_id)?;
 
     match node.backend {
         BackendType::LlamaServer | BackendType::OpenAICompat => Err((
@@ -404,6 +422,8 @@ pub async fn download_model(
                 "stream": false,
             });
 
+            // NOTE: download_id is generated for client tracking but not yet persisted
+            // to the model_downloads table. Full progress tracking is a future enhancement.
             let download_id = uuid::Uuid::new_v4().to_string();
 
             // Fire the pull request using the long-timeout management client
@@ -451,21 +471,7 @@ pub async fn list_node_models(
     State(state): State<AppState>,
     Path(node_id): Path<String>,
 ) -> Result<Json<NodeModelsResponse>, (StatusCode, Json<serde_json::Value>)> {
-    let node = state
-        .node_db
-        .get_node(&node_id)
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(serde_json::json!({"error": format!("Database error: {}", e)})),
-            )
-        })?
-        .ok_or_else(|| {
-            (
-                StatusCode::NOT_FOUND,
-                Json(serde_json::json!({"error": "Node not found"})),
-            )
-        })?;
+    let node = get_node_or_404(&state.node_db, &node_id)?;
 
     let (model_paths, model_registry) = match node.backend {
         BackendType::LlamaServer => {
@@ -494,21 +500,7 @@ pub async fn delete_node_model(
     State(state): State<AppState>,
     Path((node_id, model_name)): Path<(String, String)>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
-    let node = state
-        .node_db
-        .get_node(&node_id)
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(serde_json::json!({"error": format!("Database error: {}", e)})),
-            )
-        })?
-        .ok_or_else(|| {
-            (
-                StatusCode::NOT_FOUND,
-                Json(serde_json::json!({"error": "Node not found"})),
-            )
-        })?;
+    let node = get_node_or_404(&state.node_db, &node_id)?;
 
     match node.backend {
         BackendType::LlamaServer | BackendType::OpenAICompat => Err((
@@ -621,10 +613,10 @@ mod tests {
         let nodes = vec![
             test_node("big-node", 32768),
             test_node("small-node", 8192),
-            test_node("medium-node", 16384),
+            test_node("medium-node", 24576),
         ];
-        // ~15 GB file — fits on big-node and medium-node
-        let file_size = 15_000_000_000u64; // 14305 MB
+        // ~15 GB file — with 1.2x safety margin (~17167 MB), fits on big-node and medium-node
+        let file_size = 15_000_000_000u64; // 14305 MB raw, ~17167 MB with 1.2x
         let fits = compute_fits_on(&nodes, file_size);
         assert!(fits.contains(&"big-node".to_string()));
         assert!(fits.contains(&"medium-node".to_string()));

--- a/src/api/models.rs
+++ b/src/api/models.rs
@@ -1,0 +1,758 @@
+use crate::config::BackendType;
+use crate::server::AppState;
+use axum::{
+    extract::{Path, Query, State},
+    http::StatusCode,
+    Json,
+};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Instant;
+use tokio::sync::RwLock;
+
+// ---------------------------------------------------------------------------
+// Search cache
+// ---------------------------------------------------------------------------
+
+struct CacheEntry {
+    results: Vec<ModelSearchResult>,
+    created_at: Instant,
+}
+
+pub struct SearchCache {
+    entries: Arc<RwLock<HashMap<String, CacheEntry>>>,
+}
+
+impl Default for SearchCache {
+    fn default() -> Self {
+        Self {
+            entries: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+}
+
+impl SearchCache {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Get cached results if they exist and are less than `ttl` old.
+    async fn get(&self, key: &str, ttl: std::time::Duration) -> Option<Vec<ModelSearchResult>> {
+        let map = self.entries.read().await;
+        if let Some(entry) = map.get(key) {
+            if entry.created_at.elapsed() < ttl {
+                return Some(entry.results.clone());
+            }
+        }
+        None
+    }
+
+    /// Store results in cache.
+    async fn put(&self, key: String, results: Vec<ModelSearchResult>) {
+        let mut map = self.entries.write().await;
+        map.insert(
+            key,
+            CacheEntry {
+                results,
+                created_at: Instant::now(),
+            },
+        );
+    }
+}
+
+// Use a lazy-initialized global cache. Adding to AppState would require modifying
+// the struct which other teammates are also touching — a static is simpler.
+static SEARCH_CACHE: std::sync::OnceLock<SearchCache> = std::sync::OnceLock::new();
+
+fn cache() -> &'static SearchCache {
+    SEARCH_CACHE.get_or_init(SearchCache::new)
+}
+
+const CACHE_TTL: std::time::Duration = std::time::Duration::from_secs(300); // 5 minutes
+
+// ---------------------------------------------------------------------------
+// Request / response types
+// ---------------------------------------------------------------------------
+
+#[derive(Deserialize)]
+pub struct ModelSearchParams {
+    pub q: String,
+    #[serde(default)]
+    pub quant: Option<String>,
+    #[serde(default)]
+    pub max_size_gb: Option<f32>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ModelSearchResult {
+    pub repo_id: String,
+    pub author: String,
+    pub model_name: String,
+    pub quant: Option<String>,
+    pub file_name: String,
+    pub file_size_bytes: u64,
+    pub downloads: u64,
+    pub updated_at: Option<String>,
+    pub fits_on: Vec<String>,
+}
+
+#[derive(Serialize)]
+pub struct ModelSearchResponse {
+    pub results: Vec<ModelSearchResult>,
+    pub cached: bool,
+}
+
+#[derive(Deserialize)]
+pub struct DownloadRequest {
+    pub repo_id: String,
+    pub file_name: String,
+    #[serde(default)]
+    pub target_path: Option<String>,
+}
+
+#[derive(Serialize)]
+pub struct DownloadResponse {
+    pub download_id: String,
+    pub status: String,
+    pub message: String,
+}
+
+#[derive(Serialize)]
+pub struct NodeModelsResponse {
+    pub node_id: String,
+    pub hostname: String,
+    pub backend: String,
+    pub models_loaded: Vec<String>,
+    pub models_available: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model_paths: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model_registry: Option<Vec<crate::nodes::ModelRegistryEntry>>,
+}
+
+// ---------------------------------------------------------------------------
+// HuggingFace API types (internal)
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+struct HfModelEntry {
+    id: String,
+    #[serde(default)]
+    author: Option<String>,
+    #[serde(default)]
+    downloads: u64,
+    #[serde(default, alias = "lastModified")]
+    last_modified: Option<String>,
+    #[serde(default)]
+    siblings: Vec<HfSibling>,
+}
+
+#[derive(Debug, Deserialize)]
+struct HfSibling {
+    rfilename: String,
+    #[serde(default)]
+    size: Option<u64>,
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Extract quant type from a GGUF filename.
+/// Examples:
+///   "model-Q4_K_M.gguf"       -> Some("Q4_K_M")
+///   "gemma-4-26B-A4B-it-UD-Q4_K_M.gguf" -> Some("Q4_K_M")
+///   "model-IQ3_XXS.gguf"      -> Some("IQ3_XXS")
+///   "readme.md"                -> None
+pub(crate) fn extract_quant(filename: &str) -> Option<String> {
+    let stem = filename.strip_suffix(".gguf").unwrap_or(filename);
+    extract_quant_manual(stem)
+}
+
+fn extract_quant_manual(stem: &str) -> Option<String> {
+    // Split by '-' or '.' and look for common quant tokens
+    let parts: Vec<&str> = stem.split(['-', '.']).collect();
+    for part in parts.iter().rev() {
+        let upper = part.to_uppercase();
+        if is_quant_token(&upper) {
+            return Some(upper);
+        }
+    }
+    // Also try underscore-joined pairs from the end: "UD-Q4_K_M" => look for "Q4_K_M" in original
+    // Search the full stem for well-known quant patterns
+    for pat in QUANT_PATTERNS {
+        if let Some(pos) = stem.to_uppercase().find(pat) {
+            // Extract the matched portion from original string at same position
+            let end = pos + pat.len();
+            if end <= stem.len() {
+                let matched = &stem[pos..end];
+                return Some(matched.to_uppercase());
+            }
+        }
+    }
+    None
+}
+
+const QUANT_PATTERNS: &[&str] = &[
+    "IQ4_NL", "IQ4_XS", "IQ3_XXS", "IQ3_XS", "IQ3_S", "IQ3_M", "IQ2_XXS", "IQ2_XS", "IQ2_S",
+    "IQ2_M", "IQ1_S", "IQ1_M", "Q8_0", "Q6_K", "Q5_K_S", "Q5_K_M", "Q5_K_L", "Q5_K", "Q5_0",
+    "Q5_1", "Q4_K_S", "Q4_K_M", "Q4_K_L", "Q4_K", "Q4_0", "Q4_1", "Q3_K_S", "Q3_K_M", "Q3_K_L",
+    "Q3_K", "Q2_K_S", "Q2_K", "F32", "F16", "BF16",
+];
+
+fn is_quant_token(s: &str) -> bool {
+    QUANT_PATTERNS.contains(&s)
+}
+
+/// Build a cache key from search params.
+fn cache_key(params: &ModelSearchParams) -> String {
+    format!(
+        "{}|{}|{}",
+        params.q,
+        params.quant.as_deref().unwrap_or(""),
+        params
+            .max_size_gb
+            .map(|v| format!("{:.1}", v))
+            .unwrap_or_default()
+    )
+}
+
+// ---------------------------------------------------------------------------
+// GET /api/models/search
+// ---------------------------------------------------------------------------
+
+pub async fn search_models(
+    State(state): State<AppState>,
+    Query(params): Query<ModelSearchParams>,
+) -> Result<Json<ModelSearchResponse>, (StatusCode, Json<serde_json::Value>)> {
+    let q = params.q.trim();
+    if q.is_empty() {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({"error": "Query parameter 'q' is required"})),
+        ));
+    }
+
+    let key = cache_key(&params);
+
+    // Check cache
+    if let Some(cached) = cache().get(&key, CACHE_TTL).await {
+        return Ok(Json(ModelSearchResponse {
+            results: cached,
+            cached: true,
+        }));
+    }
+
+    // Query HuggingFace API
+    let resp = state
+        .client
+        .get("https://huggingface.co/api/models")
+        .query(&[
+            ("search", q),
+            ("filter", "gguf"),
+            ("sort", "downloads"),
+            ("direction", "-1"),
+            ("limit", "20"),
+        ])
+        .header("User-Agent", "herd/0.9.0")
+        .send()
+        .await
+        .map_err(|e| {
+            tracing::error!("HuggingFace API request failed: {}", e);
+            (
+                StatusCode::BAD_GATEWAY,
+                Json(serde_json::json!({"error": format!("HuggingFace API error: {}", e)})),
+            )
+        })?;
+
+    if !resp.status().is_success() {
+        let status = resp.status().as_u16();
+        let body = resp.text().await.unwrap_or_default();
+        tracing::warn!("HuggingFace API returned {}: {}", status, body);
+        return Err((
+            StatusCode::BAD_GATEWAY,
+            Json(serde_json::json!({
+                "error": format!("HuggingFace API returned HTTP {}", status)
+            })),
+        ));
+    }
+
+    let hf_models: Vec<HfModelEntry> = resp.json().await.map_err(|e| {
+        tracing::error!("Failed to parse HuggingFace response: {}", e);
+        (
+            StatusCode::BAD_GATEWAY,
+            Json(serde_json::json!({"error": "Failed to parse HuggingFace response"})),
+        )
+    })?;
+
+    // Get registered nodes for VRAM comparison
+    let nodes = state.node_db.list_nodes().unwrap_or_default();
+
+    let mut results = Vec::new();
+
+    for model in &hf_models {
+        let author = model
+            .author
+            .clone()
+            .unwrap_or_else(|| model.id.split('/').next().unwrap_or("unknown").to_string());
+        let model_name = model.id.split('/').nth(1).unwrap_or(&model.id).to_string();
+
+        // Find GGUF siblings
+        for sib in &model.siblings {
+            if !sib.rfilename.ends_with(".gguf") {
+                continue;
+            }
+
+            let file_size = sib.size.unwrap_or(0);
+            let quant = extract_quant(&sib.rfilename);
+
+            // Apply quant filter
+            if let Some(ref filter_quant) = params.quant {
+                if let Some(ref q) = quant {
+                    if !q.to_uppercase().contains(&filter_quant.to_uppercase()) {
+                        continue;
+                    }
+                } else {
+                    continue; // no quant detected, skip if filter is set
+                }
+            }
+
+            // Apply size filter
+            if let Some(max_gb) = params.max_size_gb {
+                let size_gb = file_size as f64 / (1024.0 * 1024.0 * 1024.0);
+                if size_gb > max_gb as f64 {
+                    continue;
+                }
+            }
+
+            // Compute fits_on: which nodes have enough VRAM
+            let fits_on = compute_fits_on(&nodes, file_size);
+
+            results.push(ModelSearchResult {
+                repo_id: model.id.clone(),
+                author: author.clone(),
+                model_name: model_name.clone(),
+                quant,
+                file_name: sib.rfilename.clone(),
+                file_size_bytes: file_size,
+                downloads: model.downloads,
+                updated_at: model.last_modified.clone(),
+                fits_on,
+            });
+        }
+    }
+
+    // Cache results
+    cache().put(key, results.clone()).await;
+
+    Ok(Json(ModelSearchResponse {
+        results,
+        cached: false,
+    }))
+}
+
+/// Determine which registered nodes have enough VRAM for the given file size.
+fn compute_fits_on(nodes: &[crate::nodes::Node], file_size_bytes: u64) -> Vec<String> {
+    let file_size_mb = (file_size_bytes as f64 / (1024.0 * 1024.0)).ceil() as u64;
+    nodes
+        .iter()
+        .filter(|n| n.enabled && n.vram_mb as u64 >= file_size_mb)
+        .map(|n| n.hostname.clone())
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// POST /api/nodes/:id/models/download
+// ---------------------------------------------------------------------------
+
+pub async fn download_model(
+    State(state): State<AppState>,
+    Path(node_id): Path<String>,
+    Json(req): Json<DownloadRequest>,
+) -> Result<Json<DownloadResponse>, (StatusCode, Json<serde_json::Value>)> {
+    let node = state
+        .node_db
+        .get_node(&node_id)
+        .map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({"error": format!("Database error: {}", e)})),
+            )
+        })?
+        .ok_or_else(|| {
+            (
+                StatusCode::NOT_FOUND,
+                Json(serde_json::json!({"error": "Node not found"})),
+            )
+        })?;
+
+    match node.backend {
+        BackendType::LlamaServer | BackendType::OpenAICompat => Err((
+            StatusCode::NOT_IMPLEMENTED,
+            Json(serde_json::json!({
+                "error": "Model download not supported for this backend type. Ollama backends only."
+            })),
+        )),
+        BackendType::Ollama => {
+            // Proxy to Ollama's pull API
+            let pull_url = format!("{}/api/pull", node.backend_url.trim_end_matches('/'));
+
+            // For Ollama, the model name is the repo_id (or a short tag)
+            let pull_body = serde_json::json!({
+                "name": req.repo_id,
+                "stream": false,
+            });
+
+            let download_id = uuid::Uuid::new_v4().to_string();
+
+            // Fire the pull request using the long-timeout management client
+            let client = state.mgmt_client.clone();
+            let pull_url_clone = pull_url.clone();
+            let pull_body_clone = pull_body.clone();
+
+            tokio::spawn(async move {
+                match client
+                    .post(&pull_url_clone)
+                    .json(&pull_body_clone)
+                    .send()
+                    .await
+                {
+                    Ok(resp) if resp.status().is_success() => {
+                        tracing::info!("Ollama pull started for {}", pull_body_clone["name"]);
+                    }
+                    Ok(resp) => {
+                        tracing::warn!(
+                            "Ollama pull returned {}: {}",
+                            resp.status(),
+                            resp.text().await.unwrap_or_default()
+                        );
+                    }
+                    Err(e) => {
+                        tracing::error!("Ollama pull request failed: {}", e);
+                    }
+                }
+            });
+
+            Ok(Json(DownloadResponse {
+                download_id,
+                status: "pulling".to_string(),
+                message: format!("Pull started on node {} via Ollama API", node.hostname),
+            }))
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// GET /api/nodes/:id/models
+// ---------------------------------------------------------------------------
+
+pub async fn list_node_models(
+    State(state): State<AppState>,
+    Path(node_id): Path<String>,
+) -> Result<Json<NodeModelsResponse>, (StatusCode, Json<serde_json::Value>)> {
+    let node = state
+        .node_db
+        .get_node(&node_id)
+        .map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({"error": format!("Database error: {}", e)})),
+            )
+        })?
+        .ok_or_else(|| {
+            (
+                StatusCode::NOT_FOUND,
+                Json(serde_json::json!({"error": "Node not found"})),
+            )
+        })?;
+
+    let (model_paths, model_registry) = match node.backend {
+        BackendType::LlamaServer => {
+            let registry = node.model_registry();
+            (Some(node.model_paths.clone()), Some(registry))
+        }
+        BackendType::Ollama | BackendType::OpenAICompat => (None, None),
+    };
+
+    Ok(Json(NodeModelsResponse {
+        node_id: node.id,
+        hostname: node.hostname,
+        backend: node.backend.to_string(),
+        models_loaded: node.models_loaded,
+        models_available: node.models_available,
+        model_paths,
+        model_registry,
+    }))
+}
+
+// ---------------------------------------------------------------------------
+// DELETE /api/nodes/:id/models/:model_name
+// ---------------------------------------------------------------------------
+
+pub async fn delete_node_model(
+    State(state): State<AppState>,
+    Path((node_id, model_name)): Path<(String, String)>,
+) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
+    let node = state
+        .node_db
+        .get_node(&node_id)
+        .map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({"error": format!("Database error: {}", e)})),
+            )
+        })?
+        .ok_or_else(|| {
+            (
+                StatusCode::NOT_FOUND,
+                Json(serde_json::json!({"error": "Node not found"})),
+            )
+        })?;
+
+    match node.backend {
+        BackendType::LlamaServer | BackendType::OpenAICompat => Err((
+            StatusCode::NOT_IMPLEMENTED,
+            Json(serde_json::json!({
+                "error": "Model deletion not supported for this backend type. Ollama backends only."
+            })),
+        )),
+        BackendType::Ollama => {
+            let delete_url = format!("{}/api/delete", node.backend_url.trim_end_matches('/'));
+            let delete_body = serde_json::json!({ "name": model_name });
+
+            let resp = state
+                .client
+                .delete(&delete_url)
+                .json(&delete_body)
+                .send()
+                .await
+                .map_err(|e| {
+                    (
+                        StatusCode::BAD_GATEWAY,
+                        Json(
+                            serde_json::json!({"error": format!("Failed to contact node: {}", e)}),
+                        ),
+                    )
+                })?;
+
+            if resp.status().is_success() {
+                Ok(Json(serde_json::json!({
+                    "status": "deleted",
+                    "model": model_name,
+                    "node": node.hostname
+                })))
+            } else {
+                let status = resp.status().as_u16();
+                let body = resp.text().await.unwrap_or_default();
+                Err((
+                    StatusCode::BAD_GATEWAY,
+                    Json(serde_json::json!({
+                        "error": format!("Ollama delete returned HTTP {}: {}", status, body)
+                    })),
+                ))
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extract_quant_q4_k_m() {
+        assert_eq!(
+            extract_quant("gemma-4-26B-A4B-it-UD-Q4_K_M.gguf"),
+            Some("Q4_K_M".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_quant_q8_0() {
+        assert_eq!(extract_quant("model-Q8_0.gguf"), Some("Q8_0".to_string()));
+    }
+
+    #[test]
+    fn extract_quant_iq3_xxs() {
+        assert_eq!(
+            extract_quant("some-model-IQ3_XXS.gguf"),
+            Some("IQ3_XXS".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_quant_f16() {
+        assert_eq!(extract_quant("model-F16.gguf"), Some("F16".to_string()));
+    }
+
+    #[test]
+    fn extract_quant_none_for_non_gguf() {
+        assert_eq!(extract_quant("README.md"), None);
+    }
+
+    #[test]
+    fn extract_quant_none_for_no_quant_in_name() {
+        assert_eq!(extract_quant("some-model.gguf"), None);
+    }
+
+    #[test]
+    fn vram_compatibility_fits() {
+        let nodes = vec![test_node("citadel", 32768)]; // 32 GB VRAM
+        let file_size = 15_700_000_000u64; // 15.7 GB
+        let fits = compute_fits_on(&nodes, file_size);
+        assert_eq!(fits, vec!["citadel"]);
+    }
+
+    #[test]
+    fn vram_compatibility_does_not_fit() {
+        let nodes = vec![test_node("minipc", 16384)]; // 16 GB VRAM
+        let file_size = 17_500_000_000u64; // 17.5 GB ≈ 16689 MB > 16384 MB
+        let fits = compute_fits_on(&nodes, file_size);
+        assert!(fits.is_empty());
+    }
+
+    #[test]
+    fn vram_compatibility_mixed_fleet() {
+        let nodes = vec![
+            test_node("big-node", 32768),
+            test_node("small-node", 8192),
+            test_node("medium-node", 16384),
+        ];
+        // ~15 GB file — fits on big-node and medium-node
+        let file_size = 15_000_000_000u64; // 14305 MB
+        let fits = compute_fits_on(&nodes, file_size);
+        assert!(fits.contains(&"big-node".to_string()));
+        assert!(fits.contains(&"medium-node".to_string()));
+        assert!(!fits.contains(&"small-node".to_string()));
+    }
+
+    #[test]
+    fn parse_hf_model_response() {
+        let json = r#"[{
+            "id": "unsloth/gemma-4-26B-A4B-it-UD-Q4_K_M",
+            "author": "unsloth",
+            "downloads": 12345,
+            "lastModified": "2026-04-01T00:00:00Z",
+            "siblings": [
+                {"rfilename": "gemma-4-26B-A4B-it-UD-Q4_K_M.gguf", "size": 15700000000},
+                {"rfilename": "README.md", "size": 1234}
+            ]
+        }]"#;
+
+        let models: Vec<HfModelEntry> = serde_json::from_str(json).unwrap();
+        assert_eq!(models.len(), 1);
+        assert_eq!(models[0].id, "unsloth/gemma-4-26B-A4B-it-UD-Q4_K_M");
+        assert_eq!(models[0].author, Some("unsloth".to_string()));
+        assert_eq!(models[0].downloads, 12345);
+
+        let gguf_siblings: Vec<_> = models[0]
+            .siblings
+            .iter()
+            .filter(|s| s.rfilename.ends_with(".gguf"))
+            .collect();
+        assert_eq!(gguf_siblings.len(), 1);
+        assert_eq!(gguf_siblings[0].size, Some(15700000000));
+    }
+
+    #[test]
+    fn download_request_validation() {
+        let json = r#"{"repo_id": "unsloth/gemma-4", "file_name": "model.gguf"}"#;
+        let req: DownloadRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.repo_id, "unsloth/gemma-4");
+        assert_eq!(req.file_name, "model.gguf");
+        assert!(req.target_path.is_none());
+
+        let json2 = r#"{"repo_id": "foo/bar", "file_name": "x.gguf", "target_path": "/models"}"#;
+        let req2: DownloadRequest = serde_json::from_str(json2).unwrap();
+        assert_eq!(req2.target_path.as_deref(), Some("/models"));
+    }
+
+    #[tokio::test]
+    async fn search_cache_hit_and_expiry() {
+        let cache = SearchCache::new();
+        let ttl = std::time::Duration::from_millis(100);
+
+        // Put and get
+        cache.put("test".to_string(), vec![dummy_result("a")]).await;
+        let hit = cache.get("test", ttl).await;
+        assert!(hit.is_some());
+        assert_eq!(hit.unwrap().len(), 1);
+
+        // Wait for expiry
+        tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+        let miss = cache.get("test", ttl).await;
+        assert!(miss.is_none());
+    }
+
+    #[test]
+    fn cache_key_includes_all_params() {
+        let p1 = ModelSearchParams {
+            q: "gemma".to_string(),
+            quant: Some("Q4_K_M".to_string()),
+            max_size_gb: Some(16.0),
+        };
+        let p2 = ModelSearchParams {
+            q: "gemma".to_string(),
+            quant: None,
+            max_size_gb: None,
+        };
+        assert_ne!(cache_key(&p1), cache_key(&p2));
+    }
+
+    // -- helpers --
+
+    fn test_node(hostname: &str, vram_mb: u32) -> crate::nodes::Node {
+        crate::nodes::Node {
+            id: uuid::Uuid::new_v4().to_string(),
+            node_id: None,
+            hostname: hostname.to_string(),
+            backend_url: format!("http://{}:11434", hostname),
+            backend: BackendType::Ollama,
+            backend_version: None,
+            gpu: None,
+            gpu_vendor: None,
+            gpu_model: None,
+            gpu_backend: None,
+            cuda_version: None,
+            vram_mb,
+            ram_mb: 65536,
+            max_concurrent: 1,
+            ollama_version: None,
+            os: None,
+            status: "healthy".to_string(),
+            priority: 10,
+            enabled: true,
+            tags: vec![],
+            models_available: 0,
+            models_loaded: vec![],
+            model_paths: vec![],
+            capabilities: vec![],
+            gpu_driver_version: None,
+            max_context_len: 4096,
+            recommended_config: serde_json::json!({}),
+            config_applied: false,
+            last_health_check: None,
+            registered_at: "2026-04-08T00:00:00Z".to_string(),
+            updated_at: "2026-04-08T00:00:00Z".to_string(),
+        }
+    }
+
+    fn dummy_result(name: &str) -> ModelSearchResult {
+        ModelSearchResult {
+            repo_id: format!("test/{}", name),
+            author: "test".to_string(),
+            model_name: name.to_string(),
+            quant: Some("Q4_K_M".to_string()),
+            file_name: format!("{}-Q4_K_M.gguf", name),
+            file_size_bytes: 1_000_000,
+            downloads: 100,
+            updated_at: None,
+            fits_on: vec![],
+        }
+    }
+}

--- a/src/api/nodes.rs
+++ b/src/api/nodes.rs
@@ -69,7 +69,7 @@ pub async fn register_node(
     tracing::info!(
         "Node {} ({}) {} — id={}",
         reg.hostname,
-        reg.ollama_url,
+        reg.effective_url(),
         if is_new { "registered" } else { "re-registered" },
         id
     );

--- a/src/api/nodes.rs
+++ b/src/api/nodes.rs
@@ -70,7 +70,11 @@ pub async fn register_node(
         "Node {} ({}) {} — id={}",
         reg.hostname,
         reg.effective_url(),
-        if is_new { "registered" } else { "re-registered" },
+        if is_new {
+            "registered"
+        } else {
+            "re-registered"
+        },
         id
     );
 
@@ -220,16 +224,14 @@ pub async fn download_script(
     };
 
     // Determine public URL: prefer explicit env var, fall back to Host header
-    let public_url = std::env::var("HERD_PUBLIC_URL")
-        .ok()
-        .unwrap_or_else(|| {
-            let host = req
-                .headers()
-                .get("host")
-                .and_then(|h| h.to_str().ok())
-                .unwrap_or("localhost:40114");
-            format!("http://{}", host)
-        });
+    let public_url = std::env::var("HERD_PUBLIC_URL").ok().unwrap_or_else(|| {
+        let host = req
+            .headers()
+            .get("host")
+            .and_then(|h| h.to_str().ok())
+            .unwrap_or("localhost:40114");
+        format!("http://{}", host)
+    });
 
     let config = state.config.read().await;
     let enrollment_key = config.server.enrollment_key.clone().unwrap_or_default();

--- a/src/api/openai.rs
+++ b/src/api/openai.rs
@@ -178,6 +178,12 @@ pub async fn chat_completions(
                 request_id: Some(request_id.clone()),
                 tier: None,
                 classified_by: None,
+                tokens_in: None,
+                tokens_out: None,
+                tokens_per_second: None,
+                prompt_eval_ms: None,
+                eval_ms: None,
+                backend_type: None,
             };
             state
                 .metrics
@@ -209,6 +215,12 @@ pub async fn chat_completions(
         request_id: Some(request_id.clone()),
         tier: None,
         classified_by: None,
+        tokens_in: None,
+        tokens_out: None,
+        tokens_per_second: None,
+        prompt_eval_ms: None,
+        eval_ms: None,
+        backend_type: None,
     };
     state
         .metrics

--- a/src/api/openai.rs
+++ b/src/api/openai.rs
@@ -60,10 +60,15 @@ pub async fn chat_completions(
         .await
         .map_err(|_| openai_error(StatusCode::PAYLOAD_TOO_LARGE, "Request body too large"))?;
 
-    // Extract model from body (required for routing)
-    let model_name = serde_json::from_slice::<Value>(&body_bytes)
-        .ok()
+    // Extract model and streaming flag from body
+    let request_json = serde_json::from_slice::<Value>(&body_bytes).ok();
+    let model_name = request_json
+        .as_ref()
         .and_then(|v| v.get("model").and_then(|m| m.as_str()).map(String::from));
+    let is_streaming = request_json
+        .as_ref()
+        .and_then(|v| v.get("stream").and_then(|s| s.as_bool()))
+        .unwrap_or(false);
 
     // Extract tags from X-Herd-Tags header (comma-separated)
     let tags: Option<Vec<String>> = headers
@@ -204,32 +209,7 @@ pub async fn chat_completions(
     } else {
         "error"
     };
-
-    let log = crate::analytics::RequestLog {
-        timestamp: chrono::Utc::now().timestamp(),
-        model: model_name,
-        backend: selected_backend.unwrap_or_else(|| "none".to_string()),
-        duration_ms: duration.as_millis() as u64,
-        status: status.to_string(),
-        path: "/v1/chat/completions".to_string(),
-        request_id: Some(request_id.clone()),
-        tier: None,
-        classified_by: None,
-        tokens_in: None,
-        tokens_out: None,
-        tokens_per_second: None,
-        prompt_eval_ms: None,
-        eval_ms: None,
-        backend_type: None,
-    };
-    state
-        .metrics
-        .record_request(&log.backend, &log.status, log.duration_ms)
-        .await;
-
-    if let Err(e) = state.analytics.log_request(log).await {
-        tracing::error!("Failed to log request: {}", e);
-    }
+    let backend_name = selected_backend.unwrap_or_else(|| "none".to_string());
 
     // Bridge response back (reqwest → axum)
     let status_code = axum::http::StatusCode::from_u16(response.status().as_u16())
@@ -247,14 +227,108 @@ pub async fn chat_completions(
         }
     }
 
-    // Stream body for SSE streaming support
-    let body = axum::body::Body::from_stream(response.bytes_stream());
-    builder.body(body).map_err(|_| {
-        openai_error(
-            StatusCode::INTERNAL_SERVER_ERROR,
-            "Failed to build response",
-        )
-    })
+    if is_streaming {
+        // Streaming: pass through as-is, token extraction from SSE not yet supported
+        let log = crate::analytics::RequestLog {
+            timestamp: chrono::Utc::now().timestamp(),
+            model: model_name,
+            backend: backend_name.clone(),
+            duration_ms: duration.as_millis() as u64,
+            status: status.to_string(),
+            path: "/v1/chat/completions".to_string(),
+            request_id: Some(request_id.clone()),
+            tier: None,
+            classified_by: None,
+            tokens_in: None,
+            tokens_out: None,
+            tokens_per_second: None,
+            prompt_eval_ms: None,
+            eval_ms: None,
+            backend_type: None,
+        };
+        state
+            .metrics
+            .record_request(&log.backend, &log.status, log.duration_ms)
+            .await;
+        if let Err(e) = state.analytics.log_request(log).await {
+            tracing::error!("Failed to log request: {}", e);
+        }
+
+        let body = axum::body::Body::from_stream(response.bytes_stream());
+        builder.body(body).map_err(|_| {
+            openai_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Failed to build response",
+            )
+        })
+    } else {
+        // Non-streaming: buffer body to extract token usage
+        let body_bytes = response.bytes().await.unwrap_or_default();
+
+        let mut tokens_in: Option<u32> = None;
+        let mut tokens_out: Option<u32> = None;
+        if let Ok(body_json) = serde_json::from_slice::<Value>(&body_bytes) {
+            if let Some(usage) = body_json.get("usage") {
+                tokens_in = usage
+                    .get("prompt_tokens")
+                    .and_then(|v| v.as_u64())
+                    .map(|v| v as u32);
+                tokens_out = usage
+                    .get("completion_tokens")
+                    .and_then(|v| v.as_u64())
+                    .map(|v| v as u32);
+            }
+        }
+
+        let duration_ms = duration.as_millis() as u64;
+        let log = crate::analytics::RequestLog {
+            timestamp: chrono::Utc::now().timestamp(),
+            model: model_name.clone(),
+            backend: backend_name.clone(),
+            duration_ms,
+            status: status.to_string(),
+            path: "/v1/chat/completions".to_string(),
+            request_id: Some(request_id.clone()),
+            tier: None,
+            classified_by: None,
+            tokens_in,
+            tokens_out,
+            tokens_per_second: None,
+            prompt_eval_ms: None,
+            eval_ms: None,
+            backend_type: None,
+        };
+        state
+            .metrics
+            .record_request(&log.backend, &log.status, duration_ms)
+            .await;
+        if let (Some(tin), Some(tout)) = (tokens_in, tokens_out) {
+            state
+                .metrics
+                .record_tokens(model_name.as_deref().unwrap_or("unknown"), tin, tout)
+                .await;
+            state
+                .metrics
+                .record_request_labeled(
+                    &backend_name,
+                    model_name.as_deref().unwrap_or("unknown"),
+                    status,
+                    duration_ms,
+                )
+                .await;
+        }
+        if let Err(e) = state.analytics.log_request(log).await {
+            tracing::error!("Failed to log request: {}", e);
+        }
+
+        let body = axum::body::Body::from(body_bytes);
+        builder.body(body).map_err(|_| {
+            openai_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Failed to build response",
+            )
+        })
+    }
 }
 
 /// Returns an OpenAI-format error response.

--- a/src/backend/discovery.rs
+++ b/src/backend/discovery.rs
@@ -139,7 +139,7 @@ impl ModelDiscovery {
 
     async fn discover_models(&self, pool: &BackendPool, backend: &Backend) -> Result<()> {
         let mut model_names: Vec<String> = match backend.backend {
-            crate::config::BackendType::LlamaServer => {
+            crate::config::BackendType::LlamaServer | crate::config::BackendType::OpenAICompat => {
                 let url = format!("{}/v1/models", backend.url);
                 let resp = self.client.get(&url).send().await?;
                 let models: OpenAIModelsResponse = resp.json().await?;
@@ -187,8 +187,8 @@ impl ModelDiscovery {
 
     async fn discover_running(&self, pool: &BackendPool, backend: &Backend) -> Result<()> {
         let current = match backend.backend {
-            crate::config::BackendType::LlamaServer => {
-                // llama-server always has its model loaded — use /v1/models
+            crate::config::BackendType::LlamaServer | crate::config::BackendType::OpenAICompat => {
+                // llama-server/OpenAI-compat always has its model loaded — use /v1/models
                 let url = format!("{}/v1/models", backend.url);
                 let resp = self.client.get(&url).send().await?;
                 let models: OpenAIModelsResponse = resp.json().await?;

--- a/src/backend/discovery.rs
+++ b/src/backend/discovery.rs
@@ -28,6 +28,18 @@ struct OllamaRunningModel {
     model: String,
 }
 
+/// OpenAI-compatible /v1/models response (used by llama-server)
+#[derive(Debug, Deserialize)]
+struct OpenAIModelsResponse {
+    #[serde(default)]
+    data: Vec<OpenAIModel>,
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenAIModel {
+    id: String,
+}
+
 #[derive(Debug, Deserialize)]
 struct GpuHotData {
     gpus: Vec<GpuInfo>,
@@ -126,11 +138,20 @@ impl ModelDiscovery {
     }
 
     async fn discover_models(&self, pool: &BackendPool, backend: &Backend) -> Result<()> {
-        let url = format!("{}/api/tags", backend.url);
-        let resp = self.client.get(&url).send().await?;
-        let models: OllamaModels = resp.json().await?;
-
-        let mut model_names: Vec<String> = models.models.into_iter().map(|m| m.name).collect();
+        let mut model_names: Vec<String> = match backend.backend {
+            crate::config::BackendType::LlamaServer => {
+                let url = format!("{}/v1/models", backend.url);
+                let resp = self.client.get(&url).send().await?;
+                let models: OpenAIModelsResponse = resp.json().await?;
+                models.data.into_iter().map(|m| m.id).collect()
+            }
+            crate::config::BackendType::Ollama => {
+                let url = format!("{}/api/tags", backend.url);
+                let resp = self.client.get(&url).send().await?;
+                let models: OllamaModels = resp.json().await?;
+                models.models.into_iter().map(|m| m.name).collect()
+            }
+        };
 
         // Apply model_filter regex if configured
         if let Some(ref filter) = backend.model_filter {
@@ -165,18 +186,27 @@ impl ModelDiscovery {
     }
 
     async fn discover_running(&self, pool: &BackendPool, backend: &Backend) -> Result<()> {
-        let url = format!("{}/api/ps", backend.url);
-        let resp = self.client.get(&url).send().await?;
-        let running: OllamaRunning = resp.json().await?;
-
-        // Get the first running model (if any)
-        let current = running.models.first().map(|m| {
-            if m.model.is_empty() {
-                m.name.clone()
-            } else {
-                m.model.clone()
+        let current = match backend.backend {
+            crate::config::BackendType::LlamaServer => {
+                // llama-server always has its model loaded — use /v1/models
+                let url = format!("{}/v1/models", backend.url);
+                let resp = self.client.get(&url).send().await?;
+                let models: OpenAIModelsResponse = resp.json().await?;
+                models.data.first().map(|m| m.id.clone())
             }
-        });
+            crate::config::BackendType::Ollama => {
+                let url = format!("{}/api/ps", backend.url);
+                let resp = self.client.get(&url).send().await?;
+                let running: OllamaRunning = resp.json().await?;
+                running.models.first().map(|m| {
+                    if m.model.is_empty() {
+                        m.name.clone()
+                    } else {
+                        m.model.clone()
+                    }
+                })
+            }
+        };
 
         pool.update_current_model(&backend.name, current).await;
         Ok(())
@@ -199,5 +229,20 @@ impl ModelDiscovery {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_openai_models_response() {
+        let json = r#"{"object":"list","data":[
+            {"id":"gemma-4-26B","object":"model","owned_by":"llamacpp","created":1234}
+        ]}"#;
+        let resp: OpenAIModelsResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.data.len(), 1);
+        assert_eq!(resp.data[0].id, "gemma-4-26B");
     }
 }

--- a/src/backend/health.rs
+++ b/src/backend/health.rs
@@ -40,7 +40,10 @@ impl HealthChecker {
                     );
                     continue;
                 }
-                let path = state.config.health_check_path.as_deref()
+                let path = state
+                    .config
+                    .health_check_path
+                    .as_deref()
                     .unwrap_or(state.config.default_health_check_path());
                 let url = format!("{}{}", state.config.url.trim_end_matches('/'), path);
                 match self.client.get(&url).send().await {
@@ -107,7 +110,9 @@ mod tests {
             priority: 50,
             ..Default::default()
         };
-        let path = b.health_check_path.as_deref()
+        let path = b
+            .health_check_path
+            .as_deref()
             .unwrap_or(b.default_health_check_path());
         assert_eq!(path, "/health");
     }
@@ -115,7 +120,9 @@ mod tests {
     #[test]
     fn ollama_default_health_check_path() {
         let b = Backend::default();
-        let path = b.health_check_path.as_deref()
+        let path = b
+            .health_check_path
+            .as_deref()
             .unwrap_or(b.default_health_check_path());
         assert_eq!(path, "/");
     }
@@ -130,7 +137,9 @@ mod tests {
             priority: 50,
             ..Default::default()
         };
-        let path = b.health_check_path.as_deref()
+        let path = b
+            .health_check_path
+            .as_deref()
             .unwrap_or(b.default_health_check_path());
         assert_eq!(path, "/v1/models");
     }

--- a/src/backend/health.rs
+++ b/src/backend/health.rs
@@ -40,7 +40,8 @@ impl HealthChecker {
                     );
                     continue;
                 }
-                let path = state.config.health_check_path.as_deref().unwrap_or("/");
+                let path = state.config.health_check_path.as_deref()
+                    .unwrap_or(state.config.default_health_check_path());
                 let url = format!("{}{}", state.config.url.trim_end_matches('/'), path);
                 match self.client.get(&url).send().await {
                     Ok(resp) => {
@@ -95,5 +96,42 @@ mod tests {
         let b: Backend = serde_yaml::from_str(yaml).unwrap();
         assert_eq!(b.health_check_path.as_deref(), Some("/health"));
         assert_eq!(b.health_check_status, Some(204));
+    }
+
+    #[test]
+    fn llama_server_default_health_check_path() {
+        let b = Backend {
+            name: "llama1".into(),
+            url: "http://localhost:8090".into(),
+            backend: crate::config::BackendType::LlamaServer,
+            priority: 50,
+            ..Default::default()
+        };
+        let path = b.health_check_path.as_deref()
+            .unwrap_or(b.default_health_check_path());
+        assert_eq!(path, "/health");
+    }
+
+    #[test]
+    fn ollama_default_health_check_path() {
+        let b = Backend::default();
+        let path = b.health_check_path.as_deref()
+            .unwrap_or(b.default_health_check_path());
+        assert_eq!(path, "/");
+    }
+
+    #[test]
+    fn explicit_health_check_path_overrides_default() {
+        let b = Backend {
+            name: "custom".into(),
+            url: "http://localhost:8090".into(),
+            backend: crate::config::BackendType::LlamaServer,
+            health_check_path: Some("/v1/models".into()),
+            priority: 50,
+            ..Default::default()
+        };
+        let path = b.health_check_path.as_deref()
+            .unwrap_or(b.default_health_check_path());
+        assert_eq!(path, "/v1/models");
     }
 }

--- a/src/backend/pool.rs
+++ b/src/backend/pool.rs
@@ -54,7 +54,9 @@ fn filter_healthy<'a>(
 fn least_busy_cmp(a: &&BackendState, b: &&BackendState) -> std::cmp::Ordering {
     let a_busy = a.gpu_metrics.as_ref().map(|g| g.utilization).unwrap_or(0.0);
     let b_busy = b.gpu_metrics.as_ref().map(|g| g.utilization).unwrap_or(0.0);
-    a_busy.partial_cmp(&b_busy).unwrap_or(std::cmp::Ordering::Equal)
+    a_busy
+        .partial_cmp(&b_busy)
+        .unwrap_or(std::cmp::Ordering::Equal)
 }
 
 impl BackendPool {
@@ -114,7 +116,10 @@ impl BackendPool {
         self.get_by_priority_excluding(&HashSet::new()).await
     }
 
-    pub async fn get_by_priority_excluding(&self, excluded: &HashSet<String>) -> Option<BackendState> {
+    pub async fn get_by_priority_excluding(
+        &self,
+        excluded: &HashSet<String>,
+    ) -> Option<BackendState> {
         self.get_by_priority_tagged_excluding(&[], excluded).await
     }
 
@@ -127,7 +132,8 @@ impl BackendPool {
         model: &str,
         excluded: &HashSet<String>,
     ) -> Option<BackendState> {
-        self.get_by_model_tagged_excluding(model, &[], excluded).await
+        self.get_by_model_tagged_excluding(model, &[], excluded)
+            .await
     }
 
     pub async fn get_least_busy(&self) -> Option<BackendState> {
@@ -202,7 +208,8 @@ impl BackendPool {
     }
 
     pub async fn get_by_priority_tagged(&self, tags: &[String]) -> Option<BackendState> {
-        self.get_by_priority_tagged_excluding(tags, &HashSet::new()).await
+        self.get_by_priority_tagged_excluding(tags, &HashSet::new())
+            .await
     }
 
     pub async fn get_by_priority_tagged_excluding(

--- a/src/backend/warmer.rs
+++ b/src/backend/warmer.rs
@@ -39,7 +39,7 @@ impl ModelWarmer {
             if let Some(state) = pool.get(&name).await {
                 // Skip llama-server backends — models are loaded at server start,
                 // and /api/generate is Ollama-specific.
-                if state.config.backend == crate::config::BackendType::LlamaServer {
+                if state.config.backend != crate::config::BackendType::Ollama {
                     continue;
                 }
                 for model in &state.config.hot_models {

--- a/src/backend/warmer.rs
+++ b/src/backend/warmer.rs
@@ -37,6 +37,11 @@ impl ModelWarmer {
         let backends = pool.all().await;
         for name in backends {
             if let Some(state) = pool.get(&name).await {
+                // Skip llama-server backends — models are loaded at server start,
+                // and /api/generate is Ollama-specific.
+                if state.config.backend == crate::config::BackendType::LlamaServer {
+                    continue;
+                }
                 for model in &state.config.hot_models {
                     let url = warm_url(&state.config.url);
                     let payload = warm_payload(model);
@@ -80,6 +85,15 @@ mod tests {
     fn warm_url_constructed_correctly() {
         let url = warm_url("http://citadel:11434");
         assert_eq!(url, "http://citadel:11434/api/generate");
+    }
+
+    #[test]
+    fn llama_server_backend_should_be_skipped_by_warmer() {
+        // llama-server backends don't support /api/generate.
+        // The warmer skips them based on backend type check.
+        // This test documents that warm_url produces Ollama-specific paths.
+        let url = warm_url("http://citadel:8090");
+        assert!(url.contains("/api/generate"), "warm_url is Ollama-specific");
     }
 
     #[test]

--- a/src/classifier.rs
+++ b/src/classifier.rs
@@ -1,11 +1,11 @@
+use crate::config::TaskClassifierConfig;
+use crate::server::AppState;
 use axum::{
     body::Body,
     extract::State,
     http::{HeaderValue, Request, Response},
     middleware::Next,
 };
-use crate::config::TaskClassifierConfig;
-use crate::server::AppState;
 
 /// Classification result attached to request extensions.
 #[derive(Debug, Clone)]
@@ -92,9 +92,9 @@ pub fn extract_last_user_message(json: &serde_json::Value) -> String {
     json.get("messages")
         .and_then(|m| m.as_array())
         .and_then(|msgs| {
-            msgs.iter().rev().find(|msg| {
-                msg.get("role").and_then(|r| r.as_str()) == Some("user")
-            })
+            msgs.iter()
+                .rev()
+                .find(|msg| msg.get("role").and_then(|r| r.as_str()) == Some("user"))
         })
         .and_then(|msg| msg.get("content"))
         .and_then(|c| c.as_str())
@@ -124,28 +124,28 @@ pub fn classify_by_keywords(
     }
 
     // No keyword match — use default tier if configured
-    config.tiers.get(&config.default_tier).map(|default_tier| ClassificationResult {
-        tier: config.default_tier.clone(),
-        model: default_tier.model.clone(),
-        classified_by: "default".to_string(),
-    })
+    config
+        .tiers
+        .get(&config.default_tier)
+        .map(|default_tier| ClassificationResult {
+            tier: config.default_tier.clone(),
+            model: default_tier.model.clone(),
+            classified_by: "default".to_string(),
+        })
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::collections::HashMap;
     use crate::config::{TaskClassifierConfig, TierConfig};
+    use std::collections::HashMap;
 
     fn test_config() -> TaskClassifierConfig {
         let mut tiers = HashMap::new();
         tiers.insert(
             "heavy".to_string(),
             TierConfig {
-                keywords: vec![
-                    "analyze".to_string(),
-                    "debug complex".to_string(),
-                ],
+                keywords: vec!["analyze".to_string(), "debug complex".to_string()],
                 model: "qwen2.5:32b-instruct".to_string(),
             },
         );

--- a/src/config.rs
+++ b/src/config.rs
@@ -124,6 +124,25 @@ impl std::fmt::Display for RoutingStrategy {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub enum BackendType {
+    #[default]
+    #[serde(rename = "ollama")]
+    Ollama,
+
+    #[serde(rename = "llama-server")]
+    LlamaServer,
+}
+
+impl std::fmt::Display for BackendType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            BackendType::Ollama => write!(f, "ollama"),
+            BackendType::LlamaServer => write!(f, "llama-server"),
+        }
+    }
+}
+
 fn default_strategy() -> RoutingStrategy {
     RoutingStrategy::ModelAware
 }
@@ -141,6 +160,10 @@ fn default_keep_alive_value() -> String {
 pub struct Backend {
     pub name: String,
     pub url: String,
+
+    #[serde(default)]
+    pub backend: BackendType,
+
     pub priority: u32,
 
     #[serde(default)]
@@ -167,6 +190,7 @@ impl Default for Backend {
         Self {
             name: String::new(),
             url: String::new(),
+            backend: BackendType::default(),
             priority: 50,
             hot_models: Vec::new(),
             gpu_hot_url: None,
@@ -501,6 +525,7 @@ pub fn parse_duration(input: &str) -> Result<Duration> {
 #[cfg(test)]
 mod tests {
     use super::parse_duration;
+    use super::BackendType;
     use super::Config;
     use std::time::Duration;
 
@@ -548,5 +573,26 @@ mod tests {
         let yaml = "backends:\n  - name: x\n    url: http://x\n    priority: 50\n    default_model: llama3:8b\n";
         let result: Result<Config, _> = serde_yaml::from_str(yaml);
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn backend_type_defaults_to_ollama() {
+        let yaml = "backends:\n  - name: x\n    url: http://x\n    priority: 50\n";
+        let config: Config = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(config.backends[0].backend, BackendType::Ollama);
+    }
+
+    #[test]
+    fn backend_type_llama_server_parses() {
+        let yaml = "backends:\n  - name: x\n    url: http://x\n    priority: 50\n    backend: llama-server\n";
+        let config: Config = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(config.backends[0].backend, BackendType::LlamaServer);
+    }
+
+    #[test]
+    fn backend_type_ollama_explicit() {
+        let yaml = "backends:\n  - name: x\n    url: http://x\n    priority: 50\n    backend: ollama\n";
+        let config: Config = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(config.backends[0].backend, BackendType::Ollama);
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -185,6 +185,16 @@ pub struct Backend {
     pub tags: Vec<String>,
 }
 
+impl Backend {
+    /// Default health check path based on backend type.
+    pub fn default_health_check_path(&self) -> &str {
+        match self.backend {
+            BackendType::LlamaServer => "/health",
+            BackendType::Ollama => "/",
+        }
+    }
+}
+
 impl Default for Backend {
     fn default() -> Self {
         Self {

--- a/src/config.rs
+++ b/src/config.rs
@@ -132,6 +132,9 @@ pub enum BackendType {
 
     #[serde(rename = "llama-server")]
     LlamaServer,
+
+    #[serde(rename = "openai-compat")]
+    OpenAICompat,
 }
 
 impl std::fmt::Display for BackendType {
@@ -139,6 +142,7 @@ impl std::fmt::Display for BackendType {
         match self {
             BackendType::Ollama => write!(f, "ollama"),
             BackendType::LlamaServer => write!(f, "llama-server"),
+            BackendType::OpenAICompat => write!(f, "openai-compat"),
         }
     }
 }
@@ -190,6 +194,7 @@ impl Backend {
     pub fn default_health_check_path(&self) -> &str {
         match self.backend {
             BackendType::LlamaServer => "/health",
+            BackendType::OpenAICompat => "/v1/models",
             BackendType::Ollama => "/",
         }
     }
@@ -601,8 +606,67 @@ mod tests {
 
     #[test]
     fn backend_type_ollama_explicit() {
-        let yaml = "backends:\n  - name: x\n    url: http://x\n    priority: 50\n    backend: ollama\n";
+        let yaml =
+            "backends:\n  - name: x\n    url: http://x\n    priority: 50\n    backend: ollama\n";
         let config: Config = serde_yaml::from_str(yaml).unwrap();
         assert_eq!(config.backends[0].backend, BackendType::Ollama);
+    }
+
+    #[test]
+    fn backend_type_openai_compat_parses() {
+        let yaml = "backends:\n  - name: x\n    url: http://x\n    priority: 50\n    backend: openai-compat\n";
+        let config: Config = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(config.backends[0].backend, BackendType::OpenAICompat);
+    }
+
+    #[test]
+    fn backend_type_openai_compat_display() {
+        assert_eq!(BackendType::OpenAICompat.to_string(), "openai-compat");
+    }
+
+    #[test]
+    fn openai_compat_default_health_check_path() {
+        let b = super::Backend {
+            name: "compat1".into(),
+            url: "http://localhost:8080".into(),
+            backend: BackendType::OpenAICompat,
+            priority: 50,
+            ..Default::default()
+        };
+        assert_eq!(b.default_health_check_path(), "/v1/models");
+    }
+
+    #[test]
+    fn backend_type_round_trip_serialize() {
+        for bt in [
+            BackendType::Ollama,
+            BackendType::LlamaServer,
+            BackendType::OpenAICompat,
+        ] {
+            let json = serde_json::to_string(&bt).unwrap();
+            let deserialized: BackendType = serde_json::from_str(&json).unwrap();
+            assert_eq!(bt, deserialized);
+        }
+    }
+
+    #[test]
+    fn config_without_backend_field_defaults_to_ollama() {
+        // Backward compat: existing YAML configs without `backend` field
+        let yaml = r#"
+server:
+  host: 0.0.0.0
+  port: 40114
+backends:
+  - name: gpu1
+    url: http://localhost:11434
+    priority: 100
+  - name: gpu2
+    url: http://192.168.1.50:11434
+    priority: 50
+"#;
+        let config: Config = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(config.backends.len(), 2);
+        assert_eq!(config.backends[0].backend, BackendType::Ollama);
+        assert_eq!(config.backends[1].backend, BackendType::Ollama);
     }
 }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -17,7 +17,7 @@ pub struct Metrics {
     pub routing_selections: Arc<RwLock<HashMap<String, AtomicU64>>>,
     /// Token counts by "{direction}|{model}" where direction is "in" or "out"
     pub tokens_total: Arc<RwLock<HashMap<String, AtomicU64>>>,
-    /// Tokens per second exponential moving average (stored as f32 bits in AtomicU64)
+    /// Tokens per second exponential moving average.
     pub tokens_per_second_ema: Arc<RwLock<f32>>,
     /// Labeled latency histogram by "{backend}|{model}|{status}"
     pub labeled_latency: Arc<RwLock<HashMap<String, LatencyHistogram>>>,
@@ -61,31 +61,59 @@ impl LatencyHistogram {
         // value exceeds all bucket bounds — counted in +Inf via self.count
     }
 
+    /// Render histogram buckets in Prometheus format with optional labels.
+    pub fn render_with_labels(&self, metric_name: &str, labels: &str) -> String {
+        let mut out = String::new();
+        let mut cumulative = 0u64;
+        for (i, bound) in self.bucket_bounds.iter().enumerate() {
+            cumulative += self.bucket_counts[i].load(Ordering::Relaxed);
+            if labels.is_empty() {
+                out.push_str(&format!(
+                    "{}_bucket{{le=\"{}\"}} {}\n",
+                    metric_name, bound, cumulative
+                ));
+            } else {
+                out.push_str(&format!(
+                    "{}_bucket{{{},le=\"{}\"}} {}\n",
+                    metric_name, labels, bound, cumulative
+                ));
+            }
+        }
+        let total = self.count.load(Ordering::Relaxed);
+        if labels.is_empty() {
+            out.push_str(&format!(
+                "{}_bucket{{le=\"+Inf\"}} {}\n",
+                metric_name, total
+            ));
+            out.push_str(&format!(
+                "{}_sum {}\n",
+                metric_name,
+                self.sum.load(Ordering::Relaxed)
+            ));
+            out.push_str(&format!("{}_count {}\n", metric_name, total));
+        } else {
+            out.push_str(&format!(
+                "{}_bucket{{{},le=\"+Inf\"}} {}\n",
+                metric_name, labels, total
+            ));
+            out.push_str(&format!(
+                "{}_sum{{{}}} {}\n",
+                metric_name,
+                labels,
+                self.sum.load(Ordering::Relaxed)
+            ));
+            out.push_str(&format!("{}_count{{{}}} {}\n", metric_name, labels, total));
+        }
+        out
+    }
+
     pub fn render(&self) -> String {
         let mut out = String::new();
         out.push_str(
             "# HELP herd_request_duration_ms Request duration histogram in milliseconds\n",
         );
         out.push_str("# TYPE herd_request_duration_ms histogram\n");
-        // Buckets are cumulative in Prometheus
-        let mut cumulative = 0u64;
-        for (i, bound) in self.bucket_bounds.iter().enumerate() {
-            cumulative += self.bucket_counts[i].load(Ordering::Relaxed);
-            out.push_str(&format!(
-                "herd_request_duration_ms_bucket{{le=\"{}\"}} {}\n",
-                bound, cumulative
-            ));
-        }
-        let total = self.count.load(Ordering::Relaxed);
-        out.push_str(&format!(
-            "herd_request_duration_ms_bucket{{le=\"+Inf\"}} {}\n",
-            total
-        ));
-        out.push_str(&format!(
-            "herd_request_duration_ms_sum {}\n",
-            self.sum.load(Ordering::Relaxed)
-        ));
-        out.push_str(&format!("herd_request_duration_ms_count {}\n", total));
+        out.push_str(&self.render_with_labels("herd_request_duration_ms", ""));
         out
     }
 }
@@ -173,6 +201,10 @@ impl Metrics {
     ) {
         let key = format!("{}|{}|{}", backend, model, status);
         let mut map = self.labeled_latency.write().await;
+        const MAX_LABEL_COMBOS: usize = 200;
+        if !map.contains_key(&key) && map.len() >= MAX_LABEL_COMBOS {
+            return; // Cardinality cap reached — skip to avoid memory growth
+        }
         map.entry(key)
             .or_insert_with(LatencyHistogram::new)
             .observe(duration_ms);
@@ -275,29 +307,9 @@ impl Metrics {
                         "backend=\"{}\", model=\"{}\", status=\"{}\"",
                         backend, model, status
                     );
-
-                    let mut cumulative = 0u64;
-                    for (i, bound) in hist.bucket_bounds.iter().enumerate() {
-                        cumulative += hist.bucket_counts[i].load(Ordering::Relaxed);
-                        out.push_str(&format!(
-                            "herd_request_duration_labeled_ms_bucket{{le=\"{}\", {}}} {}\n",
-                            bound, labels, cumulative
-                        ));
-                    }
-                    let total = hist.count.load(Ordering::Relaxed);
-                    out.push_str(&format!(
-                        "herd_request_duration_labeled_ms_bucket{{le=\"+Inf\", {}}} {}\n",
-                        labels, total
-                    ));
-                    out.push_str(&format!(
-                        "herd_request_duration_labeled_ms_sum{{{}}} {}\n",
-                        labels,
-                        hist.sum.load(Ordering::Relaxed)
-                    ));
-                    out.push_str(&format!(
-                        "herd_request_duration_labeled_ms_count{{{}}} {}\n",
-                        labels, total
-                    ));
+                    out.push_str(
+                        &hist.render_with_labels("herd_request_duration_labeled_ms", &labels),
+                    );
                 }
             }
         }
@@ -404,5 +416,57 @@ mod tests {
         assert!(output.contains(
             "herd_request_duration_labeled_ms_count{backend=\"gpu1\", model=\"llama3:8b\", status=\"success\"} 2"
         ));
+    }
+
+    #[tokio::test]
+    async fn labeled_histogram_cardinality_cap() {
+        let m = Metrics::new();
+        // Fill up to the cap (200 unique label combos)
+        for i in 0..200 {
+            m.record_request_labeled("gpu1", &format!("model-{}", i), "success", 100)
+                .await;
+        }
+        {
+            let map = m.labeled_latency.read().await;
+            assert_eq!(map.len(), 200);
+        }
+        // 201st unique combo should be silently dropped
+        m.record_request_labeled("gpu1", "model-overflow", "success", 100)
+            .await;
+        {
+            let map = m.labeled_latency.read().await;
+            assert_eq!(map.len(), 200);
+            assert!(!map.contains_key("gpu1|model-overflow|success"));
+        }
+        // Existing keys can still be updated
+        m.record_request_labeled("gpu1", "model-0", "success", 200)
+            .await;
+        {
+            let map = m.labeled_latency.read().await;
+            let hist = map.get("gpu1|model-0|success").unwrap();
+            assert_eq!(hist.count.load(Ordering::Relaxed), 2);
+        }
+    }
+
+    #[test]
+    fn render_with_labels_no_labels() {
+        let h = LatencyHistogram::new();
+        h.observe(5);
+        let rendered = h.render_with_labels("test_metric", "");
+        assert!(rendered.contains("test_metric_bucket{le=\"10\"} 1"));
+        assert!(rendered.contains("test_metric_bucket{le=\"+Inf\"} 1"));
+        assert!(rendered.contains("test_metric_sum 5"));
+        assert!(rendered.contains("test_metric_count 1"));
+    }
+
+    #[test]
+    fn render_with_labels_with_labels() {
+        let h = LatencyHistogram::new();
+        h.observe(5);
+        let rendered = h.render_with_labels("test_metric", "backend=\"gpu1\"");
+        assert!(rendered.contains("test_metric_bucket{backend=\"gpu1\",le=\"10\"} 1"));
+        assert!(rendered.contains("test_metric_bucket{backend=\"gpu1\",le=\"+Inf\"} 1"));
+        assert!(rendered.contains("test_metric_sum{backend=\"gpu1\"} 5"));
+        assert!(rendered.contains("test_metric_count{backend=\"gpu1\"} 1"));
     }
 }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -15,13 +15,19 @@ pub struct Metrics {
     pub latency_buckets: Arc<RwLock<LatencyHistogram>>,
     /// Routing selections by "{backend}|{strategy}"
     pub routing_selections: Arc<RwLock<HashMap<String, AtomicU64>>>,
+    /// Token counts by "{direction}|{model}" where direction is "in" or "out"
+    pub tokens_total: Arc<RwLock<HashMap<String, AtomicU64>>>,
+    /// Tokens per second exponential moving average (stored as f32 bits in AtomicU64)
+    pub tokens_per_second_ema: Arc<RwLock<f32>>,
+    /// Labeled latency histogram by "{backend}|{model}|{status}"
+    pub labeled_latency: Arc<RwLock<HashMap<String, LatencyHistogram>>>,
 }
 
 pub struct LatencyHistogram {
-    bucket_bounds: Vec<u64>,       // upper bounds in ms
-    bucket_counts: Vec<AtomicU64>, // count of observations <= bound
-    sum: AtomicU64,                // total sum of observations in ms
-    count: AtomicU64,              // total count of observations
+    pub bucket_bounds: Vec<u64>,       // upper bounds in ms
+    pub bucket_counts: Vec<AtomicU64>, // count of observations <= bound
+    pub sum: AtomicU64,                // total sum of observations in ms
+    pub count: AtomicU64,              // total count of observations
 }
 
 impl Default for LatencyHistogram {
@@ -97,6 +103,9 @@ impl Metrics {
             requests_by_backend: Arc::new(RwLock::new(HashMap::new())),
             latency_buckets: Arc::new(RwLock::new(LatencyHistogram::new())),
             routing_selections: Arc::new(RwLock::new(HashMap::new())),
+            tokens_total: Arc::new(RwLock::new(HashMap::new())),
+            tokens_per_second_ema: Arc::new(RwLock::new(0.0)),
+            labeled_latency: Arc::new(RwLock::new(HashMap::new())),
         }
     }
 
@@ -128,6 +137,45 @@ impl Metrics {
         map.entry(key)
             .or_insert_with(|| AtomicU64::new(0))
             .fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Record token usage for a model. Increments `herd_tokens_total` counters.
+    pub async fn record_tokens(&self, model: &str, tokens_in: u32, tokens_out: u32) {
+        let mut map = self.tokens_total.write().await;
+        let key_in = format!("in|{}", model);
+        map.entry(key_in)
+            .or_insert_with(|| AtomicU64::new(0))
+            .fetch_add(tokens_in as u64, Ordering::Relaxed);
+        let key_out = format!("out|{}", model);
+        map.entry(key_out)
+            .or_insert_with(|| AtomicU64::new(0))
+            .fetch_add(tokens_out as u64, Ordering::Relaxed);
+    }
+
+    /// Record tokens-per-second using exponential moving average (alpha=0.1).
+    pub async fn record_tokens_per_second(&self, tps: f32) {
+        let alpha = 0.1_f32;
+        let mut ema = self.tokens_per_second_ema.write().await;
+        if *ema == 0.0 {
+            *ema = tps;
+        } else {
+            *ema = alpha * tps + (1.0 - alpha) * *ema;
+        }
+    }
+
+    /// Record a request with backend, model, and status labels for the labeled histogram.
+    pub async fn record_request_labeled(
+        &self,
+        backend: &str,
+        model: &str,
+        status: &str,
+        duration_ms: u64,
+    ) {
+        let key = format!("{}|{}|{}", backend, model, status);
+        let mut map = self.labeled_latency.write().await;
+        map.entry(key)
+            .or_insert_with(LatencyHistogram::new)
+            .observe(duration_ms);
     }
 
     pub async fn render(&self) -> String {
@@ -162,7 +210,9 @@ impl Metrics {
         }
 
         // Routing selections
-        out.push_str("\n# HELP herd_routing_selections_total Routing selections by backend and strategy\n");
+        out.push_str(
+            "\n# HELP herd_routing_selections_total Routing selections by backend and strategy\n",
+        );
         out.push_str("# TYPE herd_routing_selections_total counter\n");
         {
             let map = self.routing_selections.read().await;
@@ -183,6 +233,73 @@ impl Metrics {
         {
             let hist = self.latency_buckets.read().await;
             out.push_str(&hist.render());
+        }
+
+        // Token totals
+        out.push_str("\n# HELP herd_tokens_total Total tokens processed by direction and model\n");
+        out.push_str("# TYPE herd_tokens_total counter\n");
+        {
+            let map = self.tokens_total.read().await;
+            for (key, count) in map.iter() {
+                if let Some((direction, model)) = key.split_once('|') {
+                    out.push_str(&format!(
+                        "herd_tokens_total{{direction=\"{}\", model=\"{}\"}} {}\n",
+                        direction,
+                        model,
+                        count.load(Ordering::Relaxed)
+                    ));
+                }
+            }
+        }
+
+        // Tokens per second EMA gauge
+        out.push_str(
+            "\n# HELP herd_tokens_per_second Tokens per second (exponential moving average)\n",
+        );
+        out.push_str("# TYPE herd_tokens_per_second gauge\n");
+        {
+            let ema = self.tokens_per_second_ema.read().await;
+            out.push_str(&format!("herd_tokens_per_second {:.2}\n", *ema));
+        }
+
+        // Labeled latency histograms
+        out.push_str("\n# HELP herd_request_duration_labeled_ms Request duration histogram with backend, model, and status labels\n");
+        out.push_str("# TYPE herd_request_duration_labeled_ms histogram\n");
+        {
+            let map = self.labeled_latency.read().await;
+            for (key, hist) in map.iter() {
+                let parts: Vec<&str> = key.splitn(3, '|').collect();
+                if parts.len() == 3 {
+                    let (backend, model, status) = (parts[0], parts[1], parts[2]);
+                    let labels = format!(
+                        "backend=\"{}\", model=\"{}\", status=\"{}\"",
+                        backend, model, status
+                    );
+
+                    let mut cumulative = 0u64;
+                    for (i, bound) in hist.bucket_bounds.iter().enumerate() {
+                        cumulative += hist.bucket_counts[i].load(Ordering::Relaxed);
+                        out.push_str(&format!(
+                            "herd_request_duration_labeled_ms_bucket{{le=\"{}\", {}}} {}\n",
+                            bound, labels, cumulative
+                        ));
+                    }
+                    let total = hist.count.load(Ordering::Relaxed);
+                    out.push_str(&format!(
+                        "herd_request_duration_labeled_ms_bucket{{le=\"+Inf\", {}}} {}\n",
+                        labels, total
+                    ));
+                    out.push_str(&format!(
+                        "herd_request_duration_labeled_ms_sum{{{}}} {}\n",
+                        labels,
+                        hist.sum.load(Ordering::Relaxed)
+                    ));
+                    out.push_str(&format!(
+                        "herd_request_duration_labeled_ms_count{{{}}} {}\n",
+                        labels, total
+                    ));
+                }
+            }
         }
 
         out
@@ -215,8 +332,11 @@ mod tests {
         m.record_routing_selection("gpu2", "least_busy").await;
 
         let output = m.render().await;
-        assert!(output.contains("herd_routing_selections_total{backend=\"gpu1\", strategy=\"priority\"} 2"));
-        assert!(output.contains("herd_routing_selections_total{backend=\"gpu2\", strategy=\"least_busy\"} 1"));
+        assert!(output
+            .contains("herd_routing_selections_total{backend=\"gpu1\", strategy=\"priority\"} 2"));
+        assert!(output.contains(
+            "herd_routing_selections_total{backend=\"gpu2\", strategy=\"least_busy\"} 1"
+        ));
     }
 
     #[test]
@@ -233,5 +353,56 @@ mod tests {
         assert!(rendered.contains("le=\"100\"} 2"));
         // 500ms bucket should have 3 cumulative
         assert!(rendered.contains("le=\"500\"} 3"));
+    }
+
+    #[tokio::test]
+    async fn record_tokens_renders_correctly() {
+        let m = Metrics::new();
+        m.record_tokens("llama3:8b", 100, 200).await;
+        m.record_tokens("llama3:8b", 50, 75).await;
+
+        let output = m.render().await;
+        assert!(output.contains("herd_tokens_total{direction=\"in\", model=\"llama3:8b\"} 150"));
+        assert!(output.contains("herd_tokens_total{direction=\"out\", model=\"llama3:8b\"} 275"));
+    }
+
+    #[tokio::test]
+    async fn tokens_per_second_ema() {
+        let m = Metrics::new();
+        // First value initializes the EMA
+        m.record_tokens_per_second(100.0).await;
+        {
+            let ema = m.tokens_per_second_ema.read().await;
+            assert!((100.0 - *ema).abs() < 0.01);
+        }
+
+        // Second value: EMA = 0.1 * 50 + 0.9 * 100 = 5 + 90 = 95
+        m.record_tokens_per_second(50.0).await;
+        {
+            let ema = m.tokens_per_second_ema.read().await;
+            assert!((95.0 - *ema).abs() < 0.01);
+        }
+
+        let output = m.render().await;
+        assert!(output.contains("herd_tokens_per_second 95.00"));
+    }
+
+    #[tokio::test]
+    async fn labeled_histogram_renders() {
+        let m = Metrics::new();
+        m.record_request_labeled("gpu1", "llama3:8b", "success", 150)
+            .await;
+        m.record_request_labeled("gpu1", "llama3:8b", "success", 50)
+            .await;
+
+        let output = m.render().await;
+        assert!(output.contains("herd_request_duration_labeled_ms"));
+        assert!(output.contains("backend=\"gpu1\""));
+        assert!(output.contains("model=\"llama3:8b\""));
+        assert!(output.contains("status=\"success\""));
+        // Count should be 2
+        assert!(output.contains(
+            "herd_request_duration_labeled_ms_count{backend=\"gpu1\", model=\"llama3:8b\", status=\"success\"} 2"
+        ));
     }
 }

--- a/src/nodes/db.rs
+++ b/src/nodes/db.rs
@@ -53,63 +53,98 @@ impl NodeDb {
                 updated_at TEXT NOT NULL
             );",
         )?;
-        // Migration: add stable machine identity column
+        // Migration v1: add stable machine identity column
         conn.execute_batch("ALTER TABLE nodes ADD COLUMN node_id TEXT;")
             .ok(); // silently ignores "duplicate column" on subsequent runs
         // Create unique index separately (idempotent)
         conn.execute_batch(
             "CREATE UNIQUE INDEX IF NOT EXISTS idx_nodes_node_id ON nodes(node_id) WHERE node_id IS NOT NULL;",
         )?;
+
+        // Migration v2: llama-server backend support
+        conn.execute_batch("ALTER TABLE nodes ADD COLUMN backend TEXT NOT NULL DEFAULT 'ollama';")
+            .ok();
+        conn.execute_batch("ALTER TABLE nodes ADD COLUMN backend_url TEXT NOT NULL DEFAULT '';")
+            .ok();
+        conn.execute_batch("ALTER TABLE nodes ADD COLUMN backend_version TEXT;")
+            .ok();
+        conn.execute_batch("ALTER TABLE nodes ADD COLUMN gpu_vendor TEXT;")
+            .ok();
+        conn.execute_batch("ALTER TABLE nodes ADD COLUMN gpu_model TEXT;")
+            .ok();
+        conn.execute_batch("ALTER TABLE nodes ADD COLUMN gpu_backend TEXT;")
+            .ok();
+        conn.execute_batch("ALTER TABLE nodes ADD COLUMN cuda_version TEXT;")
+            .ok();
+        conn.execute_batch("ALTER TABLE nodes ADD COLUMN model_paths TEXT DEFAULT '[]';")
+            .ok();
+        conn.execute_batch("ALTER TABLE nodes ADD COLUMN capabilities TEXT DEFAULT '[]';")
+            .ok();
+
+        // Backfill: copy ollama_url -> backend_url for existing rows where backend_url is empty
+        conn.execute_batch(
+            "UPDATE nodes SET backend_url = ollama_url WHERE backend_url = '' AND ollama_url != '';",
+        )?;
+
         Ok(())
     }
 
-    /// Map a SELECT row (21 columns, node_id at index 1) to a Node struct.
-    /// Column order: id, node_id, hostname, ollama_url (→ backend_url), gpu, vram_mb, ram_mb,
-    ///   max_concurrent, ollama_version, os, status, priority, enabled, tags,
-    ///   models_available, models_loaded, recommended_config, config_applied,
-    ///   last_health_check, registered_at, updated_at
-    /// NOTE: Full schema migration happens in Task 3. This is a minimal bridge
-    /// that reads the old column into backend_url and defaults new fields.
+    /// Map a SELECT row (29 columns) to a Node struct.
+    /// Column order matches NODE_COLUMNS:
+    ///   id, node_id, hostname, backend_url, backend, backend_version,
+    ///   gpu, gpu_vendor, gpu_model, gpu_backend, cuda_version,
+    ///   vram_mb, ram_mb, max_concurrent,
+    ///   ollama_version, os, status, priority, enabled, tags, models_available,
+    ///   models_loaded, model_paths, capabilities,
+    ///   recommended_config, config_applied, last_health_check,
+    ///   registered_at, updated_at
     fn row_to_node(row: &rusqlite::Row) -> rusqlite::Result<Node> {
+        let backend_str: String = row.get(4)?;
+        let backend = match backend_str.as_str() {
+            "llama-server" => crate::config::BackendType::LlamaServer,
+            _ => crate::config::BackendType::Ollama,
+        };
         Ok(Node {
             id: row.get(0)?,
             node_id: row.get(1)?,
             hostname: row.get(2)?,
             backend_url: row.get(3)?,
-            backend: crate::config::BackendType::default(),
-            backend_version: None,
-            gpu: row.get(4)?,
-            gpu_vendor: None,
-            gpu_model: None,
-            gpu_backend: None,
-            cuda_version: None,
-            vram_mb: row.get::<_, i32>(5)? as u32,
-            ram_mb: row.get::<_, i32>(6)? as u32,
-            max_concurrent: row.get::<_, i32>(7)? as u32,
-            ollama_version: row.get(8)?,
-            os: row.get(9)?,
-            status: row.get(10)?,
-            priority: row.get::<_, i32>(11)? as u32,
-            enabled: row.get::<_, i32>(12)? != 0,
-            tags: serde_json::from_str(&row.get::<_, String>(13)?).unwrap_or_default(),
-            models_available: row.get::<_, i32>(14)? as u32,
-            models_loaded: serde_json::from_str(&row.get::<_, String>(15)?)
+            backend,
+            backend_version: row.get(5)?,
+            gpu: row.get(6)?,
+            gpu_vendor: row.get(7)?,
+            gpu_model: row.get(8)?,
+            gpu_backend: row.get(9)?,
+            cuda_version: row.get(10)?,
+            vram_mb: row.get::<_, i32>(11)? as u32,
+            ram_mb: row.get::<_, i32>(12)? as u32,
+            max_concurrent: row.get::<_, i32>(13)? as u32,
+            ollama_version: row.get(14)?,
+            os: row.get(15)?,
+            status: row.get(16)?,
+            priority: row.get::<_, i32>(17)? as u32,
+            enabled: row.get::<_, i32>(18)? != 0,
+            tags: serde_json::from_str(&row.get::<_, String>(19)?).unwrap_or_default(),
+            models_available: row.get::<_, i32>(20)? as u32,
+            models_loaded: serde_json::from_str(&row.get::<_, String>(21)?).unwrap_or_default(),
+            model_paths: serde_json::from_str(&row.get::<_, String>(22)?).unwrap_or_default(),
+            capabilities: serde_json::from_str(&row.get::<_, String>(23)?).unwrap_or_default(),
+            recommended_config: serde_json::from_str(&row.get::<_, String>(24)?)
                 .unwrap_or_default(),
-            model_paths: Vec::new(),
-            capabilities: Vec::new(),
-            recommended_config: serde_json::from_str(&row.get::<_, String>(16)?)
-                .unwrap_or_default(),
-            config_applied: row.get::<_, i32>(17)? != 0,
-            last_health_check: row.get(18)?,
-            registered_at: row.get(19)?,
-            updated_at: row.get(20)?,
+            config_applied: row.get::<_, i32>(25)? != 0,
+            last_health_check: row.get(26)?,
+            registered_at: row.get(27)?,
+            updated_at: row.get(28)?,
         })
     }
 
     const NODE_COLUMNS: &'static str =
-        "id, node_id, hostname, ollama_url, gpu, vram_mb, ram_mb, max_concurrent,
+        "id, node_id, hostname, backend_url, backend, backend_version,
+         gpu, gpu_vendor, gpu_model, gpu_backend, cuda_version,
+         vram_mb, ram_mb, max_concurrent,
          ollama_version, os, status, priority, enabled, tags, models_available,
-         models_loaded, recommended_config, config_applied, last_health_check,
+         models_loaded, model_paths, capabilities,
+         recommended_config, config_applied, last_health_check,
          registered_at, updated_at";
 
     /// Insert or update a node by hostname (idempotent registration).
@@ -145,7 +180,11 @@ impl NodeDb {
             });
 
         let models_loaded_json = serde_json::to_string(&reg.models_loaded)?;
+        let model_paths_json = serde_json::to_string(&reg.model_paths)?;
+        let capabilities_json = serde_json::to_string(&reg.capabilities)?;
         let recommended_config_json = serde_json::to_string(&reg.recommended_config)?;
+        let backend_str = reg.backend.to_string();
+        let backend_url = reg.effective_url().to_string();
 
         // Derive max_concurrent from recommended_config.num_parallel or default to 1
         let max_concurrent = reg
@@ -162,10 +201,13 @@ impl NodeDb {
                     max_concurrent = ?5, ollama_version = ?6, os = ?7,
                     status = 'healthy', models_available = ?8, models_loaded = ?9,
                     recommended_config = ?10, config_applied = ?11, updated_at = ?12,
-                    node_id = COALESCE(?14, node_id), hostname = ?15
+                    node_id = COALESCE(?14, node_id), hostname = ?15,
+                    backend = ?16, backend_url = ?17, backend_version = ?18,
+                    gpu_vendor = ?19, gpu_model = ?20, gpu_backend = ?21,
+                    cuda_version = ?22, model_paths = ?23, capabilities = ?24
                 WHERE id = ?13",
                 rusqlite::params![
-                    reg.effective_url().to_string(),
+                    backend_url,
                     reg.gpu,
                     reg.vram_mb,
                     reg.ram_mb,
@@ -179,7 +221,16 @@ impl NodeDb {
                     now,
                     id,
                     reg.node_id,
-                    reg.hostname
+                    reg.hostname,
+                    backend_str,
+                    backend_url,
+                    reg.backend_version,
+                    reg.gpu_vendor,
+                    reg.gpu_model,
+                    reg.gpu_backend,
+                    reg.cuda_version,
+                    model_paths_json,
+                    capabilities_json
                 ],
             )?;
             Ok((id, false))
@@ -190,13 +241,17 @@ impl NodeDb {
                 "INSERT INTO nodes (id, node_id, hostname, ollama_url, gpu, vram_mb, ram_mb,
                     max_concurrent, ollama_version, os, status, models_available,
                     models_loaded, recommended_config, config_applied,
-                    registered_at, updated_at)
-                VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, 'healthy', ?11, ?12, ?13, ?14, ?15, ?16)",
+                    registered_at, updated_at,
+                    backend, backend_url, backend_version,
+                    gpu_vendor, gpu_model, gpu_backend, cuda_version,
+                    model_paths, capabilities)
+                VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, 'healthy', ?11, ?12, ?13, ?14, ?15, ?16,
+                        ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25)",
                 rusqlite::params![
                     id,
                     reg.node_id,
                     reg.hostname,
-                    reg.effective_url().to_string(),
+                    backend_url,
                     reg.gpu,
                     reg.vram_mb,
                     reg.ram_mb,
@@ -208,7 +263,16 @@ impl NodeDb {
                     recommended_config_json,
                     reg.config_applied as i32,
                     registered_at,
-                    now
+                    now,
+                    backend_str,
+                    backend_url,
+                    reg.backend_version,
+                    reg.gpu_vendor,
+                    reg.gpu_model,
+                    reg.gpu_backend,
+                    reg.cuda_version,
+                    model_paths_json,
+                    capabilities_json
                 ],
             )?;
             Ok((id, true))
@@ -364,5 +428,135 @@ impl NodeDb {
             .query_map([], Self::row_to_node)?
             .collect::<Result<Vec<_>, _>>()?;
         Ok(nodes)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::BackendType;
+
+    fn test_db() -> NodeDb {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;")
+            .unwrap();
+        let db = NodeDb {
+            conn: Mutex::new(conn),
+        };
+        db.migrate().unwrap();
+        db
+    }
+
+    #[test]
+    fn migrate_creates_table_and_columns() {
+        let db = test_db();
+        let reg = NodeRegistration {
+            hostname: "test-node".to_string(),
+            ollama_url: "http://test:11434".to_string(),
+            backend: BackendType::Ollama,
+            ..Default::default()
+        };
+        let (id, is_new) = db.upsert_node(&reg).unwrap();
+        assert!(is_new);
+
+        let node = db.get_node(&id).unwrap().unwrap();
+        assert_eq!(node.backend, BackendType::Ollama);
+        assert_eq!(node.backend_url, "http://test:11434");
+    }
+
+    #[test]
+    fn upsert_llama_server_node() {
+        let db = test_db();
+        let reg = NodeRegistration {
+            hostname: "citadel".to_string(),
+            ollama_url: String::new(),
+            backend_url: Some("http://citadel:8090".to_string()),
+            backend: BackendType::LlamaServer,
+            backend_version: Some("b8678".to_string()),
+            gpu_vendor: Some("nvidia".to_string()),
+            gpu_model: Some("RTX 5090".to_string()),
+            gpu_backend: Some("cuda".to_string()),
+            cuda_version: Some("13.1".to_string()),
+            vram_mb: 32768,
+            models_loaded: vec!["gemma-4.gguf".to_string()],
+            model_paths: vec!["/models/gemma-4.gguf".to_string()],
+            capabilities: vec!["cuda".to_string(), "flash_attn".to_string()],
+            ..Default::default()
+        };
+        let (id, is_new) = db.upsert_node(&reg).unwrap();
+        assert!(is_new);
+
+        let node = db.get_node(&id).unwrap().unwrap();
+        assert_eq!(node.backend, BackendType::LlamaServer);
+        assert_eq!(node.backend_url, "http://citadel:8090");
+        assert_eq!(node.backend_version.as_deref(), Some("b8678"));
+        assert_eq!(node.gpu_vendor.as_deref(), Some("nvidia"));
+        assert_eq!(node.gpu_model.as_deref(), Some("RTX 5090"));
+        assert_eq!(node.gpu_backend.as_deref(), Some("cuda"));
+        assert_eq!(node.cuda_version.as_deref(), Some("13.1"));
+        assert_eq!(node.vram_mb, 32768);
+        assert_eq!(node.capabilities, vec!["cuda", "flash_attn"]);
+        assert_eq!(node.model_paths, vec!["/models/gemma-4.gguf"]);
+    }
+
+    #[test]
+    fn upsert_idempotent_re_registration() {
+        let db = test_db();
+        let reg = NodeRegistration {
+            hostname: "node1".to_string(),
+            ollama_url: "http://node1:11434".to_string(),
+            backend: BackendType::Ollama,
+            ..Default::default()
+        };
+        let (id1, new1) = db.upsert_node(&reg).unwrap();
+        assert!(new1);
+
+        let (id2, new2) = db.upsert_node(&reg).unwrap();
+        assert!(!new2);
+        assert_eq!(id1, id2);
+    }
+
+    #[test]
+    fn routable_nodes_filters_correctly() {
+        let db = test_db();
+        let reg = NodeRegistration {
+            hostname: "healthy-node".to_string(),
+            ollama_url: "http://healthy:11434".to_string(),
+            ..Default::default()
+        };
+        db.upsert_node(&reg).unwrap();
+
+        let routable = db.get_routable_nodes().unwrap();
+        assert_eq!(routable.len(), 1);
+        assert_eq!(routable[0].hostname, "healthy-node");
+    }
+
+    #[test]
+    fn update_preserves_backend_fields() {
+        let db = test_db();
+        let reg = NodeRegistration {
+            hostname: "citadel".to_string(),
+            backend_url: Some("http://citadel:8090".to_string()),
+            backend: BackendType::LlamaServer,
+            gpu_vendor: Some("nvidia".to_string()),
+            ..Default::default()
+        };
+        let (id, _) = db.upsert_node(&reg).unwrap();
+
+        // Update priority -- backend fields should be preserved
+        db.update_node(
+            &id,
+            &NodeUpdate {
+                priority: Some(200),
+                tags: None,
+                enabled: None,
+            },
+        )
+        .unwrap();
+
+        let node = db.get_node(&id).unwrap().unwrap();
+        assert_eq!(node.priority, 200);
+        assert_eq!(node.backend, BackendType::LlamaServer);
+        assert_eq!(node.gpu_vendor.as_deref(), Some("nvidia"));
     }
 }

--- a/src/nodes/db.rs
+++ b/src/nodes/db.rs
@@ -1,7 +1,23 @@
 use super::types::*;
 use anyhow::Result;
 use rusqlite::Connection;
+use serde::{Deserialize, Serialize};
 use std::sync::Mutex;
+
+/// Tracks a model file download in progress or completed.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ModelDownload {
+    pub id: String,
+    pub node_id: String,
+    pub url: String,
+    pub file_name: String,
+    pub target_path: String,
+    pub bytes_downloaded: u64,
+    pub total_bytes: u64,
+    pub status: String,
+    pub created_at: String,
+    pub updated_at: String,
+}
 
 pub struct NodeDb {
     conn: Mutex<Connection>,
@@ -56,7 +72,7 @@ impl NodeDb {
         // Migration v1: add stable machine identity column
         conn.execute_batch("ALTER TABLE nodes ADD COLUMN node_id TEXT;")
             .ok(); // silently ignores "duplicate column" on subsequent runs
-        // Create unique index separately (idempotent)
+                   // Create unique index separately (idempotent)
         conn.execute_batch(
             "CREATE UNIQUE INDEX IF NOT EXISTS idx_nodes_node_id ON nodes(node_id) WHERE node_id IS NOT NULL;",
         )?;
@@ -86,22 +102,46 @@ impl NodeDb {
             "UPDATE nodes SET backend_url = ollama_url WHERE backend_url = '' AND ollama_url != '';",
         )?;
 
+        // Migration v3: additional GPU metadata
+        conn.execute_batch("ALTER TABLE nodes ADD COLUMN gpu_driver_version TEXT;")
+            .ok();
+        conn.execute_batch("ALTER TABLE nodes ADD COLUMN max_context_len INTEGER DEFAULT 4096;")
+            .ok();
+
+        // Migration v4: model download tracking
+        conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS model_downloads (
+                id TEXT PRIMARY KEY,
+                node_id TEXT NOT NULL,
+                url TEXT NOT NULL,
+                file_name TEXT NOT NULL,
+                target_path TEXT NOT NULL,
+                bytes_downloaded INTEGER DEFAULT 0,
+                total_bytes INTEGER DEFAULT 0,
+                status TEXT DEFAULT 'pending',
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                FOREIGN KEY (node_id) REFERENCES nodes(id)
+            );",
+        )?;
+
         Ok(())
     }
 
-    /// Map a SELECT row (29 columns) to a Node struct.
+    /// Map a SELECT row (31 columns) to a Node struct.
     /// Column order matches NODE_COLUMNS:
     ///   id, node_id, hostname, backend_url, backend, backend_version,
     ///   gpu, gpu_vendor, gpu_model, gpu_backend, cuda_version,
     ///   vram_mb, ram_mb, max_concurrent,
     ///   ollama_version, os, status, priority, enabled, tags, models_available,
-    ///   models_loaded, model_paths, capabilities,
+    ///   models_loaded, model_paths, capabilities, gpu_driver_version, max_context_len,
     ///   recommended_config, config_applied, last_health_check,
     ///   registered_at, updated_at
     fn row_to_node(row: &rusqlite::Row) -> rusqlite::Result<Node> {
         let backend_str: String = row.get(4)?;
         let backend = match backend_str.as_str() {
             "llama-server" => crate::config::BackendType::LlamaServer,
+            "openai-compat" => crate::config::BackendType::OpenAICompat,
             _ => crate::config::BackendType::Ollama,
         };
         Ok(Node {
@@ -129,12 +169,14 @@ impl NodeDb {
             models_loaded: serde_json::from_str(&row.get::<_, String>(21)?).unwrap_or_default(),
             model_paths: serde_json::from_str(&row.get::<_, String>(22)?).unwrap_or_default(),
             capabilities: serde_json::from_str(&row.get::<_, String>(23)?).unwrap_or_default(),
-            recommended_config: serde_json::from_str(&row.get::<_, String>(24)?)
+            gpu_driver_version: row.get(24)?,
+            max_context_len: row.get::<_, i32>(25)? as u32,
+            recommended_config: serde_json::from_str(&row.get::<_, String>(26)?)
                 .unwrap_or_default(),
-            config_applied: row.get::<_, i32>(25)? != 0,
-            last_health_check: row.get(26)?,
-            registered_at: row.get(27)?,
-            updated_at: row.get(28)?,
+            config_applied: row.get::<_, i32>(27)? != 0,
+            last_health_check: row.get(28)?,
+            registered_at: row.get(29)?,
+            updated_at: row.get(30)?,
         })
     }
 
@@ -143,7 +185,7 @@ impl NodeDb {
          gpu, gpu_vendor, gpu_model, gpu_backend, cuda_version,
          vram_mb, ram_mb, max_concurrent,
          ollama_version, os, status, priority, enabled, tags, models_available,
-         models_loaded, model_paths, capabilities,
+         models_loaded, model_paths, capabilities, gpu_driver_version, max_context_len,
          recommended_config, config_applied, last_health_check,
          registered_at, updated_at";
 
@@ -204,7 +246,8 @@ impl NodeDb {
                     node_id = COALESCE(?14, node_id), hostname = ?15,
                     backend = ?16, backend_url = ?17, backend_version = ?18,
                     gpu_vendor = ?19, gpu_model = ?20, gpu_backend = ?21,
-                    cuda_version = ?22, model_paths = ?23, capabilities = ?24
+                    cuda_version = ?22, model_paths = ?23, capabilities = ?24,
+                    gpu_driver_version = ?25, max_context_len = ?26
                 WHERE id = ?13",
                 rusqlite::params![
                     backend_url,
@@ -230,7 +273,9 @@ impl NodeDb {
                     reg.gpu_backend,
                     reg.cuda_version,
                     model_paths_json,
-                    capabilities_json
+                    capabilities_json,
+                    reg.gpu_driver_version,
+                    reg.max_context_len
                 ],
             )?;
             Ok((id, false))
@@ -244,9 +289,10 @@ impl NodeDb {
                     registered_at, updated_at,
                     backend, backend_url, backend_version,
                     gpu_vendor, gpu_model, gpu_backend, cuda_version,
-                    model_paths, capabilities)
+                    model_paths, capabilities,
+                    gpu_driver_version, max_context_len)
                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, 'healthy', ?11, ?12, ?13, ?14, ?15, ?16,
-                        ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25)",
+                        ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25, ?26, ?27)",
                 rusqlite::params![
                     id,
                     reg.node_id,
@@ -272,7 +318,9 @@ impl NodeDb {
                     reg.gpu_backend,
                     reg.cuda_version,
                     model_paths_json,
-                    capabilities_json
+                    capabilities_json,
+                    reg.gpu_driver_version,
+                    reg.max_context_len
                 ],
             )?;
             Ok((id, true))
@@ -302,10 +350,7 @@ impl NodeDb {
             .conn
             .lock()
             .map_err(|e| anyhow::anyhow!("DB lock: {}", e))?;
-        let sql = format!(
-            "SELECT {} FROM nodes WHERE id = ?1",
-            Self::NODE_COLUMNS
-        );
+        let sql = format!("SELECT {} FROM nodes WHERE id = ?1", Self::NODE_COLUMNS);
         let result = conn.query_row(&sql, rusqlite::params![id], Self::row_to_node);
         match result {
             Ok(node) => Ok(Some(node)),
@@ -402,10 +447,7 @@ impl NodeDb {
             .conn
             .lock()
             .map_err(|e| anyhow::anyhow!("DB lock: {}", e))?;
-        let sql = format!(
-            "SELECT {} FROM nodes WHERE enabled = 1",
-            Self::NODE_COLUMNS
-        );
+        let sql = format!("SELECT {} FROM nodes WHERE enabled = 1", Self::NODE_COLUMNS);
         let mut stmt = conn.prepare(&sql)?;
         let nodes = stmt
             .query_map([], Self::row_to_node)?
@@ -428,6 +470,127 @@ impl NodeDb {
             .query_map([], Self::row_to_node)?
             .collect::<Result<Vec<_>, _>>()?;
         Ok(nodes)
+    }
+
+    // ── Model download tracking ──────────────────────────────────────
+
+    /// Create a new download tracking entry. Returns the download ID.
+    pub fn create_download(
+        &self,
+        node_id: &str,
+        url: &str,
+        file_name: &str,
+        target_path: &str,
+        total_bytes: u64,
+    ) -> Result<String> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| anyhow::anyhow!("DB lock: {}", e))?;
+        let id = uuid::Uuid::new_v4().to_string();
+        let now = chrono::Utc::now().to_rfc3339();
+        conn.execute(
+            "INSERT INTO model_downloads (id, node_id, url, file_name, target_path, total_bytes, status, created_at, updated_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, 'pending', ?7, ?7)",
+            rusqlite::params![id, node_id, url, file_name, target_path, total_bytes as i64, now],
+        )?;
+        Ok(id)
+    }
+
+    /// Update download progress (bytes_downloaded and optionally status).
+    pub fn update_download_progress(
+        &self,
+        id: &str,
+        bytes_downloaded: u64,
+        status: &str,
+    ) -> Result<bool> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| anyhow::anyhow!("DB lock: {}", e))?;
+        let now = chrono::Utc::now().to_rfc3339();
+        let rows = conn.execute(
+            "UPDATE model_downloads SET bytes_downloaded = ?1, status = ?2, updated_at = ?3 WHERE id = ?4",
+            rusqlite::params![bytes_downloaded as i64, status, now, id],
+        )?;
+        Ok(rows > 0)
+    }
+
+    /// Get a single download by ID.
+    pub fn get_download(&self, id: &str) -> Result<Option<ModelDownload>> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| anyhow::anyhow!("DB lock: {}", e))?;
+        let result = conn.query_row(
+            "SELECT id, node_id, url, file_name, target_path, bytes_downloaded, total_bytes, status, created_at, updated_at
+             FROM model_downloads WHERE id = ?1",
+            rusqlite::params![id],
+            Self::row_to_download,
+        );
+        match result {
+            Ok(dl) => Ok(Some(dl)),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    /// List all downloads, optionally filtered by node_id.
+    pub fn list_downloads(&self, node_id: Option<&str>) -> Result<Vec<ModelDownload>> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| anyhow::anyhow!("DB lock: {}", e))?;
+        let (sql, params): (String, Vec<Box<dyn rusqlite::types::ToSql>>) = if let Some(nid) =
+            node_id
+        {
+            (
+                "SELECT id, node_id, url, file_name, target_path, bytes_downloaded, total_bytes, status, created_at, updated_at
+                 FROM model_downloads WHERE node_id = ?1 ORDER BY created_at DESC".to_string(),
+                vec![Box::new(nid.to_string())],
+            )
+        } else {
+            (
+                "SELECT id, node_id, url, file_name, target_path, bytes_downloaded, total_bytes, status, created_at, updated_at
+                 FROM model_downloads ORDER BY created_at DESC".to_string(),
+                vec![],
+            )
+        };
+        let mut stmt = conn.prepare(&sql)?;
+        let params_ref: Vec<&dyn rusqlite::types::ToSql> =
+            params.iter().map(|p| p.as_ref()).collect();
+        let downloads = stmt
+            .query_map(params_ref.as_slice(), Self::row_to_download)?
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(downloads)
+    }
+
+    /// Delete a download record.
+    pub fn delete_download(&self, id: &str) -> Result<bool> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| anyhow::anyhow!("DB lock: {}", e))?;
+        let rows = conn.execute(
+            "DELETE FROM model_downloads WHERE id = ?1",
+            rusqlite::params![id],
+        )?;
+        Ok(rows > 0)
+    }
+
+    fn row_to_download(row: &rusqlite::Row) -> rusqlite::Result<ModelDownload> {
+        Ok(ModelDownload {
+            id: row.get(0)?,
+            node_id: row.get(1)?,
+            url: row.get(2)?,
+            file_name: row.get(3)?,
+            target_path: row.get(4)?,
+            bytes_downloaded: row.get::<_, i64>(5)? as u64,
+            total_bytes: row.get::<_, i64>(6)? as u64,
+            status: row.get(7)?,
+            created_at: row.get(8)?,
+            updated_at: row.get(9)?,
+        })
     }
 }
 
@@ -558,5 +721,178 @@ mod tests {
         assert_eq!(node.priority, 200);
         assert_eq!(node.backend, BackendType::LlamaServer);
         assert_eq!(node.gpu_vendor.as_deref(), Some("nvidia"));
+    }
+
+    #[test]
+    fn migrate_v3_adds_gpu_driver_and_context_columns() {
+        let db = test_db();
+        // Verify columns exist by inserting a node with the new fields
+        let reg = NodeRegistration {
+            hostname: "v3-test".to_string(),
+            ollama_url: "http://test:11434".to_string(),
+            gpu_driver_version: Some("572.83".to_string()),
+            max_context_len: 8192,
+            ..Default::default()
+        };
+        let (id, _) = db.upsert_node(&reg).unwrap();
+        let node = db.get_node(&id).unwrap().unwrap();
+        assert_eq!(node.gpu_driver_version.as_deref(), Some("572.83"));
+        assert_eq!(node.max_context_len, 8192);
+    }
+
+    #[test]
+    fn upsert_with_gpu_driver_and_context_len() {
+        let db = test_db();
+        let reg = NodeRegistration {
+            hostname: "gpu-node".to_string(),
+            backend_url: Some("http://gpu:8090".to_string()),
+            backend: BackendType::LlamaServer,
+            gpu_driver_version: Some("572.83".to_string()),
+            max_context_len: 131072,
+            ..Default::default()
+        };
+        let (id, is_new) = db.upsert_node(&reg).unwrap();
+        assert!(is_new);
+
+        let node = db.get_node(&id).unwrap().unwrap();
+        assert_eq!(node.gpu_driver_version.as_deref(), Some("572.83"));
+        assert_eq!(node.max_context_len, 131072);
+
+        // Re-register with updated driver version
+        let reg2 = NodeRegistration {
+            hostname: "gpu-node".to_string(),
+            backend_url: Some("http://gpu:8090".to_string()),
+            backend: BackendType::LlamaServer,
+            gpu_driver_version: Some("575.01".to_string()),
+            max_context_len: 65536,
+            ..Default::default()
+        };
+        let (id2, is_new2) = db.upsert_node(&reg2).unwrap();
+        assert!(!is_new2);
+        assert_eq!(id, id2);
+
+        let node2 = db.get_node(&id2).unwrap().unwrap();
+        assert_eq!(node2.gpu_driver_version.as_deref(), Some("575.01"));
+        assert_eq!(node2.max_context_len, 65536);
+    }
+
+    #[test]
+    fn backward_compat_old_payload_defaults_new_fields() {
+        let db = test_db();
+        // Old-style registration without gpu_driver_version or max_context_len
+        let reg = NodeRegistration {
+            hostname: "old-node".to_string(),
+            ollama_url: "http://old:11434".to_string(),
+            ..Default::default()
+        };
+        let (id, _) = db.upsert_node(&reg).unwrap();
+        let node = db.get_node(&id).unwrap().unwrap();
+        assert!(node.gpu_driver_version.is_none());
+        assert_eq!(node.max_context_len, 4096); // default
+    }
+
+    #[test]
+    fn model_registry_computation() {
+        let db = test_db();
+        let reg = NodeRegistration {
+            hostname: "registry-node".to_string(),
+            backend_url: Some("http://node:8090".to_string()),
+            backend: BackendType::LlamaServer,
+            model_paths: vec![
+                "/models/gemma-4-26B.gguf".to_string(),
+                "/models/qwen3-32b.gguf".to_string(),
+            ],
+            models_loaded: vec!["gemma-4-26B.gguf".to_string()],
+            ..Default::default()
+        };
+        let (id, _) = db.upsert_node(&reg).unwrap();
+        let node = db.get_node(&id).unwrap().unwrap();
+
+        let registry = node.model_registry();
+        assert_eq!(registry.len(), 2);
+
+        assert_eq!(registry[0].file_name, "gemma-4-26B.gguf");
+        assert_eq!(registry[0].file_path, "/models/gemma-4-26B.gguf");
+        assert!(registry[0].loaded);
+
+        assert_eq!(registry[1].file_name, "qwen3-32b.gguf");
+        assert_eq!(registry[1].file_path, "/models/qwen3-32b.gguf");
+        assert!(!registry[1].loaded);
+    }
+
+    #[test]
+    fn download_tracking_crud() {
+        let db = test_db();
+        // Create a node first (foreign key)
+        let reg = NodeRegistration {
+            hostname: "dl-node".to_string(),
+            ollama_url: "http://dl:11434".to_string(),
+            ..Default::default()
+        };
+        let (node_id, _) = db.upsert_node(&reg).unwrap();
+
+        // Create download
+        let dl_id = db
+            .create_download(
+                &node_id,
+                "https://huggingface.co/model/file.gguf",
+                "file.gguf",
+                "/models/file.gguf",
+                5_000_000_000,
+            )
+            .unwrap();
+
+        // Get download
+        let dl = db.get_download(&dl_id).unwrap().unwrap();
+        assert_eq!(dl.node_id, node_id);
+        assert_eq!(dl.file_name, "file.gguf");
+        assert_eq!(dl.status, "pending");
+        assert_eq!(dl.bytes_downloaded, 0);
+        assert_eq!(dl.total_bytes, 5_000_000_000);
+
+        // Update progress
+        db.update_download_progress(&dl_id, 1_000_000_000, "downloading")
+            .unwrap();
+        let dl2 = db.get_download(&dl_id).unwrap().unwrap();
+        assert_eq!(dl2.bytes_downloaded, 1_000_000_000);
+        assert_eq!(dl2.status, "downloading");
+
+        // Complete
+        db.update_download_progress(&dl_id, 5_000_000_000, "completed")
+            .unwrap();
+        let dl3 = db.get_download(&dl_id).unwrap().unwrap();
+        assert_eq!(dl3.status, "completed");
+        assert_eq!(dl3.bytes_downloaded, 5_000_000_000);
+
+        // List downloads
+        let all = db.list_downloads(None).unwrap();
+        assert_eq!(all.len(), 1);
+        let by_node = db.list_downloads(Some(&node_id)).unwrap();
+        assert_eq!(by_node.len(), 1);
+        let by_other = db.list_downloads(Some("nonexistent")).unwrap();
+        assert!(by_other.is_empty());
+
+        // Delete
+        assert!(db.delete_download(&dl_id).unwrap());
+        assert!(db.get_download(&dl_id).unwrap().is_none());
+        assert!(!db.delete_download(&dl_id).unwrap()); // already deleted
+    }
+
+    #[test]
+    fn node_columns_count_matches_row_to_node() {
+        // Verify NODE_COLUMNS has exactly 31 columns matching row_to_node expectations
+        let col_count = NodeDb::NODE_COLUMNS
+            .split(',')
+            .filter(|s| !s.trim().is_empty())
+            .count();
+        assert_eq!(col_count, 31, "NODE_COLUMNS should have 31 columns");
+    }
+
+    #[test]
+    fn migrate_v4_creates_downloads_table() {
+        let db = test_db();
+        // Verify the table exists by listing downloads (should be empty, not error)
+        let downloads = db.list_downloads(None).unwrap();
+        assert!(downloads.is_empty());
     }
 }

--- a/src/nodes/db.rs
+++ b/src/nodes/db.rs
@@ -4,6 +4,38 @@ use rusqlite::Connection;
 use serde::{Deserialize, Serialize};
 use std::sync::Mutex;
 
+/// Status of a model file download.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum DownloadStatus {
+    Pending,
+    Downloading,
+    Completed,
+    Failed,
+}
+
+impl std::fmt::Display for DownloadStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            DownloadStatus::Pending => write!(f, "pending"),
+            DownloadStatus::Downloading => write!(f, "downloading"),
+            DownloadStatus::Completed => write!(f, "completed"),
+            DownloadStatus::Failed => write!(f, "failed"),
+        }
+    }
+}
+
+impl DownloadStatus {
+    fn from_str(s: &str) -> Self {
+        match s {
+            "downloading" => DownloadStatus::Downloading,
+            "completed" => DownloadStatus::Completed,
+            "failed" => DownloadStatus::Failed,
+            _ => DownloadStatus::Pending,
+        }
+    }
+}
+
 /// Tracks a model file download in progress or completed.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ModelDownload {
@@ -14,7 +46,7 @@ pub struct ModelDownload {
     pub target_path: String,
     pub bytes_downloaded: u64,
     pub total_bytes: u64,
-    pub status: String,
+    pub status: DownloadStatus,
     pub created_at: String,
     pub updated_at: String,
 }
@@ -128,55 +160,50 @@ impl NodeDb {
         Ok(())
     }
 
-    /// Map a SELECT row (31 columns) to a Node struct.
-    /// Column order matches NODE_COLUMNS:
-    ///   id, node_id, hostname, backend_url, backend, backend_version,
-    ///   gpu, gpu_vendor, gpu_model, gpu_backend, cuda_version,
-    ///   vram_mb, ram_mb, max_concurrent,
-    ///   ollama_version, os, status, priority, enabled, tags, models_available,
-    ///   models_loaded, model_paths, capabilities, gpu_driver_version, max_context_len,
-    ///   recommended_config, config_applied, last_health_check,
-    ///   registered_at, updated_at
+    /// Map a SELECT row to a Node struct using named column access.
     fn row_to_node(row: &rusqlite::Row) -> rusqlite::Result<Node> {
-        let backend_str: String = row.get(4)?;
+        let backend_str: String = row.get("backend")?;
         let backend = match backend_str.as_str() {
             "llama-server" => crate::config::BackendType::LlamaServer,
             "openai-compat" => crate::config::BackendType::OpenAICompat,
             _ => crate::config::BackendType::Ollama,
         };
         Ok(Node {
-            id: row.get(0)?,
-            node_id: row.get(1)?,
-            hostname: row.get(2)?,
-            backend_url: row.get(3)?,
+            id: row.get("id")?,
+            node_id: row.get("node_id")?,
+            hostname: row.get("hostname")?,
+            backend_url: row.get("backend_url")?,
             backend,
-            backend_version: row.get(5)?,
-            gpu: row.get(6)?,
-            gpu_vendor: row.get(7)?,
-            gpu_model: row.get(8)?,
-            gpu_backend: row.get(9)?,
-            cuda_version: row.get(10)?,
-            vram_mb: row.get::<_, i32>(11)? as u32,
-            ram_mb: row.get::<_, i32>(12)? as u32,
-            max_concurrent: row.get::<_, i32>(13)? as u32,
-            ollama_version: row.get(14)?,
-            os: row.get(15)?,
-            status: row.get(16)?,
-            priority: row.get::<_, i32>(17)? as u32,
-            enabled: row.get::<_, i32>(18)? != 0,
-            tags: serde_json::from_str(&row.get::<_, String>(19)?).unwrap_or_default(),
-            models_available: row.get::<_, i32>(20)? as u32,
-            models_loaded: serde_json::from_str(&row.get::<_, String>(21)?).unwrap_or_default(),
-            model_paths: serde_json::from_str(&row.get::<_, String>(22)?).unwrap_or_default(),
-            capabilities: serde_json::from_str(&row.get::<_, String>(23)?).unwrap_or_default(),
-            gpu_driver_version: row.get(24)?,
-            max_context_len: row.get::<_, i32>(25)? as u32,
-            recommended_config: serde_json::from_str(&row.get::<_, String>(26)?)
+            backend_version: row.get("backend_version")?,
+            gpu: row.get("gpu")?,
+            gpu_vendor: row.get("gpu_vendor")?,
+            gpu_model: row.get("gpu_model")?,
+            gpu_backend: row.get("gpu_backend")?,
+            cuda_version: row.get("cuda_version")?,
+            vram_mb: row.get::<_, i32>("vram_mb")? as u32,
+            ram_mb: row.get::<_, i32>("ram_mb")? as u32,
+            max_concurrent: row.get::<_, i32>("max_concurrent")? as u32,
+            ollama_version: row.get("ollama_version")?,
+            os: row.get("os")?,
+            status: row.get("status")?,
+            priority: row.get::<_, i32>("priority")? as u32,
+            enabled: row.get::<_, i32>("enabled")? != 0,
+            tags: serde_json::from_str(&row.get::<_, String>("tags")?).unwrap_or_default(),
+            models_available: row.get::<_, i32>("models_available")? as u32,
+            models_loaded: serde_json::from_str(&row.get::<_, String>("models_loaded")?)
                 .unwrap_or_default(),
-            config_applied: row.get::<_, i32>(27)? != 0,
-            last_health_check: row.get(28)?,
-            registered_at: row.get(29)?,
-            updated_at: row.get(30)?,
+            model_paths: serde_json::from_str(&row.get::<_, String>("model_paths")?)
+                .unwrap_or_default(),
+            capabilities: serde_json::from_str(&row.get::<_, String>("capabilities")?)
+                .unwrap_or_default(),
+            gpu_driver_version: row.get("gpu_driver_version")?,
+            max_context_len: row.get::<_, i32>("max_context_len")? as u32,
+            recommended_config: serde_json::from_str(&row.get::<_, String>("recommended_config")?)
+                .unwrap_or_default(),
+            config_applied: row.get::<_, i32>("config_applied")? != 0,
+            last_health_check: row.get("last_health_check")?,
+            registered_at: row.get("registered_at")?,
+            updated_at: row.get("updated_at")?,
         })
     }
 
@@ -281,6 +308,10 @@ impl NodeDb {
             Ok((id, false))
         } else {
             // Insert new node
+            // Note: The SQL column is still named `ollama_url` for backward compatibility
+            // with older databases. The Rust-side field was renamed to `backend_url`.
+            // A future migration could rename the column, but ALTER TABLE RENAME COLUMN
+            // requires SQLite 3.25+.
             let id = uuid::Uuid::new_v4().to_string();
             conn.execute(
                 "INSERT INTO nodes (id, node_id, hostname, ollama_url, gpu, vram_mb, ram_mb,
@@ -502,7 +533,7 @@ impl NodeDb {
         &self,
         id: &str,
         bytes_downloaded: u64,
-        status: &str,
+        status: &DownloadStatus,
     ) -> Result<bool> {
         let conn = self
             .conn
@@ -511,7 +542,7 @@ impl NodeDb {
         let now = chrono::Utc::now().to_rfc3339();
         let rows = conn.execute(
             "UPDATE model_downloads SET bytes_downloaded = ?1, status = ?2, updated_at = ?3 WHERE id = ?4",
-            rusqlite::params![bytes_downloaded as i64, status, now, id],
+            rusqlite::params![bytes_downloaded as i64, status.to_string(), now, id],
         )?;
         Ok(rows > 0)
     }
@@ -579,6 +610,7 @@ impl NodeDb {
     }
 
     fn row_to_download(row: &rusqlite::Row) -> rusqlite::Result<ModelDownload> {
+        let status_str: String = row.get(7)?;
         Ok(ModelDownload {
             id: row.get(0)?,
             node_id: row.get(1)?,
@@ -587,7 +619,7 @@ impl NodeDb {
             target_path: row.get(4)?,
             bytes_downloaded: row.get::<_, i64>(5)? as u64,
             total_bytes: row.get::<_, i64>(6)? as u64,
-            status: row.get(7)?,
+            status: DownloadStatus::from_str(&status_str),
             created_at: row.get(8)?,
             updated_at: row.get(9)?,
         })
@@ -846,22 +878,22 @@ mod tests {
         let dl = db.get_download(&dl_id).unwrap().unwrap();
         assert_eq!(dl.node_id, node_id);
         assert_eq!(dl.file_name, "file.gguf");
-        assert_eq!(dl.status, "pending");
+        assert_eq!(dl.status, DownloadStatus::Pending);
         assert_eq!(dl.bytes_downloaded, 0);
         assert_eq!(dl.total_bytes, 5_000_000_000);
 
         // Update progress
-        db.update_download_progress(&dl_id, 1_000_000_000, "downloading")
+        db.update_download_progress(&dl_id, 1_000_000_000, &DownloadStatus::Downloading)
             .unwrap();
         let dl2 = db.get_download(&dl_id).unwrap().unwrap();
         assert_eq!(dl2.bytes_downloaded, 1_000_000_000);
-        assert_eq!(dl2.status, "downloading");
+        assert_eq!(dl2.status, DownloadStatus::Downloading);
 
         // Complete
-        db.update_download_progress(&dl_id, 5_000_000_000, "completed")
+        db.update_download_progress(&dl_id, 5_000_000_000, &DownloadStatus::Completed)
             .unwrap();
         let dl3 = db.get_download(&dl_id).unwrap().unwrap();
-        assert_eq!(dl3.status, "completed");
+        assert_eq!(dl3.status, DownloadStatus::Completed);
         assert_eq!(dl3.bytes_downloaded, 5_000_000_000);
 
         // List downloads
@@ -894,5 +926,25 @@ mod tests {
         // Verify the table exists by listing downloads (should be empty, not error)
         let downloads = db.list_downloads(None).unwrap();
         assert!(downloads.is_empty());
+    }
+
+    #[test]
+    fn download_status_display_and_parse() {
+        assert_eq!(DownloadStatus::Pending.to_string(), "pending");
+        assert_eq!(DownloadStatus::Downloading.to_string(), "downloading");
+        assert_eq!(DownloadStatus::Completed.to_string(), "completed");
+        assert_eq!(DownloadStatus::Failed.to_string(), "failed");
+
+        assert_eq!(DownloadStatus::from_str("pending"), DownloadStatus::Pending);
+        assert_eq!(
+            DownloadStatus::from_str("downloading"),
+            DownloadStatus::Downloading
+        );
+        assert_eq!(
+            DownloadStatus::from_str("completed"),
+            DownloadStatus::Completed
+        );
+        assert_eq!(DownloadStatus::from_str("failed"), DownloadStatus::Failed);
+        assert_eq!(DownloadStatus::from_str("unknown"), DownloadStatus::Pending);
     }
 }

--- a/src/nodes/db.rs
+++ b/src/nodes/db.rs
@@ -64,17 +64,25 @@ impl NodeDb {
     }
 
     /// Map a SELECT row (21 columns, node_id at index 1) to a Node struct.
-    /// Column order: id, node_id, hostname, ollama_url, gpu, vram_mb, ram_mb,
+    /// Column order: id, node_id, hostname, ollama_url (→ backend_url), gpu, vram_mb, ram_mb,
     ///   max_concurrent, ollama_version, os, status, priority, enabled, tags,
     ///   models_available, models_loaded, recommended_config, config_applied,
     ///   last_health_check, registered_at, updated_at
+    /// NOTE: Full schema migration happens in Task 3. This is a minimal bridge
+    /// that reads the old column into backend_url and defaults new fields.
     fn row_to_node(row: &rusqlite::Row) -> rusqlite::Result<Node> {
         Ok(Node {
             id: row.get(0)?,
             node_id: row.get(1)?,
             hostname: row.get(2)?,
-            ollama_url: row.get(3)?,
+            backend_url: row.get(3)?,
+            backend: crate::config::BackendType::default(),
+            backend_version: None,
             gpu: row.get(4)?,
+            gpu_vendor: None,
+            gpu_model: None,
+            gpu_backend: None,
+            cuda_version: None,
             vram_mb: row.get::<_, i32>(5)? as u32,
             ram_mb: row.get::<_, i32>(6)? as u32,
             max_concurrent: row.get::<_, i32>(7)? as u32,
@@ -87,6 +95,8 @@ impl NodeDb {
             models_available: row.get::<_, i32>(14)? as u32,
             models_loaded: serde_json::from_str(&row.get::<_, String>(15)?)
                 .unwrap_or_default(),
+            model_paths: Vec::new(),
+            capabilities: Vec::new(),
             recommended_config: serde_json::from_str(&row.get::<_, String>(16)?)
                 .unwrap_or_default(),
             config_applied: row.get::<_, i32>(17)? != 0,
@@ -155,7 +165,7 @@ impl NodeDb {
                     node_id = COALESCE(?14, node_id), hostname = ?15
                 WHERE id = ?13",
                 rusqlite::params![
-                    reg.ollama_url,
+                    reg.effective_url().to_string(),
                     reg.gpu,
                     reg.vram_mb,
                     reg.ram_mb,
@@ -186,7 +196,7 @@ impl NodeDb {
                     id,
                     reg.node_id,
                     reg.hostname,
-                    reg.ollama_url,
+                    reg.effective_url().to_string(),
                     reg.gpu,
                     reg.vram_mb,
                     reg.ram_mb,

--- a/src/nodes/health.rs
+++ b/src/nodes/health.rs
@@ -130,8 +130,7 @@ impl NodeHealthPoller {
                 if let Some(mut state) = pool.get(&backend_name).await {
                     state.config = backend;
                     state.models = node.models_loaded.clone();
-                    state.healthy =
-                        node.status == "healthy" || node.status == "degraded";
+                    state.healthy = node.status == "healthy" || node.status == "degraded";
                     if node.vram_mb > 0 {
                         state.vram_total_mb = Some(node.vram_mb as u64);
                         state.vram_populated = true;
@@ -174,7 +173,7 @@ impl NodeHealthPoller {
         let base_url = node.backend_url.trim_end_matches('/');
 
         match node.backend {
-            crate::config::BackendType::LlamaServer => {
+            crate::config::BackendType::LlamaServer | crate::config::BackendType::OpenAICompat => {
                 self.poll_llama_server(node_db, node, base_url).await;
             }
             crate::config::BackendType::Ollama => {
@@ -222,11 +221,7 @@ impl NodeHealthPoller {
                 if let Err(e) =
                     node_db.update_health(&node.id, status, &models_loaded, models_available)
                 {
-                    tracing::error!(
-                        "Failed to update health for node {}: {}",
-                        node.hostname,
-                        e
-                    );
+                    tracing::error!("Failed to update health for node {}: {}", node.hostname, e);
                 }
             }
             Ok(resp) => {
@@ -243,11 +238,7 @@ impl NodeHealthPoller {
                     "unreachable"
                 };
                 if let Err(e) = node_db.update_health(&node.id, new_status, &[], None) {
-                    tracing::error!(
-                        "Failed to update health for node {}: {}",
-                        node.hostname,
-                        e
-                    );
+                    tracing::error!("Failed to update health for node {}: {}", node.hostname, e);
                 }
             }
             Err(e) => {
@@ -263,22 +254,13 @@ impl NodeHealthPoller {
                     _ => "unreachable",
                 };
                 if let Err(e) = node_db.update_health(&node.id, new_status, &[], None) {
-                    tracing::error!(
-                        "Failed to update health for node {}: {}",
-                        node.hostname,
-                        e
-                    );
+                    tracing::error!("Failed to update health for node {}: {}", node.hostname, e);
                 }
             }
         }
     }
 
-    async fn poll_llama_server(
-        &self,
-        node_db: &NodeDb,
-        node: &crate::nodes::Node,
-        base_url: &str,
-    ) {
+    async fn poll_llama_server(&self, node_db: &NodeDb, node: &crate::nodes::Node, base_url: &str) {
         // GET /health — server health status
         let health_url = format!("{}/health", base_url);
         let health_result = self.client.get(&health_url).send().await;
@@ -320,11 +302,7 @@ impl NodeHealthPoller {
                 if let Err(e) =
                     node_db.update_health(&node.id, "healthy", &models_loaded, models_available)
                 {
-                    tracing::error!(
-                        "Failed to update health for node {}: {}",
-                        node.hostname,
-                        e
-                    );
+                    tracing::error!("Failed to update health for node {}: {}", node.hostname, e);
                 }
             }
             Ok(resp) => {
@@ -340,11 +318,7 @@ impl NodeHealthPoller {
                     "unreachable"
                 };
                 if let Err(e) = node_db.update_health(&node.id, new_status, &[], None) {
-                    tracing::error!(
-                        "Failed to update health for node {}: {}",
-                        node.hostname,
-                        e
-                    );
+                    tracing::error!("Failed to update health for node {}: {}", node.hostname, e);
                 }
             }
             Err(e) => {
@@ -360,11 +334,7 @@ impl NodeHealthPoller {
                     _ => "unreachable",
                 };
                 if let Err(e) = node_db.update_health(&node.id, new_status, &[], None) {
-                    tracing::error!(
-                        "Failed to update health for node {}: {}",
-                        node.hostname,
-                        e
-                    );
+                    tracing::error!("Failed to update health for node {}: {}", node.hostname, e);
                 }
             }
         }

--- a/src/nodes/health.rs
+++ b/src/nodes/health.rs
@@ -29,6 +29,24 @@ struct OllamaTagModel {
     name: String,
 }
 
+/// llama-server /v1/models response (OpenAI format)
+#[derive(Debug, Deserialize)]
+struct LlamaServerModelsResponse {
+    #[serde(default)]
+    data: Vec<LlamaServerModel>,
+}
+
+#[derive(Debug, Deserialize)]
+struct LlamaServerModel {
+    id: String,
+}
+
+/// llama-server /health response
+#[derive(Debug, Deserialize)]
+struct LlamaServerHealthResponse {
+    status: String,
+}
+
 pub struct NodeHealthPoller {
     client: reqwest::Client,
     poll_interval: Duration,
@@ -101,6 +119,7 @@ impl NodeHealthPoller {
             let backend = crate::config::Backend {
                 name: backend_name.clone(),
                 url: node.backend_url.clone(),
+                backend: node.backend,
                 priority: node.priority,
                 tags: node.tags.clone(),
                 ..Default::default()
@@ -154,6 +173,23 @@ impl NodeHealthPoller {
     async fn poll_node(&self, node_db: &NodeDb, node: &crate::nodes::Node, check_tags: bool) {
         let base_url = node.backend_url.trim_end_matches('/');
 
+        match node.backend {
+            crate::config::BackendType::LlamaServer => {
+                self.poll_llama_server(node_db, node, base_url).await;
+            }
+            crate::config::BackendType::Ollama => {
+                self.poll_ollama(node_db, node, base_url, check_tags).await;
+            }
+        }
+    }
+
+    async fn poll_ollama(
+        &self,
+        node_db: &NodeDb,
+        node: &crate::nodes::Node,
+        base_url: &str,
+        check_tags: bool,
+    ) {
         // GET /api/ps — loaded models
         let ps_url = format!("{}/api/ps", base_url);
         let ps_result = self.client.get(&ps_url).send().await;
@@ -235,5 +271,129 @@ impl NodeHealthPoller {
                 }
             }
         }
+    }
+
+    async fn poll_llama_server(
+        &self,
+        node_db: &NodeDb,
+        node: &crate::nodes::Node,
+        base_url: &str,
+    ) {
+        // GET /health — server health status
+        let health_url = format!("{}/health", base_url);
+        let health_result = self.client.get(&health_url).send().await;
+
+        match health_result {
+            Ok(resp) if resp.status().is_success() => {
+                let is_ok = match resp.json::<LlamaServerHealthResponse>().await {
+                    Ok(h) => h.status == "ok",
+                    Err(_) => true, // 200 is good enough
+                };
+
+                if !is_ok {
+                    // Server is loading — mark degraded
+                    if let Err(e) =
+                        node_db.update_health(&node.id, "degraded", &node.models_loaded, None)
+                    {
+                        tracing::error!(
+                            "Failed to update health for node {}: {}",
+                            node.hostname,
+                            e
+                        );
+                    }
+                    return;
+                }
+
+                // GET /v1/models — loaded models
+                let models_url = format!("{}/v1/models", base_url);
+                let models_loaded: Vec<String> = match self.client.get(&models_url).send().await {
+                    Ok(r) if r.status().is_success() => {
+                        match r.json::<LlamaServerModelsResponse>().await {
+                            Ok(m) => m.data.into_iter().map(|d| d.id).collect(),
+                            Err(_) => node.models_loaded.clone(),
+                        }
+                    }
+                    _ => node.models_loaded.clone(),
+                };
+
+                let models_available = Some(models_loaded.len() as u32);
+                if let Err(e) =
+                    node_db.update_health(&node.id, "healthy", &models_loaded, models_available)
+                {
+                    tracing::error!(
+                        "Failed to update health for node {}: {}",
+                        node.hostname,
+                        e
+                    );
+                }
+            }
+            Ok(resp) => {
+                tracing::warn!(
+                    "Node {} ({}) returned status {} from /health",
+                    node.hostname,
+                    base_url,
+                    resp.status()
+                );
+                let new_status = if node.status == "healthy" || node.status == "degraded" {
+                    "degraded"
+                } else {
+                    "unreachable"
+                };
+                if let Err(e) = node_db.update_health(&node.id, new_status, &[], None) {
+                    tracing::error!(
+                        "Failed to update health for node {}: {}",
+                        node.hostname,
+                        e
+                    );
+                }
+            }
+            Err(e) => {
+                tracing::warn!(
+                    "Node {} ({}) health check failed: {}",
+                    node.hostname,
+                    base_url,
+                    e
+                );
+                let new_status = match node.status.as_str() {
+                    "healthy" => "degraded",
+                    "degraded" => "unreachable",
+                    _ => "unreachable",
+                };
+                if let Err(e) = node_db.update_health(&node.id, new_status, &[], None) {
+                    tracing::error!(
+                        "Failed to update health for node {}: {}",
+                        node.hostname,
+                        e
+                    );
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_llama_server_models_response() {
+        let json = r#"{"object":"list","data":[{"id":"gemma-4-26B","object":"model","owned_by":"llamacpp"}]}"#;
+        let resp: LlamaServerModelsResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.data.len(), 1);
+        assert_eq!(resp.data[0].id, "gemma-4-26B");
+    }
+
+    #[test]
+    fn parse_llama_server_health_response() {
+        let json = r#"{"status":"ok"}"#;
+        let resp: LlamaServerHealthResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.status, "ok");
+    }
+
+    #[test]
+    fn parse_llama_server_health_loading() {
+        let json = r#"{"status":"loading model"}"#;
+        let resp: LlamaServerHealthResponse = serde_json::from_str(json).unwrap();
+        assert_ne!(resp.status, "ok");
     }
 }

--- a/src/nodes/health.rs
+++ b/src/nodes/health.rs
@@ -100,7 +100,7 @@ impl NodeHealthPoller {
             let backend_name = format!("node:{}", node.hostname);
             let backend = crate::config::Backend {
                 name: backend_name.clone(),
-                url: node.ollama_url.clone(),
+                url: node.backend_url.clone(),
                 priority: node.priority,
                 tags: node.tags.clone(),
                 ..Default::default()
@@ -131,7 +131,7 @@ impl NodeHealthPoller {
                 tracing::info!(
                     "Added node backend {} to pool ({})",
                     backend_name,
-                    node.ollama_url
+                    node.backend_url
                 );
             }
         }
@@ -152,7 +152,7 @@ impl NodeHealthPoller {
     }
 
     async fn poll_node(&self, node_db: &NodeDb, node: &crate::nodes::Node, check_tags: bool) {
-        let base_url = node.ollama_url.trim_end_matches('/');
+        let base_url = node.backend_url.trim_end_matches('/');
 
         // GET /api/ps — loaded models
         let ps_url = format!("{}/api/ps", base_url);

--- a/src/nodes/mod.rs
+++ b/src/nodes/mod.rs
@@ -2,6 +2,6 @@ pub mod db;
 pub mod health;
 pub mod types;
 
-pub use db::{ModelDownload, NodeDb};
+pub use db::{DownloadStatus, ModelDownload, NodeDb};
 pub use health::NodeHealthPoller;
 pub use types::*;

--- a/src/nodes/mod.rs
+++ b/src/nodes/mod.rs
@@ -2,6 +2,6 @@ pub mod db;
 pub mod health;
 pub mod types;
 
-pub use db::NodeDb;
+pub use db::{ModelDownload, NodeDb};
 pub use health::NodeHealthPoller;
 pub use types::*;

--- a/src/nodes/types.rs
+++ b/src/nodes/types.rs
@@ -1,25 +1,70 @@
+use crate::config::BackendType;
 use serde::{Deserialize, Serialize};
 
 /// Registration payload from herd-tune scripts
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct NodeRegistration {
     pub hostname: String,
+
+    /// Legacy field — used by Ollama backends. For llama-server, use backend_url.
+    #[serde(default)]
     pub ollama_url: String,
+
+    /// Preferred URL field for all backend types. Falls back to ollama_url if not set.
+    #[serde(default)]
+    pub backend_url: Option<String>,
+
+    /// Backend type: "ollama" (default) or "llama-server"
+    #[serde(default)]
+    pub backend: BackendType,
+
     /// Stable machine identifier (preferred over hostname for upsert).
     #[serde(default)]
     pub node_id: Option<String>,
+
     #[serde(default)]
     pub gpu: Option<String>,
+
+    /// GPU vendor: "nvidia", "amd", "intel", "none"
+    #[serde(default)]
+    pub gpu_vendor: Option<String>,
+
+    /// GPU model name (e.g., "NVIDIA GeForce RTX 5090")
+    #[serde(default)]
+    pub gpu_model: Option<String>,
+
+    /// GPU compute backend: "cuda", "rocm", "sycl", "vulkan", "cpu"
+    #[serde(default)]
+    pub gpu_backend: Option<String>,
+
+    /// CUDA version (NVIDIA only, e.g., "13.1")
+    #[serde(default)]
+    pub cuda_version: Option<String>,
+
     #[serde(default)]
     pub vram_mb: u32,
     #[serde(default)]
     pub ram_mb: u32,
     #[serde(default)]
     pub ollama_version: Option<String>,
+
+    /// llama.cpp build version (e.g., "b8678")
+    #[serde(default)]
+    pub backend_version: Option<String>,
+
     #[serde(default)]
     pub models_available: u32,
     #[serde(default)]
     pub models_loaded: Vec<String>,
+
+    /// GGUF file paths (llama-server only)
+    #[serde(default)]
+    pub model_paths: Vec<String>,
+
+    /// Capabilities: ["cuda", "flash_attn", "moe", etc.]
+    #[serde(default)]
+    pub capabilities: Vec<String>,
+
     #[serde(default)]
     pub recommended_config: serde_json::Value,
     #[serde(default)]
@@ -32,14 +77,58 @@ pub struct NodeRegistration {
     pub registered_at: Option<String>,
 }
 
+impl NodeRegistration {
+    /// Returns the effective backend URL, preferring backend_url over ollama_url.
+    pub fn effective_url(&self) -> &str {
+        self.backend_url.as_deref().unwrap_or(&self.ollama_url)
+    }
+}
+
+impl Default for NodeRegistration {
+    fn default() -> Self {
+        Self {
+            hostname: String::new(),
+            ollama_url: String::new(),
+            backend_url: None,
+            backend: BackendType::default(),
+            node_id: None,
+            gpu: None,
+            gpu_vendor: None,
+            gpu_model: None,
+            gpu_backend: None,
+            cuda_version: None,
+            vram_mb: 0,
+            ram_mb: 0,
+            ollama_version: None,
+            backend_version: None,
+            models_available: 0,
+            models_loaded: Vec::new(),
+            model_paths: Vec::new(),
+            capabilities: Vec::new(),
+            recommended_config: serde_json::Value::Object(Default::default()),
+            config_applied: false,
+            herd_tune_version: None,
+            os: None,
+            registered_at: None,
+        }
+    }
+}
+
 /// Stored node record from SQLite
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Node {
     pub id: String,
     pub node_id: Option<String>,
     pub hostname: String,
-    pub ollama_url: String,
+    /// Effective backend URL (unified field)
+    pub backend_url: String,
+    pub backend: BackendType,
+    pub backend_version: Option<String>,
     pub gpu: Option<String>,
+    pub gpu_vendor: Option<String>,
+    pub gpu_model: Option<String>,
+    pub gpu_backend: Option<String>,
+    pub cuda_version: Option<String>,
     pub vram_mb: u32,
     pub ram_mb: u32,
     pub max_concurrent: u32,
@@ -51,6 +140,8 @@ pub struct Node {
     pub tags: Vec<String>,
     pub models_available: u32,
     pub models_loaded: Vec<String>,
+    pub model_paths: Vec<String>,
+    pub capabilities: Vec<String>,
     pub recommended_config: serde_json::Value,
     pub config_applied: bool,
     pub last_health_check: Option<String>,
@@ -73,4 +164,79 @@ pub struct NodeRegistrationResponse {
     pub hostname: String,
     pub status: String,
     pub message: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn node_registration_defaults_to_ollama_backend() {
+        let json = r#"{
+            "hostname": "test",
+            "ollama_url": "http://test:11434"
+        }"#;
+        let reg: NodeRegistration = serde_json::from_str(json).unwrap();
+        assert_eq!(reg.backend, crate::config::BackendType::Ollama);
+        assert!(reg.backend_url.is_none());
+    }
+
+    #[test]
+    fn node_registration_llama_server_fields() {
+        let json = r#"{
+            "hostname": "citadel",
+            "backend": "llama-server",
+            "backend_url": "http://citadel:8090",
+            "gpu_vendor": "nvidia",
+            "gpu_model": "NVIDIA GeForce RTX 5090",
+            "gpu_backend": "cuda",
+            "cuda_version": "13.1",
+            "vram_mb": 32768,
+            "ram_mb": 131072,
+            "models_loaded": ["gemma-4-26B.gguf"],
+            "capabilities": ["cuda", "flash_attn"]
+        }"#;
+        let reg: NodeRegistration = serde_json::from_str(json).unwrap();
+        assert_eq!(reg.backend, crate::config::BackendType::LlamaServer);
+        assert_eq!(reg.backend_url.as_deref(), Some("http://citadel:8090"));
+        assert_eq!(reg.gpu_vendor.as_deref(), Some("nvidia"));
+        assert_eq!(reg.capabilities, vec!["cuda", "flash_attn"]);
+    }
+
+    #[test]
+    fn node_registration_backward_compat_ollama() {
+        // Old herd-tune scripts only send ollama_url, no backend field
+        let json = r#"{
+            "hostname": "minipc",
+            "ollama_url": "http://minipc:11434",
+            "ollama_version": "0.16.1",
+            "models_available": 42,
+            "models_loaded": ["qwen3:32b"]
+        }"#;
+        let reg: NodeRegistration = serde_json::from_str(json).unwrap();
+        assert_eq!(reg.backend, crate::config::BackendType::Ollama);
+        assert_eq!(reg.ollama_url, "http://minipc:11434");
+        assert!(reg.backend_url.is_none());
+    }
+
+    #[test]
+    fn effective_url_prefers_backend_url() {
+        let reg = NodeRegistration {
+            hostname: "test".to_string(),
+            ollama_url: "http://test:11434".to_string(),
+            backend_url: Some("http://test:8090".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(reg.effective_url(), "http://test:8090");
+    }
+
+    #[test]
+    fn effective_url_falls_back_to_ollama_url() {
+        let reg = NodeRegistration {
+            hostname: "test".to_string(),
+            ollama_url: "http://test:11434".to_string(),
+            ..Default::default()
+        };
+        assert_eq!(reg.effective_url(), "http://test:11434");
+    }
 }

--- a/src/nodes/types.rs
+++ b/src/nodes/types.rs
@@ -1,5 +1,6 @@
 use crate::config::BackendType;
 use serde::{Deserialize, Serialize};
+use std::path::Path;
 
 /// Registration payload from herd-tune scripts
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -65,6 +66,14 @@ pub struct NodeRegistration {
     #[serde(default)]
     pub capabilities: Vec<String>,
 
+    /// GPU driver version string (e.g., "572.83")
+    #[serde(default)]
+    pub gpu_driver_version: Option<String>,
+
+    /// Max context length the backend supports
+    #[serde(default = "default_max_context_len")]
+    pub max_context_len: u32,
+
     #[serde(default)]
     pub recommended_config: serde_json::Value,
     #[serde(default)]
@@ -75,6 +84,10 @@ pub struct NodeRegistration {
     pub os: Option<String>,
     #[serde(default)]
     pub registered_at: Option<String>,
+}
+
+fn default_max_context_len() -> u32 {
+    4096
 }
 
 impl NodeRegistration {
@@ -105,6 +118,8 @@ impl Default for NodeRegistration {
             models_loaded: Vec::new(),
             model_paths: Vec::new(),
             capabilities: Vec::new(),
+            gpu_driver_version: None,
+            max_context_len: 4096,
             recommended_config: serde_json::Value::Object(Default::default()),
             config_applied: false,
             herd_tune_version: None,
@@ -142,11 +157,46 @@ pub struct Node {
     pub models_loaded: Vec<String>,
     pub model_paths: Vec<String>,
     pub capabilities: Vec<String>,
+    pub gpu_driver_version: Option<String>,
+    pub max_context_len: u32,
     pub recommended_config: serde_json::Value,
     pub config_applied: bool,
     pub last_health_check: Option<String>,
     pub registered_at: String,
     pub updated_at: String,
+}
+
+/// Entry in a node's model registry, derived from model_paths and models_loaded.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ModelRegistryEntry {
+    pub file_name: String,
+    pub file_path: String,
+    pub file_size_bytes: Option<u64>,
+    pub loaded: bool,
+}
+
+impl Node {
+    /// For llama-server nodes, compute model registry from model_paths + models_loaded.
+    pub fn model_registry(&self) -> Vec<ModelRegistryEntry> {
+        self.model_paths
+            .iter()
+            .map(|path| {
+                let file_name = Path::new(path)
+                    .file_name()
+                    .map(|f| f.to_string_lossy().to_string())
+                    .unwrap_or_else(|| path.clone());
+                let loaded = self.models_loaded.iter().any(|m| {
+                    m == &file_name || m == path || file_name.contains(m) || m.contains(&file_name)
+                });
+                ModelRegistryEntry {
+                    file_name,
+                    file_path: path.clone(),
+                    file_size_bytes: None,
+                    loaded,
+                }
+            })
+            .collect()
+    }
 }
 
 /// Update payload for PUT /api/nodes/:id

--- a/src/nodes/types.rs
+++ b/src/nodes/types.rs
@@ -185,9 +185,10 @@ impl Node {
                     .file_name()
                     .map(|f| f.to_string_lossy().to_string())
                     .unwrap_or_else(|| path.clone());
-                let loaded = self.models_loaded.iter().any(|m| {
-                    m == &file_name || m == path || file_name.contains(m) || m.contains(&file_name)
-                });
+                let loaded = self
+                    .models_loaded
+                    .iter()
+                    .any(|m| m == &file_name || m == path);
                 ModelRegistryEntry {
                     file_name,
                     file_path: path.clone(),
@@ -288,5 +289,104 @@ mod tests {
             ..Default::default()
         };
         assert_eq!(reg.effective_url(), "http://test:11434");
+    }
+
+    #[test]
+    fn model_registry_exact_match_only() {
+        let node = Node {
+            id: "test".to_string(),
+            node_id: None,
+            hostname: "test".to_string(),
+            backend_url: "http://test:8090".to_string(),
+            backend: crate::config::BackendType::LlamaServer,
+            backend_version: None,
+            gpu: None,
+            gpu_vendor: None,
+            gpu_model: None,
+            gpu_backend: None,
+            cuda_version: None,
+            vram_mb: 0,
+            ram_mb: 0,
+            max_concurrent: 1,
+            ollama_version: None,
+            os: None,
+            status: "healthy".to_string(),
+            priority: 10,
+            enabled: true,
+            tags: vec![],
+            models_available: 0,
+            models_loaded: vec!["qwen".to_string()],
+            model_paths: vec![
+                "/models/qwen3-32b.gguf".to_string(),
+                "/models/qwen.gguf".to_string(),
+            ],
+            capabilities: vec![],
+            gpu_driver_version: None,
+            max_context_len: 4096,
+            recommended_config: serde_json::Value::Object(Default::default()),
+            config_applied: false,
+            last_health_check: None,
+            registered_at: "2026-01-01T00:00:00Z".to_string(),
+            updated_at: "2026-01-01T00:00:00Z".to_string(),
+        };
+        let registry = node.model_registry();
+        // "qwen" should NOT match "qwen3-32b.gguf" (no contains matching)
+        assert!(
+            !registry[0].loaded,
+            "qwen3-32b.gguf should not match 'qwen'"
+        );
+        // "qwen" SHOULD match "qwen.gguf" (exact filename match — but filename is "qwen.gguf", not "qwen")
+        assert!(
+            !registry[1].loaded,
+            "qwen.gguf filename does not exactly match 'qwen'"
+        );
+    }
+
+    #[test]
+    fn model_registry_matches_by_path() {
+        let node = Node {
+            id: "test".to_string(),
+            node_id: None,
+            hostname: "test".to_string(),
+            backend_url: "http://test:8090".to_string(),
+            backend: crate::config::BackendType::LlamaServer,
+            backend_version: None,
+            gpu: None,
+            gpu_vendor: None,
+            gpu_model: None,
+            gpu_backend: None,
+            cuda_version: None,
+            vram_mb: 0,
+            ram_mb: 0,
+            max_concurrent: 1,
+            ollama_version: None,
+            os: None,
+            status: "healthy".to_string(),
+            priority: 10,
+            enabled: true,
+            tags: vec![],
+            models_available: 0,
+            models_loaded: vec![
+                "gemma-4-26B.gguf".to_string(),
+                "/models/qwen3-32b.gguf".to_string(),
+            ],
+            model_paths: vec![
+                "/models/gemma-4-26B.gguf".to_string(),
+                "/models/qwen3-32b.gguf".to_string(),
+            ],
+            capabilities: vec![],
+            gpu_driver_version: None,
+            max_context_len: 4096,
+            recommended_config: serde_json::Value::Object(Default::default()),
+            config_applied: false,
+            last_health_check: None,
+            registered_at: "2026-01-01T00:00:00Z".to_string(),
+            updated_at: "2026-01-01T00:00:00Z".to_string(),
+        };
+        let registry = node.model_registry();
+        // Match by filename
+        assert!(registry[0].loaded, "gemma-4-26B.gguf matches by filename");
+        // Match by full path
+        assert!(registry[1].loaded, "/models/qwen3-32b.gguf matches by path");
     }
 }

--- a/src/router/least_busy.rs
+++ b/src/router/least_busy.rs
@@ -23,7 +23,9 @@ impl Router for LeastBusyRouter {
         excluded: &HashSet<String>,
     ) -> anyhow::Result<RoutedBackend> {
         let backend = if let Some(tags) = tags {
-            self.pool.get_least_busy_tagged_excluding(tags, excluded).await
+            self.pool
+                .get_least_busy_tagged_excluding(tags, excluded)
+                .await
         } else {
             self.pool.get_least_busy_excluding(excluded).await
         }

--- a/src/router/model_aware.rs
+++ b/src/router/model_aware.rs
@@ -46,7 +46,9 @@ impl Router for ModelAwareRouter {
 
         // Fall back to highest priority healthy backend
         let backend = if let Some(tags) = tags {
-            self.pool.get_by_priority_tagged_excluding(tags, excluded).await
+            self.pool
+                .get_by_priority_tagged_excluding(tags, excluded)
+                .await
         } else {
             self.pool.get_by_priority_excluding(excluded).await
         }
@@ -147,5 +149,50 @@ mod tests {
         let result = router.route(Some("llama3"), None).await.unwrap();
         // Should pick gpu2 (least busy) despite gpu1 having higher priority
         assert_eq!(result.name, "gpu2");
+    }
+
+    #[tokio::test]
+    async fn mixed_fleet_routes_to_correct_backend() {
+        // Simulate a mixed fleet: Ollama node with many models, llama-server with one model
+        let ollama_backend = Backend {
+            name: "ollama-node".into(),
+            url: "http://ollama:11434".into(),
+            priority: 100,
+            backend: crate::config::BackendType::Ollama,
+            ..Default::default()
+        };
+        let llama_backend = Backend {
+            name: "llama-node".into(),
+            url: "http://llama:8090".into(),
+            priority: 50,
+            backend: crate::config::BackendType::LlamaServer,
+            ..Default::default()
+        };
+
+        let pool = BackendPool::new(
+            vec![ollama_backend, llama_backend],
+            3,
+            Duration::from_secs(60),
+        );
+
+        // Ollama has many models, llama-server has only one
+        pool.update_models("ollama-node", vec!["llama3:8b".into(), "mistral:7b".into()])
+            .await;
+        pool.update_models("llama-node", vec!["qwen2:14b".into()])
+            .await;
+
+        let router = ModelAwareRouter::new(pool);
+
+        // Request for qwen2:14b should route to llama-node (only node with it)
+        let result = router.route(Some("qwen2:14b"), None).await.unwrap();
+        assert_eq!(result.name, "llama-node");
+
+        // Request for llama3:8b should route to ollama-node (only node with it)
+        let result = router.route(Some("llama3:8b"), None).await.unwrap();
+        assert_eq!(result.name, "ollama-node");
+
+        // Request for unknown model falls back to priority (ollama-node has 100)
+        let result = router.route(Some("unknown:model"), None).await.unwrap();
+        assert_eq!(result.name, "ollama-node");
     }
 }

--- a/src/router/priority.rs
+++ b/src/router/priority.rs
@@ -23,7 +23,9 @@ impl Router for PriorityRouter {
         excluded: &HashSet<String>,
     ) -> anyhow::Result<RoutedBackend> {
         let backend = if let Some(tags) = tags {
-            self.pool.get_by_priority_tagged_excluding(tags, excluded).await
+            self.pool
+                .get_by_priority_tagged_excluding(tags, excluded)
+                .await
         } else {
             self.pool.get_by_priority_excluding(excluded).await
         }

--- a/src/server.rs
+++ b/src/server.rs
@@ -782,9 +782,10 @@ async fn proxy_handler(
         }
     }
 
-    // Inject keep_alive for Ollama-native endpoints
+    // Prepare both versions of the body — keep_alive is Ollama-specific
     let keep_alive_value = state.config.read().await.routing.default_keep_alive.clone();
-    let forward_bytes = inject_keep_alive(&body_bytes, &path, &keep_alive_value);
+    let forward_bytes_ollama = inject_keep_alive(&body_bytes, &path, &keep_alive_value);
+    let forward_bytes_raw = body_bytes.clone();
 
     // Extract tags from X-Herd-Tags header (comma-separated)
     let tags: Option<Vec<String>> = headers
@@ -815,11 +816,24 @@ async fn proxy_handler(
         selected_backend = Some(backend.name.clone());
         let url = format!("{}{}", backend.url, path_and_query);
 
+        // Only inject keep_alive for Ollama backends
+        let forward_bytes = if state
+            .pool
+            .get(&backend.name)
+            .await
+            .map(|s| s.config.backend == crate::config::BackendType::Ollama)
+            .unwrap_or(true)
+        {
+            forward_bytes_ollama.clone()
+        } else {
+            forward_bytes_raw.clone()
+        };
+
         let req_builder = state
             .client
             .request(method.clone(), &url)
             .timeout(state.routing_timeout())
-            .body(forward_bytes.clone());
+            .body(forward_bytes);
         let req_builder = copy_request_headers(&headers, req_builder);
 
         match req_builder.send().await {

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,5 +1,5 @@
-use crate::agent::{AgentAudit, SessionStore};
 use crate::agent::ws as agent_ws;
+use crate::agent::{AgentAudit, SessionStore};
 use crate::analytics::{Analytics, RequestLog};
 use crate::api::{admin, agent, openai};
 use crate::backend::{BackendPool, HealthChecker, ModelDiscovery, ModelWarmer};
@@ -19,6 +19,103 @@ const DEFAULT_ROUTING_TIMEOUT: Duration = Duration::from_secs(120);
 const DEFAULT_CIRCUIT_TIMEOUT: Duration = Duration::from_secs(120);
 const DEFAULT_RECOVERY_TIME: Duration = Duration::from_secs(60);
 const MAX_PROXY_BODY_BYTES: usize = 10 * 1024 * 1024; // 10 MB
+
+// ---------------------------------------------------------------------------
+// Token extraction from proxy responses
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Default)]
+struct TokenUsage {
+    tokens_in: Option<u32>,
+    tokens_out: Option<u32>,
+    tokens_per_second: Option<f32>,
+    prompt_eval_ms: Option<u64>,
+    eval_ms: Option<u64>,
+}
+
+/// Extract token usage from a response body based on backend type and request path.
+///
+/// Ollama `/api/generate` and `/api/chat` responses include:
+///   prompt_eval_count, eval_count, prompt_eval_duration, eval_duration
+///
+/// llama-server/OpenAI-compat `/v1/chat/completions` responses include:
+///   usage.prompt_tokens, usage.completion_tokens
+fn extract_tokens_from_response(
+    body: &[u8],
+    path: &str,
+    backend_type: crate::config::BackendType,
+) -> TokenUsage {
+    let Ok(json) = serde_json::from_slice::<serde_json::Value>(body) else {
+        return TokenUsage::default();
+    };
+
+    match backend_type {
+        crate::config::BackendType::Ollama => {
+            if !path.contains("/api/generate") && !path.contains("/api/chat") {
+                return TokenUsage::default();
+            }
+            let tokens_in = json
+                .get("prompt_eval_count")
+                .and_then(|v| v.as_u64())
+                .map(|v| v as u32);
+            let tokens_out = json
+                .get("eval_count")
+                .and_then(|v| v.as_u64())
+                .map(|v| v as u32);
+            let prompt_eval_duration = json.get("prompt_eval_duration").and_then(|v| v.as_u64());
+            let eval_duration = json.get("eval_duration").and_then(|v| v.as_u64());
+
+            let prompt_eval_ms = prompt_eval_duration.map(|d| d / 1_000_000);
+            let eval_ms = eval_duration.map(|d| d / 1_000_000);
+            let tokens_per_second = match (tokens_out, eval_duration) {
+                (Some(count), Some(dur)) if dur > 0 => {
+                    Some(count as f32 / (dur as f32 / 1_000_000_000.0))
+                }
+                _ => None,
+            };
+
+            TokenUsage {
+                tokens_in,
+                tokens_out,
+                tokens_per_second,
+                prompt_eval_ms,
+                eval_ms,
+            }
+        }
+        crate::config::BackendType::LlamaServer | crate::config::BackendType::OpenAICompat => {
+            let usage = json.get("usage");
+            let tokens_in = usage
+                .and_then(|u| u.get("prompt_tokens"))
+                .and_then(|v| v.as_u64())
+                .map(|v| v as u32);
+            let tokens_out = usage
+                .and_then(|u| u.get("completion_tokens"))
+                .and_then(|v| v.as_u64())
+                .map(|v| v as u32);
+            TokenUsage {
+                tokens_in,
+                tokens_out,
+                ..Default::default()
+            }
+        }
+    }
+}
+
+/// Extract the last SSE `data:` line from a chunk of SSE text.
+/// Returns the JSON payload bytes if found.
+fn extract_last_sse_data(chunk: &[u8]) -> Option<Vec<u8>> {
+    let text = std::str::from_utf8(chunk).ok()?;
+    let mut last_data: Option<&str> = None;
+    for line in text.lines() {
+        if let Some(data) = line.strip_prefix("data: ") {
+            let trimmed = data.trim();
+            if trimmed != "[DONE]" && !trimmed.is_empty() {
+                last_data = Some(trimmed);
+            }
+        }
+    }
+    last_data.map(|d| d.as_bytes().to_vec())
+}
 
 pub struct Server {
     config: Config,
@@ -89,7 +186,9 @@ impl AppState {
         let mut restart_warnings: Vec<String> = Vec::new();
         {
             let old = self.config.read().await;
-            if old.server.host != new_config.server.host || old.server.port != new_config.server.port {
+            if old.server.host != new_config.server.host
+                || old.server.port != new_config.server.port
+            {
                 restart_warnings.push("server.host/port".to_string());
             }
             if old.server.rate_limit != new_config.server.rate_limit {
@@ -209,12 +308,8 @@ impl Server {
             self.config.observability.admin_api
         };
 
-        let agent_enabled = if self.config.agent.enabled
-            && self.config.server.api_key.is_none()
-        {
-            tracing::warn!(
-                "agent is enabled but server.api_key is not set — disabling agent API"
-            );
+        let agent_enabled = if self.config.agent.enabled && self.config.server.api_key.is_none() {
+            tracing::warn!("agent is enabled but server.api_key is not set — disabling agent API");
             false
         } else {
             self.config.agent.enabled
@@ -305,7 +400,10 @@ impl Server {
                 .ok_or_else(|| anyhow::anyhow!("Could not find home directory"))?
                 .join(".herd")
                 .join("sessions");
-            Arc::new(SessionStore::persistent(self.config.agent.max_sessions, session_dir)?)
+            Arc::new(SessionStore::persistent(
+                self.config.agent.max_sessions,
+                session_dir,
+            )?)
         } else {
             Arc::new(SessionStore::new(self.config.agent.max_sessions))
         };
@@ -401,6 +499,23 @@ impl Server {
                 axum::routing::get(crate::api::nodes::get_node)
                     .put(crate::api::nodes::update_node)
                     .delete(crate::api::nodes::delete_node),
+            )
+            // Model search and node model management
+            .route(
+                "/api/models/search",
+                axum::routing::get(crate::api::models::search_models),
+            )
+            .route(
+                "/api/nodes/:id/models",
+                axum::routing::get(crate::api::models::list_node_models),
+            )
+            .route(
+                "/api/nodes/:id/models/download",
+                axum::routing::post(crate::api::models::download_model),
+            )
+            .route(
+                "/api/nodes/:id/models/:model_name",
+                axum::routing::delete(crate::api::models::delete_node_model),
             );
 
         // Conditionally mount metrics
@@ -427,8 +542,14 @@ impl Server {
                         .put(admin::update_backend)
                         .delete(admin::remove_backend),
                 )
-                .route("/:name/models", axum::routing::get(admin::list_backend_models))
-                .route("/:name/models/:model", axum::routing::delete(admin::delete_model))
+                .route(
+                    "/:name/models",
+                    axum::routing::get(admin::list_backend_models),
+                )
+                .route(
+                    "/:name/models/:model",
+                    axum::routing::delete(admin::delete_model),
+                )
                 .route("/:name/pull", axum::routing::post(admin::pull_model))
                 .layer(axum::middleware::from_fn_with_state(
                     state.clone(),
@@ -702,8 +823,7 @@ fn copy_request_headers(
 /// Only applies to /api/generate and /api/chat; all other paths and
 /// invalid JSON bodies are returned unchanged.
 fn inject_keep_alive(body: &[u8], path: &str, keep_alive: &str) -> axum::body::Bytes {
-    let is_ollama_endpoint =
-        path.contains("/api/generate") || path.contains("/api/chat");
+    let is_ollama_endpoint = path.contains("/api/generate") || path.contains("/api/chat");
     if !is_ollama_endpoint {
         return axum::body::Bytes::copy_from_slice(body);
     }
@@ -860,7 +980,8 @@ async fn proxy_handler(
                 if matches!(r.status().as_u16(), 500 | 502 | 503) {
                     tracing::warn!(
                         "Backend {} returned {} — retrying on another backend",
-                        backend.name, r.status()
+                        backend.name,
+                        r.status()
                     );
                     state.pool.mark_unhealthy(&backend.name).await;
                     excluded.insert(backend.name.clone());
@@ -870,7 +991,10 @@ async fn proxy_handler(
                 state.pool.mark_healthy(&backend.name).await;
                 response = Some(r);
                 let strategy = state.config_snapshot().await.routing.strategy.to_string();
-                state.metrics.record_routing_selection(&backend.name, &strategy).await;
+                state
+                    .metrics
+                    .record_routing_selection(&backend.name, &strategy)
+                    .await;
                 break;
             }
             Err(e) => {
@@ -893,30 +1017,77 @@ async fn proxy_handler(
     };
 
     // Check for classification result from the classifier middleware
-    let classification = extensions
-        .get::<crate::classifier::ClassificationResult>();
+    let classification = extensions.get::<crate::classifier::ClassificationResult>();
 
-    // Log request
-    let log = RequestLog {
-        timestamp: chrono::Utc::now().timestamp(),
-        model: model_name,
-        backend: selected_backend.unwrap_or_else(|| "none".to_string()),
-        duration_ms: duration.as_millis() as u64,
-        status: status.to_string(),
-        path: path.clone(),
-        request_id: Some(request_id.clone()),
-        tier: classification.map(|c| c.tier.clone()),
-        classified_by: classification.map(|c| c.classified_by.clone()),
+    // Determine backend type for the selected backend
+    let backend_type = if let Some(ref name) = selected_backend {
+        state.pool.get(name).await.map(|s| s.config.backend)
+    } else {
+        None
     };
+    let backend_type_str = backend_type.map(|bt| bt.to_string());
 
-    state
-        .metrics
-        .record_request(&log.backend, &log.status, log.duration_ms)
-        .await;
+    // Helper: build and log the RequestLog + record metrics
+    let log_and_record = |usage: TokenUsage,
+                          state: AppState,
+                          model_name: Option<String>,
+                          selected_backend: String,
+                          duration_ms: u64,
+                          status: String,
+                          path: String,
+                          request_id: String,
+                          tier: Option<String>,
+                          classified_by: Option<String>,
+                          backend_type_str: Option<String>| async move {
+        let log = RequestLog {
+            timestamp: chrono::Utc::now().timestamp(),
+            model: model_name.clone(),
+            backend: selected_backend,
+            duration_ms,
+            status: status.clone(),
+            path,
+            request_id: Some(request_id),
+            tier,
+            classified_by,
+            tokens_in: usage.tokens_in,
+            tokens_out: usage.tokens_out,
+            tokens_per_second: usage.tokens_per_second,
+            prompt_eval_ms: usage.prompt_eval_ms,
+            eval_ms: usage.eval_ms,
+            backend_type: backend_type_str,
+        };
 
-    if let Err(e) = state.analytics.log_request(log).await {
-        tracing::error!("Failed to log request: {}", e);
-    }
+        state
+            .metrics
+            .record_request(&log.backend, &log.status, log.duration_ms)
+            .await;
+
+        // Record token metrics
+        if let (Some(tin), Some(tout)) = (usage.tokens_in, usage.tokens_out) {
+            state
+                .metrics
+                .record_tokens(model_name.as_deref().unwrap_or("unknown"), tin, tout)
+                .await;
+        }
+        if let Some(tps) = usage.tokens_per_second {
+            state.metrics.record_tokens_per_second(tps).await;
+        }
+
+        // Record labeled latency
+        state
+            .metrics
+            .record_request_labeled(
+                &log.backend,
+                model_name.as_deref().unwrap_or("unknown"),
+                &status,
+                log.duration_ms,
+            )
+            .await;
+
+        if let Err(e) = state.analytics.log_request(log).await {
+            tracing::error!("Failed to log request: {}", e);
+        }
+    };
 
     match response {
         Some(r) => {
@@ -937,13 +1108,141 @@ async fn proxy_handler(
                 }
             }
 
-            // Stream the body instead of buffering
-            let body = axum::body::Body::from_stream(r.bytes_stream());
-            builder
-                .body(body)
-                .map_err(|_| axum::http::StatusCode::BAD_GATEWAY)
+            // Detect streaming response by content-type
+            let is_streaming = r
+                .headers()
+                .get(reqwest::header::CONTENT_TYPE)
+                .and_then(|v| v.to_str().ok())
+                .map(|ct| ct.contains("text/event-stream") || ct.contains("application/x-ndjson"))
+                .unwrap_or(false);
+
+            let bt = backend_type.unwrap_or(crate::config::BackendType::Ollama);
+            let selected = selected_backend.unwrap_or_else(|| "none".to_string());
+            let tier = classification.map(|c| c.tier.clone());
+            let classified_by = classification.map(|c| c.classified_by.clone());
+
+            if is_streaming {
+                // Streaming: wrap the byte stream to capture only the last SSE data chunk.
+                // The stream passes through to the client in real-time.
+                let last_data = Arc::new(tokio::sync::Mutex::new(Option::<Vec<u8>>::None));
+                let last_data_capture = last_data.clone();
+
+                let inner_stream = r.bytes_stream();
+                let capturing_stream = futures_util::stream::unfold(
+                    (inner_stream, last_data_capture),
+                    |(mut stream, last_data)| async move {
+                        use futures_util::StreamExt;
+                        match stream.next().await {
+                            Some(Ok(chunk)) => {
+                                // Check if this chunk contains SSE data lines
+                                if let Some(data) = extract_last_sse_data(&chunk) {
+                                    *last_data.lock().await = Some(data);
+                                }
+                                Some((Ok::<_, std::io::Error>(chunk), (stream, last_data)))
+                            }
+                            Some(Err(e)) => {
+                                Some((Err(std::io::Error::other(e)), (stream, last_data)))
+                            }
+                            None => None,
+                        }
+                    },
+                );
+
+                let body = axum::body::Body::from_stream(capturing_stream);
+                let resp = builder
+                    .body(body)
+                    .map_err(|_| axum::http::StatusCode::BAD_GATEWAY)?;
+
+                // Fire-and-forget: extract tokens after stream ends
+                let state_clone = state.clone();
+                let path_clone = path.clone();
+                let model_clone = model_name.clone();
+                let request_id_clone = request_id.clone();
+                let duration_ms = duration.as_millis() as u64;
+                let status_str = status.to_string();
+                let bt_str = backend_type_str.clone();
+                tokio::spawn(async move {
+                    // Wait briefly for stream to complete, then check
+                    // The last_data will be populated as the stream flows
+                    tokio::time::sleep(Duration::from_millis(100)).await;
+                    // Try to get the captured data (may not be available yet for long streams)
+                    // We'll wait up to the routing timeout for the stream to finish
+                    let mut attempts = 0;
+                    loop {
+                        let data = last_data.lock().await.clone();
+                        // The Arc strong count drops to 1 when the stream is done
+                        // (the capturing_stream closure is dropped)
+                        if Arc::strong_count(&last_data) <= 1 || attempts > 600 {
+                            let usage = if let Some(data) = data {
+                                extract_tokens_from_response(&data, &path_clone, bt)
+                            } else {
+                                TokenUsage::default()
+                            };
+                            log_and_record(
+                                usage,
+                                state_clone,
+                                model_clone,
+                                selected,
+                                duration_ms,
+                                status_str,
+                                path_clone,
+                                request_id_clone,
+                                tier,
+                                classified_by,
+                                bt_str,
+                            )
+                            .await;
+                            break;
+                        }
+                        attempts += 1;
+                        tokio::time::sleep(Duration::from_millis(500)).await;
+                    }
+                });
+
+                Ok(resp)
+            } else {
+                // Non-streaming: buffer body, extract tokens, then forward
+                let body_bytes = r.bytes().await.unwrap_or_default();
+                let usage = extract_tokens_from_response(&body_bytes, &path, bt);
+                let duration_ms = duration.as_millis() as u64;
+
+                log_and_record(
+                    usage,
+                    state.clone(),
+                    model_name.clone(),
+                    selected,
+                    duration_ms,
+                    status.to_string(),
+                    path.clone(),
+                    request_id.clone(),
+                    tier,
+                    classified_by,
+                    backend_type_str,
+                )
+                .await;
+
+                let body = axum::body::Body::from(body_bytes);
+                builder
+                    .body(body)
+                    .map_err(|_| axum::http::StatusCode::BAD_GATEWAY)
+            }
         }
         None => {
+            log_and_record(
+                TokenUsage::default(),
+                state.clone(),
+                model_name.clone(),
+                selected_backend.unwrap_or_else(|| "none".to_string()),
+                duration.as_millis() as u64,
+                status.to_string(),
+                path.clone(),
+                request_id.clone(),
+                classification.map(|c| c.tier.clone()),
+                classification.map(|c| c.classified_by.clone()),
+                backend_type_str,
+            )
+            .await;
+
             let body = axum::body::Body::from(format!(
                 "{{\"error\":\"Bad Gateway\",\"request_id\":\"{}\"}}",
                 request_id
@@ -1340,9 +1639,15 @@ async fn dashboard_handler() -> axum::response::Html<&'static str> {
     axum::response::Html(include_str!("../dashboard.html"))
 }
 
-async fn skills_md_handler() -> ([(axum::http::header::HeaderName, &'static str); 1], &'static str) {
+async fn skills_md_handler() -> (
+    [(axum::http::header::HeaderName, &'static str); 1],
+    &'static str,
+) {
     (
-        [(axum::http::header::CONTENT_TYPE, "text/markdown; charset=utf-8")],
+        [(
+            axum::http::header::CONTENT_TYPE,
+            "text/markdown; charset=utf-8",
+        )],
         include_str!("../skills.md"),
     )
 }
@@ -1480,5 +1785,169 @@ mod tests {
         let bad = b"not json at all";
         let result = inject_keep_alive(bad, "/api/generate", "-1");
         assert_eq!(result.as_ref(), bad.as_ref());
+    }
+
+    // -----------------------------------------------------------------------
+    // Token extraction tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn extract_tokens_ollama_generate() {
+        let body = serde_json::json!({
+            "model": "llama3:8b",
+            "response": "Hello!",
+            "done": true,
+            "prompt_eval_count": 26,
+            "eval_count": 298,
+            "prompt_eval_duration": 4_500_000_000_u64,
+            "eval_duration": 8_200_000_000_u64
+        });
+        let bytes = serde_json::to_vec(&body).unwrap();
+        let usage = extract_tokens_from_response(
+            &bytes,
+            "/api/generate",
+            crate::config::BackendType::Ollama,
+        );
+        assert_eq!(usage.tokens_in, Some(26));
+        assert_eq!(usage.tokens_out, Some(298));
+        assert_eq!(usage.prompt_eval_ms, Some(4500));
+        assert_eq!(usage.eval_ms, Some(8200));
+        // tokens_per_second = 298 / (8.2) ≈ 36.34
+        let tps = usage.tokens_per_second.unwrap();
+        assert!(tps > 36.0 && tps < 37.0, "tps was {}", tps);
+    }
+
+    #[test]
+    fn extract_tokens_ollama_chat() {
+        let body = serde_json::json!({
+            "model": "llama3:8b",
+            "message": {"role": "assistant", "content": "Hi"},
+            "done": true,
+            "prompt_eval_count": 50,
+            "eval_count": 100,
+            "prompt_eval_duration": 2_000_000_000_u64,
+            "eval_duration": 4_000_000_000_u64
+        });
+        let bytes = serde_json::to_vec(&body).unwrap();
+        let usage =
+            extract_tokens_from_response(&bytes, "/api/chat", crate::config::BackendType::Ollama);
+        assert_eq!(usage.tokens_in, Some(50));
+        assert_eq!(usage.tokens_out, Some(100));
+    }
+
+    #[test]
+    fn extract_tokens_llama_server() {
+        let body = serde_json::json!({
+            "id": "chatcmpl-1234",
+            "choices": [{"message": {"content": "Hi"}}],
+            "usage": {
+                "prompt_tokens": 26,
+                "completion_tokens": 298,
+                "total_tokens": 324
+            }
+        });
+        let bytes = serde_json::to_vec(&body).unwrap();
+        let usage = extract_tokens_from_response(
+            &bytes,
+            "/v1/chat/completions",
+            crate::config::BackendType::LlamaServer,
+        );
+        assert_eq!(usage.tokens_in, Some(26));
+        assert_eq!(usage.tokens_out, Some(298));
+        // llama-server doesn't provide timing info in the response
+        assert!(usage.tokens_per_second.is_none());
+        assert!(usage.prompt_eval_ms.is_none());
+        assert!(usage.eval_ms.is_none());
+    }
+
+    #[test]
+    fn extract_tokens_openai_compat() {
+        let body = serde_json::json!({
+            "id": "chatcmpl-5678",
+            "choices": [{"message": {"content": "Hello"}}],
+            "usage": {
+                "prompt_tokens": 100,
+                "completion_tokens": 50
+            }
+        });
+        let bytes = serde_json::to_vec(&body).unwrap();
+        let usage = extract_tokens_from_response(
+            &bytes,
+            "/v1/chat/completions",
+            crate::config::BackendType::OpenAICompat,
+        );
+        assert_eq!(usage.tokens_in, Some(100));
+        assert_eq!(usage.tokens_out, Some(50));
+    }
+
+    #[test]
+    fn extract_tokens_invalid_json_returns_default() {
+        let usage = extract_tokens_from_response(
+            b"not json",
+            "/api/generate",
+            crate::config::BackendType::Ollama,
+        );
+        assert!(usage.tokens_in.is_none());
+        assert!(usage.tokens_out.is_none());
+    }
+
+    #[test]
+    fn extract_tokens_ollama_wrong_path_returns_default() {
+        let body = serde_json::json!({"prompt_eval_count": 10, "eval_count": 20});
+        let bytes = serde_json::to_vec(&body).unwrap();
+        let usage =
+            extract_tokens_from_response(&bytes, "/v1/models", crate::config::BackendType::Ollama);
+        assert!(usage.tokens_in.is_none());
+    }
+
+    #[test]
+    fn extract_tokens_partial_ollama_response() {
+        // Ollama response with eval_count but no prompt_eval_count
+        let body = serde_json::json!({"eval_count": 100, "eval_duration": 2_000_000_000_u64});
+        let bytes = serde_json::to_vec(&body).unwrap();
+        let usage = extract_tokens_from_response(
+            &bytes,
+            "/api/generate",
+            crate::config::BackendType::Ollama,
+        );
+        assert!(usage.tokens_in.is_none());
+        assert_eq!(usage.tokens_out, Some(100));
+        assert_eq!(usage.eval_ms, Some(2000));
+    }
+
+    // -----------------------------------------------------------------------
+    // SSE data extraction tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn extract_last_sse_data_single_line() {
+        let chunk =
+            b"data: {\"choices\":[],\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":20}}\n\n";
+        let result = extract_last_sse_data(chunk);
+        assert!(result.is_some());
+        let json: serde_json::Value = serde_json::from_slice(&result.unwrap()).unwrap();
+        assert_eq!(json["usage"]["prompt_tokens"], 10);
+    }
+
+    #[test]
+    fn extract_last_sse_data_multiple_lines() {
+        let chunk = b"data: {\"choices\":[{\"delta\":{\"content\":\"Hi\"}}]}\n\ndata: {\"choices\":[],\"usage\":{\"prompt_tokens\":5,\"completion_tokens\":10}}\n\ndata: [DONE]\n\n";
+        let result = extract_last_sse_data(chunk);
+        assert!(result.is_some());
+        let json: serde_json::Value = serde_json::from_slice(&result.unwrap()).unwrap();
+        assert_eq!(json["usage"]["completion_tokens"], 10);
+    }
+
+    #[test]
+    fn extract_last_sse_data_done_only() {
+        let chunk = b"data: [DONE]\n\n";
+        let result = extract_last_sse_data(chunk);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn extract_last_sse_data_empty() {
+        let result = extract_last_sse_data(b"");
+        assert!(result.is_none());
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -508,15 +508,25 @@ impl Server {
             .route(
                 "/api/nodes/:id/models",
                 axum::routing::get(crate::api::models::list_node_models),
-            )
-            .route(
-                "/api/nodes/:id/models/download",
-                axum::routing::post(crate::api::models::download_model),
-            )
-            .route(
-                "/api/nodes/:id/models/:model_name",
-                axum::routing::delete(crate::api::models::delete_node_model),
             );
+
+        // Destructive model endpoints require authentication
+        {
+            let model_mgmt_routes = axum::Router::new()
+                .route(
+                    "/api/nodes/:id/models/download",
+                    axum::routing::post(crate::api::models::download_model),
+                )
+                .route(
+                    "/api/nodes/:id/models/:model_name",
+                    axum::routing::delete(crate::api::models::delete_node_model),
+                )
+                .layer(axum::middleware::from_fn_with_state(
+                    state.clone(),
+                    require_api_key,
+                ));
+            app = app.merge(model_mgmt_routes);
+        }
 
         // Conditionally mount metrics
         if self.config.observability.metrics {
@@ -1010,7 +1020,6 @@ async fn proxy_handler(
         }
     }
 
-    let duration = start.elapsed();
     let status = match &response {
         Some(r) if r.status().is_success() => "success",
         _ => "error",
@@ -1027,67 +1036,70 @@ async fn proxy_handler(
     };
     let backend_type_str = backend_type.map(|bt| bt.to_string());
 
-    // Helper: build and log the RequestLog + record metrics
-    let log_and_record = |usage: TokenUsage,
-                          state: AppState,
-                          model_name: Option<String>,
-                          selected_backend: String,
-                          duration_ms: u64,
-                          status: String,
-                          path: String,
-                          request_id: String,
-                          tier: Option<String>,
-                          classified_by: Option<String>,
-                          backend_type_str: Option<String>| async move {
-        let log = RequestLog {
-            timestamp: chrono::Utc::now().timestamp(),
-            model: model_name.clone(),
-            backend: selected_backend,
-            duration_ms,
-            status: status.clone(),
-            path,
-            request_id: Some(request_id),
-            tier,
-            classified_by,
-            tokens_in: usage.tokens_in,
-            tokens_out: usage.tokens_out,
-            tokens_per_second: usage.tokens_per_second,
-            prompt_eval_ms: usage.prompt_eval_ms,
-            eval_ms: usage.eval_ms,
-            backend_type: backend_type_str,
-        };
+    // Context struct for proxy request logging/metrics (avoids 11-parameter closures)
+    struct ProxyRequestContext {
+        state: AppState,
+        model_name: Option<String>,
+        selected_backend: String,
+        path: String,
+        request_id: String,
+        tier: Option<String>,
+        classified_by: Option<String>,
+        backend_type_str: Option<String>,
+        start: std::time::Instant,
+    }
 
-        state
-            .metrics
-            .record_request(&log.backend, &log.status, log.duration_ms)
-            .await;
+    impl ProxyRequestContext {
+        async fn log_and_record(&self, status: &str, usage: TokenUsage) {
+            let duration_ms = self.start.elapsed().as_millis() as u64;
+            let log = RequestLog {
+                timestamp: chrono::Utc::now().timestamp(),
+                model: self.model_name.clone(),
+                backend: self.selected_backend.clone(),
+                duration_ms,
+                status: status.to_string(),
+                path: self.path.clone(),
+                request_id: Some(self.request_id.clone()),
+                tier: self.tier.clone(),
+                classified_by: self.classified_by.clone(),
+                tokens_in: usage.tokens_in,
+                tokens_out: usage.tokens_out,
+                tokens_per_second: usage.tokens_per_second,
+                prompt_eval_ms: usage.prompt_eval_ms,
+                eval_ms: usage.eval_ms,
+                backend_type: self.backend_type_str.clone(),
+            };
 
-        // Record token metrics
-        if let (Some(tin), Some(tout)) = (usage.tokens_in, usage.tokens_out) {
-            state
+            self.state
                 .metrics
-                .record_tokens(model_name.as_deref().unwrap_or("unknown"), tin, tout)
+                .record_request(&log.backend, &log.status, log.duration_ms)
                 .await;
-        }
-        if let Some(tps) = usage.tokens_per_second {
-            state.metrics.record_tokens_per_second(tps).await;
-        }
 
-        // Record labeled latency
-        state
-            .metrics
-            .record_request_labeled(
-                &log.backend,
-                model_name.as_deref().unwrap_or("unknown"),
-                &status,
-                log.duration_ms,
-            )
-            .await;
+            if let (Some(tin), Some(tout)) = (usage.tokens_in, usage.tokens_out) {
+                self.state
+                    .metrics
+                    .record_tokens(self.model_name.as_deref().unwrap_or("unknown"), tin, tout)
+                    .await;
+            }
+            if let Some(tps) = usage.tokens_per_second {
+                self.state.metrics.record_tokens_per_second(tps).await;
+            }
 
-        if let Err(e) = state.analytics.log_request(log).await {
-            tracing::error!("Failed to log request: {}", e);
+            self.state
+                .metrics
+                .record_request_labeled(
+                    &log.backend,
+                    self.model_name.as_deref().unwrap_or("unknown"),
+                    status,
+                    log.duration_ms,
+                )
+                .await;
+
+            if let Err(e) = self.state.analytics.log_request(log).await {
+                tracing::error!("Failed to log request: {}", e);
+            }
         }
-    };
+    }
 
     match response {
         Some(r) => {
@@ -1127,23 +1139,39 @@ async fn proxy_handler(
                 let last_data = Arc::new(tokio::sync::Mutex::new(Option::<Vec<u8>>::None));
                 let last_data_capture = last_data.clone();
 
+                // Oneshot channel to signal stream completion (replaces Arc::strong_count polling)
+                let (stream_done_tx, stream_done_rx) = tokio::sync::oneshot::channel::<()>();
+                let mut stream_done_tx = Some(stream_done_tx);
+
                 let inner_stream = r.bytes_stream();
                 let capturing_stream = futures_util::stream::unfold(
-                    (inner_stream, last_data_capture),
-                    |(mut stream, last_data)| async move {
+                    (inner_stream, last_data_capture, stream_done_tx.take()),
+                    |(mut stream, last_data, stream_done_tx)| async move {
                         use futures_util::StreamExt;
                         match stream.next().await {
                             Some(Ok(chunk)) => {
-                                // Check if this chunk contains SSE data lines
                                 if let Some(data) = extract_last_sse_data(&chunk) {
                                     *last_data.lock().await = Some(data);
                                 }
-                                Some((Ok::<_, std::io::Error>(chunk), (stream, last_data)))
+                                Some((
+                                    Ok::<_, std::io::Error>(chunk),
+                                    (stream, last_data, stream_done_tx),
+                                ))
                             }
                             Some(Err(e)) => {
-                                Some((Err(std::io::Error::other(e)), (stream, last_data)))
+                                tracing::warn!("Stream error from backend: {}", e);
+                                Some((
+                                    Err(std::io::Error::other(e)),
+                                    (stream, last_data, stream_done_tx),
+                                ))
                             }
-                            None => None,
+                            None => {
+                                // Stream ended — signal the waiting task
+                                if let Some(tx) = stream_done_tx {
+                                    let _ = tx.send(());
+                                }
+                                None
+                            }
                         }
                     },
                 );
@@ -1154,49 +1182,27 @@ async fn proxy_handler(
                     .map_err(|_| axum::http::StatusCode::BAD_GATEWAY)?;
 
                 // Fire-and-forget: extract tokens after stream ends
-                let state_clone = state.clone();
-                let path_clone = path.clone();
-                let model_clone = model_name.clone();
-                let request_id_clone = request_id.clone();
-                let duration_ms = duration.as_millis() as u64;
-                let status_str = status.to_string();
-                let bt_str = backend_type_str.clone();
+                let ctx = ProxyRequestContext {
+                    state: state.clone(),
+                    model_name: model_name.clone(),
+                    selected_backend: selected,
+                    path: path.clone(),
+                    request_id: request_id.clone(),
+                    tier,
+                    classified_by,
+                    backend_type_str: backend_type_str.clone(),
+                    start,
+                };
                 tokio::spawn(async move {
-                    // Wait briefly for stream to complete, then check
-                    // The last_data will be populated as the stream flows
-                    tokio::time::sleep(Duration::from_millis(100)).await;
-                    // Try to get the captured data (may not be available yet for long streams)
-                    // We'll wait up to the routing timeout for the stream to finish
-                    let mut attempts = 0;
-                    loop {
-                        let data = last_data.lock().await.clone();
-                        // The Arc strong count drops to 1 when the stream is done
-                        // (the capturing_stream closure is dropped)
-                        if Arc::strong_count(&last_data) <= 1 || attempts > 600 {
-                            let usage = if let Some(data) = data {
-                                extract_tokens_from_response(&data, &path_clone, bt)
-                            } else {
-                                TokenUsage::default()
-                            };
-                            log_and_record(
-                                usage,
-                                state_clone,
-                                model_clone,
-                                selected,
-                                duration_ms,
-                                status_str,
-                                path_clone,
-                                request_id_clone,
-                                tier,
-                                classified_by,
-                                bt_str,
-                            )
-                            .await;
-                            break;
-                        }
-                        attempts += 1;
-                        tokio::time::sleep(Duration::from_millis(500)).await;
-                    }
+                    // Wait for stream to complete via oneshot signal
+                    let _ = stream_done_rx.await;
+                    let data = last_data.lock().await.clone();
+                    let usage = if let Some(data) = data {
+                        extract_tokens_from_response(&data, &ctx.path, bt)
+                    } else {
+                        TokenUsage::default()
+                    };
+                    ctx.log_and_record(status, usage).await;
                 });
 
                 Ok(resp)
@@ -1204,22 +1210,19 @@ async fn proxy_handler(
                 // Non-streaming: buffer body, extract tokens, then forward
                 let body_bytes = r.bytes().await.unwrap_or_default();
                 let usage = extract_tokens_from_response(&body_bytes, &path, bt);
-                let duration_ms = duration.as_millis() as u64;
 
-                log_and_record(
-                    usage,
-                    state.clone(),
-                    model_name.clone(),
-                    selected,
-                    duration_ms,
-                    status.to_string(),
-                    path.clone(),
-                    request_id.clone(),
+                let ctx = ProxyRequestContext {
+                    state: state.clone(),
+                    model_name: model_name.clone(),
+                    selected_backend: selected,
+                    path: path.clone(),
+                    request_id: request_id.clone(),
                     tier,
                     classified_by,
                     backend_type_str,
-                )
-                .await;
+                    start,
+                };
+                ctx.log_and_record(status, usage).await;
 
                 let body = axum::body::Body::from(body_bytes);
                 builder
@@ -1228,20 +1231,18 @@ async fn proxy_handler(
             }
         }
         None => {
-            log_and_record(
-                TokenUsage::default(),
-                state.clone(),
-                model_name.clone(),
-                selected_backend.unwrap_or_else(|| "none".to_string()),
-                duration.as_millis() as u64,
-                status.to_string(),
-                path.clone(),
-                request_id.clone(),
-                classification.map(|c| c.tier.clone()),
-                classification.map(|c| c.classified_by.clone()),
+            let ctx = ProxyRequestContext {
+                state: state.clone(),
+                model_name: model_name.clone(),
+                selected_backend: selected_backend.unwrap_or_else(|| "none".to_string()),
+                path: path.clone(),
+                request_id: request_id.clone(),
+                tier: classification.map(|c| c.tier.clone()),
+                classified_by: classification.map(|c| c.classified_by.clone()),
                 backend_type_str,
-            )
-            .await;
+                start,
+            };
+            ctx.log_and_record(status, TokenUsage::default()).await;
 
             let body = axum::body::Body::from(format!(
                 "{{\"error\":\"Bad Gateway\",\"request_id\":\"{}\"}}",


### PR DESCRIPTION
## Summary

- **llama-server as first-class backend** — route to llama.cpp's llama-server alongside Ollama, with `openai-compat` as a third backend type for generic OpenAI-compatible endpoints
- **Telemetry enrichment** — token counts, per-model/backend latency percentiles, cost estimation, Prometheus counters with labeled histograms
- **HuggingFace model search API** — search GGUF models, VRAM-fit indicators, download to Ollama nodes, with bounded search cache
- **Dashboard control plane** — Models tab with HF search + download, Fleet tab with GPU/backend badges, analytics charts (token usage, cost avoided, latency breakdowns)
- **herd-tune GPU detection** — NVIDIA/AMD/Intel/Vulkan detection, Blackwell CUDA 13 requirement check, llama-server binary download and launch config
- **Router integration** — streaming token extraction via oneshot-signaled capture, backend-agnostic model_aware routing for mixed fleets

## Key changes

**Rust (26 files, +5,050 lines)**
- `BackendType` enum: `Ollama | LlamaServer | OpenAICompat` with exhaustive match coverage
- Streaming proxy captures token usage from final SSE chunk without buffering the full stream
- SQLite migrations v2-v4: backend fields, GPU metadata, download tracking
- 4 new API endpoints: `/api/models/search`, `/api/nodes/:id/models`, download, delete
- Destructive model endpoints require API key auth
- Prometheus: `herd_tokens_total`, `herd_tokens_per_second`, labeled duration histograms (cardinality capped at 200)

**Scripts (2 files, +1,145 lines)**
- `herd-tune.ps1` / `herd-tune.sh`: `--backend ollama|llama-server|auto`, GPU vendor detection, Blackwell CUDA 13 binary selection, llama-server download + launch config

**Dashboard (+624 lines)**
- New Models tab, Fleet/Backends backend badges, analytics token/cost/latency visualizations

## Verification

- **189 tests** (174 unit + 15 integration), 0 failures — up from 117 on main
- `cargo clippy -- -D warnings` clean
- `cargo fmt --check` clean
- Full PR review completed (6 specialized agents): all 3 critical, 8 important, and 9 suggestion findings addressed before merge

## Backward compatibility

- Existing Ollama-only `herd.yaml` configs work unchanged (BackendType defaults to Ollama)
- Old JSONL analytics logs deserialize cleanly (new fields are `Option` with serde defaults)
- Old herd-tune registration payloads accepted (new fields optional)
- Old SQLite databases auto-migrate via idempotent ALTER TABLE

## Test plan

- [x] `cargo test` — 189 passing
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] Backward compat: old JSONL, old registration payloads, configs without `backend` field
- [x] Token extraction: Ollama generate/chat, llama-server, OpenAI-compat, invalid JSON, streaming SSE
- [x] Mixed fleet routing: model_aware routes to correct backend type
- [x] Dashboard renders with both Ollama and llama-server nodes (graceful fallback for missing fields)
- [ ] Manual: herd-tune.sh on Linux with NVIDIA GPU
- [ ] Manual: herd-tune.ps1 on Windows with NVIDIA GPU
- [ ] Manual: Dashboard Models tab search + download flow against live HuggingFace API

🤖 Generated with [Claude Code](https://claude.com/claude-code)