### PR TITLE
fix: update Dockerfile for v1.0.0 build compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM rust:1.83 as builder
+FROM rust:latest AS builder
 
 WORKDIR /app
 COPY . .
 RUN cargo build --release
 
-FROM debian:bookworm-slim
+FROM ubuntu:24.04
 
 RUN apt-get update && apt-get install -y \
     ca-certificates \


### PR DESCRIPTION
## Problem

The Dockerfile shipped with v1.0.0 fails to build due to two issues:

1. **`rust:1.83`** — v1.0.0 dependencies require `edition2024` and crates like `time` and `icu_properties_data` that require rustc ≥ 1.88
2. **`debian:bookworm-slim`** — binaries compiled with `rust:latest` require GLIBC 2.39; bookworm only ships 2.36, causing runtime crash

## Fix

- Builder: `rust:1.83` → `rust:latest`
- Runtime: `debian:bookworm-slim` → `ubuntu:24.04` (ships GLIBC 2.39)

## Test

Built and deployed successfully to Starbase as part of the v1.0.0 rollout.