### PR TITLE
feat(daemon): herd agent node daemon + serve/agent CLI split (v1.2 PR #4)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -623,7 +623,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -926,6 +926,7 @@ dependencies = [
  "clap",
  "dirs",
  "futures-util",
+ "hostname",
  "regex",
  "reqwest",
  "rusqlite",
@@ -941,6 +942,17 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uuid",
+]
+
+[[package]]
+name = "hostname"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617aaa3557aef3810a6369d0a99fac8a080891b68bd9f9812a1eeda0c0730cbd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-link",
 ]
 
 [[package]]
@@ -1429,7 +1441,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1708,7 +1720,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1950,7 +1962,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2355,7 +2367,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 regex = "1"
 anyhow = "1"
 thiserror = "1"
-clap = { version = "4", features = ["derive"] }
+clap = { version = "4", features = ["derive", "env"] }
 async-trait = "0.1"
 chrono = "0.4"
 dirs = "5.0"
@@ -31,6 +31,7 @@ uuid = { version = "1", features = ["v4"] }
 self_update = { version = "0.42", features = ["archive-zip", "archive-tar", "compression-flate2", "compression-zip-deflate"] }
 rusqlite = { version = "0.31", features = ["bundled"] }
 futures-util = "0.3"
+hostname = "0.4"
 axum-server = { version = "0.7", features = ["tls-rustls"], optional = true }
 
 [features]

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -125,13 +125,13 @@ No cloud dependency. No API keys exposed. Full local control.
 - ~~Multi-node discovery (static fleet config with auto-probe)~~ ✅
 - ~~**Auto Mode classifier** — LLM-based request classification when `"model": "auto"` or model omitted; classifies tier (light/standard/heavy/frontier) and capability (general/code/reasoning/creative/vision/extraction), routes to best model from configurable map; results cached by message hash; off by default~~ ✅
 
-### v1.2.0+ — Distributed Inference (In Spec)
+### v1.2.0+ — Distributed Inference (In Progress)
 
 > **See `docs/specs/v2-distributed-inference-spec.md`** for the full architecture.
 
 Three-phase delivery introduces self-registering node agents and deployment-aware routing:
 
-- **v1.2** — Agent/Gateway foundation. `herd agent` subcommand, `NodeRegistry`, single-node deployments. Sprint plan: `tasks/HERD-V1.2-SPRINT.md`.
+- **v1.2** — Agent/Gateway foundation. `herd agent` subcommand, `NodeRegistry`, single-node deployments. Sprint plan: `tasks/HERD-V1.2-SPRINT.md`. *Status: PRs #1–#4 of 8 landed — `Deployment` module, `NodeRegistry` with TTL eviction, gateway heartbeat endpoint (`HERD_AGENT_TOKEN` auth), and the node-side `herd agent` daemon (GPU/VRAM detection, local backend probe, 2s heartbeat with backoff). Remaining: dashboard Fleet integration, protocol hardening, `BackendPool` routing integration, end-to-end test.*
 - **v1.3** — Speculative decoding deployments. Draft/verifier pairs across nodes via llama.cpp's `--model-draft` for 2-3x throughput on daily-driver models.
 - **v1.4** — Pipeline parallel deployments. llama.cpp RPC integration to serve models that don't fit on any single GPU (Qwen2.5-72B-class).
 

--- a/src/api/internal.rs
+++ b/src/api/internal.rs
@@ -86,7 +86,12 @@ fn check_agent_token(
 
 fn env_truthy(name: &str) -> bool {
     std::env::var(name)
-        .map(|v| matches!(v.as_str(), "1" | "true" | "TRUE" | "yes" | "YES" | "on" | "ON"))
+        .map(|v| {
+            matches!(
+                v.as_str(),
+                "1" | "true" | "TRUE" | "yes" | "YES" | "on" | "ON"
+            )
+        })
         .unwrap_or(false)
 }
 
@@ -120,7 +125,9 @@ fn validate_capabilities(caps: &AgentCapabilities) -> Result<(), String> {
     }
 
     if caps.address.len() > MAX_ADDRESS_LEN {
-        return Err(format!("capabilities.address exceeds {MAX_ADDRESS_LEN} bytes"));
+        return Err(format!(
+            "capabilities.address exceeds {MAX_ADDRESS_LEN} bytes"
+        ));
     }
     let parsed = reqwest::Url::parse(&caps.address)
         .map_err(|e| format!("capabilities.address is not a valid URL: {e}"))?;
@@ -139,7 +146,11 @@ fn validate_capabilities(caps: &AgentCapabilities) -> Result<(), String> {
             "capabilities.models_loaded exceeds {MAX_MODELS_LOADED} entries"
         ));
     }
-    if caps.models_loaded.iter().any(|m| m.len() > MAX_MODEL_NAME_LEN) {
+    if caps
+        .models_loaded
+        .iter()
+        .any(|m| m.len() > MAX_MODEL_NAME_LEN)
+    {
         return Err(format!(
             "capabilities.models_loaded entries must be <= {MAX_MODEL_NAME_LEN} bytes"
         ));
@@ -229,8 +240,8 @@ pub async fn heartbeat(
         &headers,
         req,
     )
-        .await
-        .map(Json)
+    .await
+    .map(Json)
 }
 
 #[cfg(test)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,52 @@
 use crate::config::Backend;
+use crate::daemon::AgentArgs;
+use clap::{Parser, Subcommand};
+use std::path::PathBuf;
+
+/// Top-level CLI. The serve flags are flattened at the top level so the
+/// pre-v1.2 flat invocations (`herd -c herd.yaml`, `herd -p 8080 -b a=...`)
+/// keep parsing unchanged; `serve` and `agent` are explicit subcommands.
+#[derive(Parser)]
+#[command(name = "herd")]
+#[command(about = "Intelligent Ollama router with GPU awareness", long_about = None)]
+pub struct Cli {
+    #[command(flatten)]
+    pub serve: ServeArgs,
+
+    /// Check for updates and install if available
+    #[arg(long)]
+    pub update: bool,
+
+    #[command(subcommand)]
+    pub command: Option<Command>,
+}
+
+#[derive(Subcommand)]
+pub enum Command {
+    /// Run the gateway (default when no subcommand is given)
+    Serve(ServeArgs),
+    /// Run the node-side agent daemon that heartbeats a gateway
+    Agent(AgentArgs),
+}
+
+#[derive(clap::Args)]
+pub struct ServeArgs {
+    /// Path to config file
+    #[arg(short, long, value_name = "FILE")]
+    pub config: Option<PathBuf>,
+
+    /// Port to listen on
+    #[arg(short, long, default_value = "40114")]
+    pub port: u16,
+
+    /// Host to bind to
+    #[arg(long, default_value = "0.0.0.0")]
+    pub host: String,
+
+    /// Backend URLs (format: name=url:priority)
+    #[arg(short, long)]
+    pub backend: Vec<String>,
+}
 
 pub fn parse_backend_spec(spec: &str) -> Option<Backend> {
     let (name, raw_target) = spec.split_once('=')?;
@@ -52,6 +100,122 @@ fn has_explicit_priority(raw_target: &str) -> bool {
     }
 
     remainder.matches(':').count() >= 2
+}
+
+#[cfg(test)]
+mod cli_tests {
+    use super::{Cli, Command};
+    use clap::Parser;
+
+    #[test]
+    fn legacy_flat_invocation_parses_unchanged() {
+        let cli = Cli::try_parse_from(["herd", "-c", "foo.yaml"]).unwrap();
+        assert!(cli.command.is_none());
+        assert!(!cli.update);
+        assert_eq!(
+            cli.serve.config.as_deref().unwrap().to_str(),
+            Some("foo.yaml")
+        );
+        assert_eq!(cli.serve.port, 40114);
+        assert_eq!(cli.serve.host, "0.0.0.0");
+        assert!(cli.serve.backend.is_empty());
+    }
+
+    #[test]
+    fn legacy_port_host_backend_flags_parse_unchanged() {
+        let cli = Cli::try_parse_from([
+            "herd",
+            "-p",
+            "8080",
+            "--host",
+            "127.0.0.1",
+            "-b",
+            "citadel=http://citadel:11434:100",
+        ])
+        .unwrap();
+        assert!(cli.command.is_none());
+        assert_eq!(cli.serve.port, 8080);
+        assert_eq!(cli.serve.host, "127.0.0.1");
+        assert_eq!(cli.serve.backend, vec!["citadel=http://citadel:11434:100"]);
+    }
+
+    #[test]
+    fn legacy_update_flag_parses_unchanged() {
+        let cli = Cli::try_parse_from(["herd", "--update"]).unwrap();
+        assert!(cli.update);
+        assert!(cli.command.is_none());
+    }
+
+    #[test]
+    fn explicit_serve_subcommand_accepts_same_flags() {
+        let cli = Cli::try_parse_from(["herd", "serve", "-c", "x.yaml", "-p", "9000"]).unwrap();
+        match cli.command {
+            Some(Command::Serve(args)) => {
+                assert_eq!(args.config.as_deref().unwrap().to_str(), Some("x.yaml"));
+                assert_eq!(args.port, 9000);
+            }
+            _ => panic!("expected serve subcommand"),
+        }
+    }
+
+    #[test]
+    fn agent_subcommand_parses_with_defaults() {
+        let cli = Cli::try_parse_from(["herd", "agent", "--gateway", "http://gw:40114"]).unwrap();
+        match cli.command {
+            Some(Command::Agent(args)) => {
+                assert_eq!(args.gateway, "http://gw:40114");
+                assert!(args.node_id.is_none());
+                assert_eq!(args.heartbeat_secs, 2);
+                assert_eq!(args.backend_url, "http://127.0.0.1:11434");
+                assert!(args.advertise_url.is_none());
+                assert!(args.backend.is_none());
+            }
+            _ => panic!("expected agent subcommand"),
+        }
+    }
+
+    #[test]
+    fn agent_subcommand_accepts_overrides() {
+        let cli = Cli::try_parse_from([
+            "herd",
+            "agent",
+            "--gateway",
+            "http://gw:40114",
+            "--node-id",
+            "citadel-5090",
+            "--heartbeat-secs",
+            "5",
+            "--backend",
+            "llama-server",
+        ])
+        .unwrap();
+        match cli.command {
+            Some(Command::Agent(args)) => {
+                assert_eq!(args.node_id.as_deref(), Some("citadel-5090"));
+                assert_eq!(args.heartbeat_secs, 5);
+                assert_eq!(args.backend, Some(crate::config::BackendType::LlamaServer));
+            }
+            _ => panic!("expected agent subcommand"),
+        }
+    }
+
+    #[test]
+    fn agent_requires_gateway() {
+        assert!(Cli::try_parse_from(["herd", "agent"]).is_err());
+    }
+
+    #[test]
+    fn agent_rejects_unknown_backend_type() {
+        assert!(Cli::try_parse_from([
+            "herd",
+            "agent",
+            "--gateway",
+            "http://gw:40114",
+            "--backend",
+            "vllm"
+        ])
+        .is_err());
+    }
 }
 
 #[cfg(test)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -844,11 +844,7 @@ impl Config {
                 .is_some();
 
             if url.is_empty() {
-                tracing::warn!(
-                    "Skipping backends[{}] ('{}'): empty URL",
-                    i,
-                    backend.name
-                );
+                tracing::warn!("Skipping backends[{}] ('{}'): empty URL", i, backend.name);
                 continue;
             }
             if !valid {

--- a/src/daemon/capabilities.rs
+++ b/src/daemon/capabilities.rs
@@ -1,0 +1,373 @@
+//! Capability snapshot building for `herd agent`.
+//!
+//! GPU detection ports the probe order and tool invocations of
+//! `scripts/herd-tune.sh` / `herd-tune.ps1` (nvidia → rocm → cpu) into Rust.
+//! Parsing is kept in pure functions so it is unit-testable against canned
+//! tool output. Multi-GPU hosts reduce to the FIRST GPU (CSV line 1) — the
+//! same reduction herd-tune (`head -1`) and `backend/discovery.rs` use.
+
+use crate::config::BackendType;
+use crate::nodes::AgentCapabilities;
+
+pub const AGENT_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GpuVendor {
+    Nvidia,
+    Amd,
+    None,
+}
+
+/// Static GPU facts probed once at agent startup.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GpuStatic {
+    pub vendor: GpuVendor,
+    pub model: Option<String>,
+    pub vram_total_mb: u64,
+    pub driver_version: Option<String>,
+}
+
+impl GpuStatic {
+    fn cpu_only() -> Self {
+        Self {
+            vendor: GpuVendor::None,
+            model: None,
+            vram_total_mb: 0,
+            driver_version: None,
+        }
+    }
+}
+
+fn run_tool(cmd: &str, args: &[&str]) -> Option<String> {
+    let output = std::process::Command::new(cmd).args(args).output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    Some(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+/// Detect the GPU once at startup. Probe order matches herd-tune:
+/// nvidia-smi, then rocm-smi, then fall back to cpu-only.
+pub fn detect_gpu_static() -> GpuStatic {
+    if let Some(out) = run_tool(
+        "nvidia-smi",
+        &[
+            "--query-gpu=name,memory.total,driver_version",
+            "--format=csv,noheader,nounits",
+        ],
+    ) {
+        if let Some(gpu) = parse_nvidia_static_csv(&out) {
+            return gpu;
+        }
+    }
+
+    if let Some(out) = run_tool("rocm-smi", &["--showproductname", "--csv"]) {
+        if let Some(model) = parse_rocm_product_csv(&out) {
+            let vram_total_mb = run_tool("rocm-smi", &["--showmeminfo", "vram", "--csv"])
+                .and_then(|o| parse_rocm_vram_csv(&o))
+                .map(|(total, _used)| total)
+                .unwrap_or(0);
+            return GpuStatic {
+                vendor: GpuVendor::Amd,
+                model: Some(model),
+                vram_total_mb,
+                driver_version: None,
+            };
+        }
+    }
+
+    GpuStatic::cpu_only()
+}
+
+/// Probe current free VRAM. Called every heartbeat; returns `None` when the
+/// probe tool is unavailable or its output is malformed (callers keep the
+/// last known value).
+pub fn probe_vram_free_mb(vendor: GpuVendor) -> Option<u64> {
+    match vendor {
+        GpuVendor::Nvidia => run_tool(
+            "nvidia-smi",
+            &["--query-gpu=memory.free", "--format=csv,noheader,nounits"],
+        )
+        .and_then(|out| parse_first_u64(&out)),
+        GpuVendor::Amd => run_tool("rocm-smi", &["--showmeminfo", "vram", "--csv"])
+            .and_then(|out| parse_rocm_vram_csv(&out))
+            .map(|(total, used)| total.saturating_sub(used)),
+        GpuVendor::None => None,
+    }
+}
+
+/// Parse `nvidia-smi --query-gpu=name,memory.total,driver_version
+/// --format=csv,noheader,nounits` output. First GPU wins on multi-GPU hosts.
+pub fn parse_nvidia_static_csv(out: &str) -> Option<GpuStatic> {
+    let line = out.lines().find(|l| !l.trim().is_empty())?;
+    let mut fields = line.split(',').map(str::trim);
+    let name = fields.next().filter(|s| !s.is_empty())?;
+    let total_mb = fields.next()?.parse::<u64>().ok()?;
+    let driver = fields.next().filter(|s| !s.is_empty());
+    Some(GpuStatic {
+        vendor: GpuVendor::Nvidia,
+        model: Some(name.to_string()),
+        vram_total_mb: total_mb,
+        driver_version: driver.map(str::to_string),
+    })
+}
+
+/// Parse `rocm-smi --showproductname --csv` output: a header line then
+/// `device,Card series,...` rows. First GPU wins.
+pub fn parse_rocm_product_csv(out: &str) -> Option<String> {
+    let row = out
+        .lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty())
+        .nth(1)?;
+    let model = row
+        .split(',')
+        .nth(1)
+        .map(str::trim)
+        .filter(|s| !s.is_empty())?;
+    Some(model.to_string())
+}
+
+/// Parse `rocm-smi --showmeminfo vram --csv` output into (total_mb, used_mb).
+/// Values are reported in bytes; first GPU wins.
+pub fn parse_rocm_vram_csv(out: &str) -> Option<(u64, u64)> {
+    let row = out
+        .lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty())
+        .nth(1)?;
+    let mut fields = row.split(',').map(str::trim);
+    let _device = fields.next()?;
+    let total_bytes = fields.next()?.parse::<u64>().ok()?;
+    let used_bytes = fields
+        .next()
+        .and_then(|s| s.parse::<u64>().ok())
+        .unwrap_or(0);
+    Some((total_bytes / 1_048_576, used_bytes / 1_048_576))
+}
+
+fn parse_first_u64(out: &str) -> Option<u64> {
+    out.lines()
+        .find(|l| !l.trim().is_empty())?
+        .split(',')
+        .next()?
+        .trim()
+        .parse::<u64>()
+        .ok()
+}
+
+/// Derive the default node id: lowercase hostname plus the GPU model-number
+/// suffix when one exists (`citadel` + "NVIDIA GeForce RTX 5090" →
+/// `citadel-5090`), sanitized to the charset the gateway accepts.
+pub fn default_node_id(hostname: &str, gpu_model: Option<&str>) -> String {
+    let host = sanitize_node_id(hostname);
+    match gpu_model.and_then(model_number_suffix) {
+        Some(suffix) => format!("{host}-{suffix}"),
+        None => host,
+    }
+}
+
+/// Extract a model-number suffix from a GPU name: the last whitespace token
+/// that is all digits ("NVIDIA GeForce RTX 5090" → "5090", "Radeon RX 7900
+/// XTX" → "7900"). Returns `None` when no such token exists.
+fn model_number_suffix(model: &str) -> Option<String> {
+    model
+        .split_whitespace()
+        .rev()
+        .find(|t| t.len() >= 2 && t.chars().all(|c| c.is_ascii_digit()))
+        .map(str::to_string)
+}
+
+/// Lowercase and restrict to the node_id charset the gateway validates
+/// (ASCII alphanumeric plus '-', '_', '.', ':'); other characters become '-'.
+fn sanitize_node_id(raw: &str) -> String {
+    let sanitized: String = raw
+        .to_lowercase()
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.' | ':') {
+                c
+            } else {
+                '-'
+            }
+        })
+        .collect();
+    let trimmed = sanitized.trim_matches('-');
+    if trimmed.is_empty() {
+        "node".to_string()
+    } else {
+        trimmed.to_string()
+    }
+}
+
+/// Builds `AgentCapabilities` snapshots from startup-probed static facts plus
+/// per-beat dynamic state. Reuses the wire type from `nodes::registry`.
+#[derive(Debug, Clone)]
+pub struct SnapshotBuilder {
+    node_id: String,
+    gpu: GpuStatic,
+}
+
+impl SnapshotBuilder {
+    pub fn new(node_id: String, gpu: GpuStatic) -> Self {
+        Self { node_id, gpu }
+    }
+
+    pub fn node_id(&self) -> &str {
+        &self.node_id
+    }
+
+    pub fn snapshot(
+        &self,
+        backend: BackendType,
+        address: String,
+        vram_free_mb: u64,
+        models_loaded: Vec<String>,
+    ) -> AgentCapabilities {
+        AgentCapabilities {
+            node_id: self.node_id.clone(),
+            backend,
+            address,
+            gpu_model: self.gpu.model.clone(),
+            vram_total_mb: self.gpu.vram_total_mb,
+            // The gateway rejects free > total; clamp so a racy probe between
+            // model unloads can't invalidate the whole snapshot.
+            vram_free_mb: vram_free_mb.min(self.gpu.vram_total_mb),
+            models_loaded,
+            queue_depth: 0,
+            ttft_p50_ms: None,
+            rpc_capable: false, // v1.4 (pipeline parallel)
+            rpc_port: None,
+            agent_version: AGENT_VERSION.to_string(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_nvidia_single_gpu_csv() {
+        let out = "NVIDIA GeForce RTX 5090, 32607, 572.83\n";
+        let gpu = parse_nvidia_static_csv(out).unwrap();
+        assert_eq!(gpu.vendor, GpuVendor::Nvidia);
+        assert_eq!(gpu.model.as_deref(), Some("NVIDIA GeForce RTX 5090"));
+        assert_eq!(gpu.vram_total_mb, 32607);
+        assert_eq!(gpu.driver_version.as_deref(), Some("572.83"));
+    }
+
+    #[test]
+    fn nvidia_multi_gpu_reduces_to_first_line() {
+        let out =
+            "NVIDIA GeForce RTX 5090, 32607, 572.83\nNVIDIA GeForce RTX 4080, 16376, 572.83\n";
+        let gpu = parse_nvidia_static_csv(out).unwrap();
+        assert_eq!(gpu.model.as_deref(), Some("NVIDIA GeForce RTX 5090"));
+        assert_eq!(gpu.vram_total_mb, 32607);
+    }
+
+    #[test]
+    fn nvidia_malformed_csv_returns_none() {
+        assert!(parse_nvidia_static_csv("").is_none());
+        assert!(parse_nvidia_static_csv("\n\n").is_none());
+        assert!(parse_nvidia_static_csv("RTX 5090").is_none());
+        assert!(parse_nvidia_static_csv("RTX 5090, not-a-number, 572.83").is_none());
+    }
+
+    #[test]
+    fn parses_rocm_product_csv() {
+        let out = "device,Card series,Card model,Card vendor,Card SKU\ncard0,Radeon RX 7900 XTX,0x744c,Advanced Micro Devices,EXT94393\n";
+        assert_eq!(
+            parse_rocm_product_csv(out).as_deref(),
+            Some("Radeon RX 7900 XTX")
+        );
+    }
+
+    #[test]
+    fn rocm_product_csv_without_rows_returns_none() {
+        assert!(parse_rocm_product_csv("device,Card series\n").is_none());
+        assert!(parse_rocm_product_csv("").is_none());
+    }
+
+    #[test]
+    fn parses_rocm_vram_csv_bytes_to_mb() {
+        let out = "device,VRAM Total Memory (B),VRAM Total Used Memory (B)\ncard0,25753026560,305135616\n";
+        let (total, used) = parse_rocm_vram_csv(out).unwrap();
+        assert_eq!(total, 24560);
+        assert_eq!(used, 291);
+    }
+
+    #[test]
+    fn parses_first_u64_from_multi_gpu_output() {
+        assert_eq!(parse_first_u64("30142\n15032\n"), Some(30142));
+        assert_eq!(parse_first_u64("  29000  \n"), Some(29000));
+        assert_eq!(parse_first_u64("garbage\n"), None);
+        assert_eq!(parse_first_u64(""), None);
+    }
+
+    #[test]
+    fn default_node_id_appends_gpu_suffix() {
+        assert_eq!(
+            default_node_id("CITADEL", Some("NVIDIA GeForce RTX 5090")),
+            "citadel-5090"
+        );
+        assert_eq!(
+            default_node_id("warden", Some("Radeon RX 7900 XTX")),
+            "warden-7900"
+        );
+    }
+
+    #[test]
+    fn default_node_id_without_gpu_is_bare_hostname() {
+        assert_eq!(default_node_id("minipc", None), "minipc");
+        assert_eq!(
+            default_node_id("box", Some("Some GPU Without Numbers")),
+            "box"
+        );
+    }
+
+    #[test]
+    fn default_node_id_sanitizes_hostname() {
+        assert_eq!(default_node_id("Tom's PC", None), "tom-s-pc");
+        assert_eq!(default_node_id("", None), "node");
+    }
+
+    #[test]
+    fn snapshot_clamps_free_vram_to_total() {
+        let builder = SnapshotBuilder::new(
+            "citadel-5090".into(),
+            GpuStatic {
+                vendor: GpuVendor::Nvidia,
+                model: Some("NVIDIA GeForce RTX 5090".into()),
+                vram_total_mb: 32607,
+                driver_version: Some("572.83".into()),
+            },
+        );
+        let caps = builder.snapshot(
+            BackendType::LlamaServer,
+            "http://127.0.0.1:8080".into(),
+            99_999,
+            vec!["qwen3-32b".into()],
+        );
+        assert_eq!(caps.vram_free_mb, 32607);
+        assert_eq!(caps.vram_total_mb, 32607);
+        assert_eq!(caps.node_id, "citadel-5090");
+        assert_eq!(caps.models_loaded, vec!["qwen3-32b"]);
+        assert_eq!(caps.agent_version, AGENT_VERSION);
+        assert!(!caps.rpc_capable);
+    }
+
+    #[test]
+    fn cpu_only_snapshot_is_valid() {
+        let builder = SnapshotBuilder::new("minipc".into(), GpuStatic::cpu_only());
+        let caps = builder.snapshot(
+            BackendType::Ollama,
+            "http://127.0.0.1:11434".into(),
+            0,
+            vec![],
+        );
+        assert_eq!(caps.vram_total_mb, 0);
+        assert_eq!(caps.vram_free_mb, 0);
+        assert!(caps.gpu_model.is_none());
+    }
+}

--- a/src/daemon/client.rs
+++ b/src/daemon/client.rs
@@ -1,0 +1,335 @@
+//! Heartbeat client for `herd agent`.
+//!
+//! Split into a synchronous schedule state machine (`HeartbeatSchedule`) and a
+//! thin async HTTP driver (`HeartbeatClient`). All time-dependent logic lives
+//! in the state machine behind the injectable `Clock` pattern established in
+//! PR #2 (`nodes/registry.rs`), so retry/backoff is unit-testable without
+//! real sleeps; only the driver loop in `daemon::run` actually sleeps.
+
+use crate::nodes::AgentCapabilities;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+pub(crate) type Clock = Arc<dyn Fn() -> Instant + Send + Sync>;
+
+/// Cap on the exponential backoff while the gateway is unreachable.
+pub const MAX_BACKOFF: Duration = Duration::from_secs(30);
+/// Cap on the doubling exponent so the multiplication can't overflow.
+const MAX_BACKOFF_EXPONENT: u32 = 16;
+/// Truncation limit for error bodies echoed into logs.
+const MAX_ERROR_BODY_LEN: usize = 200;
+
+/// Result of one heartbeat attempt.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BeatOutcome {
+    /// Gateway accepted the heartbeat.
+    Success {
+        registered: bool,
+        /// Cadence the gateway asked for (`next_heartbeat_secs`), if present.
+        next_heartbeat_secs: Option<u64>,
+    },
+    /// Gateway answered with a non-2xx status (bad token, invalid payload,
+    /// registry full, ...).
+    Rejected { status: u16, body: String },
+    /// Gateway could not be reached at all.
+    Unreachable(String),
+}
+
+/// Decides how long to wait before the next heartbeat: the steady cadence on
+/// success (honoring the gateway's `next_heartbeat_secs` when it sends one),
+/// exponential backoff (base, 2×base, 4×base, ... capped at [`MAX_BACKOFF`])
+/// on failure, reset on the next success.
+pub struct HeartbeatSchedule {
+    base: Duration,
+    max_backoff: Duration,
+    consecutive_failures: u32,
+    last_success: Option<Instant>,
+    clock: Clock,
+}
+
+impl HeartbeatSchedule {
+    pub fn new(base: Duration) -> Self {
+        Self::with_clock(base, Arc::new(Instant::now))
+    }
+
+    pub(crate) fn with_clock(base: Duration, clock: Clock) -> Self {
+        Self {
+            base,
+            max_backoff: MAX_BACKOFF,
+            consecutive_failures: 0,
+            last_success: None,
+            clock,
+        }
+    }
+
+    /// Record an outcome and return the delay before the next attempt.
+    pub fn record(&mut self, outcome: &BeatOutcome) -> Duration {
+        match outcome {
+            BeatOutcome::Success {
+                next_heartbeat_secs,
+                ..
+            } => {
+                self.consecutive_failures = 0;
+                self.last_success = Some((self.clock)());
+                next_heartbeat_secs
+                    .filter(|s| *s > 0)
+                    .map(Duration::from_secs)
+                    .unwrap_or(self.base)
+            }
+            BeatOutcome::Rejected { .. } | BeatOutcome::Unreachable(_) => {
+                self.consecutive_failures = self.consecutive_failures.saturating_add(1);
+                let exponent = (self.consecutive_failures - 1).min(MAX_BACKOFF_EXPONENT);
+                self.base
+                    .saturating_mul(1u32 << exponent)
+                    .min(self.max_backoff)
+            }
+        }
+    }
+
+    pub fn consecutive_failures(&self) -> u32 {
+        self.consecutive_failures
+    }
+
+    /// How long ago the last successful heartbeat was, if any.
+    pub fn time_since_success(&self) -> Option<Duration> {
+        self.last_success
+            .map(|at| (self.clock)().duration_since(at))
+    }
+}
+
+#[derive(Serialize)]
+struct HeartbeatRequestBody<'a> {
+    capabilities: &'a AgentCapabilities,
+    /// Wall-clock timestamp. The v1.2 gateway accepts but ignores this (its
+    /// registry runs on a monotonic clock); sent for the wire format and
+    /// future skew diagnostics.
+    timestamp: String,
+}
+
+/// Lenient view of the gateway's heartbeat response. `deployments_assigned`
+/// is deliberately not modeled — it is always `[]` in v1.2 and nothing here
+/// may depend on it.
+#[derive(Debug, Default, Deserialize)]
+struct HeartbeatReply {
+    #[serde(default)]
+    registered: bool,
+    #[serde(default)]
+    next_heartbeat_secs: Option<u64>,
+}
+
+/// Thin HTTP driver that POSTs capability snapshots to the gateway.
+pub struct HeartbeatClient {
+    http: reqwest::Client,
+    endpoint: String,
+    token: Option<String>,
+}
+
+impl HeartbeatClient {
+    /// `token` is the shared bearer from `HERD_AGENT_TOKEN`: when `None`, no
+    /// Authorization header is sent at all.
+    pub fn new(gateway: &str, token: Option<String>) -> anyhow::Result<Self> {
+        let url = reqwest::Url::parse(gateway)?;
+        if !matches!(url.scheme(), "http" | "https") {
+            anyhow::bail!("gateway URL must use http or https: {gateway}");
+        }
+        let http = reqwest::Client::builder()
+            .timeout(Duration::from_secs(5))
+            .build()?;
+        Ok(Self {
+            http,
+            endpoint: format!(
+                "{}/api/internal/nodes/heartbeat",
+                gateway.trim_end_matches('/')
+            ),
+            token: token.filter(|t| !t.is_empty()),
+        })
+    }
+
+    pub async fn send(&self, caps: &AgentCapabilities) -> BeatOutcome {
+        let body = HeartbeatRequestBody {
+            capabilities: caps,
+            timestamp: chrono::Utc::now().to_rfc3339(),
+        };
+        let mut request = self.http.post(&self.endpoint).json(&body);
+        if let Some(token) = &self.token {
+            request = request.bearer_auth(token);
+        }
+
+        let response = match request.send().await {
+            Ok(r) => r,
+            Err(e) => return BeatOutcome::Unreachable(e.to_string()),
+        };
+
+        let status = response.status();
+        if status.is_success() {
+            let reply: HeartbeatReply = response.json().await.unwrap_or_default();
+            BeatOutcome::Success {
+                registered: reply.registered,
+                next_heartbeat_secs: reply.next_heartbeat_secs,
+            }
+        } else {
+            let body = response
+                .text()
+                .await
+                .unwrap_or_default()
+                .chars()
+                .take(MAX_ERROR_BODY_LEN)
+                .collect();
+            BeatOutcome::Rejected {
+                status: status.as_u16(),
+                body,
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    /// Same manual-clock pattern as `nodes/registry.rs` (PR #2).
+    #[derive(Clone)]
+    struct TestClock {
+        now: Arc<Mutex<Instant>>,
+    }
+
+    impl TestClock {
+        fn new() -> Self {
+            Self {
+                now: Arc::new(Mutex::new(Instant::now())),
+            }
+        }
+
+        fn advance(&self, delta: Duration) {
+            let mut guard = self.now.lock().unwrap();
+            *guard += delta;
+        }
+
+        fn as_fn(&self) -> Clock {
+            let now = self.now.clone();
+            Arc::new(move || *now.lock().unwrap())
+        }
+    }
+
+    fn schedule() -> (HeartbeatSchedule, TestClock) {
+        let clock = TestClock::new();
+        let sched = HeartbeatSchedule::with_clock(Duration::from_secs(2), clock.as_fn());
+        (sched, clock)
+    }
+
+    fn success(next: Option<u64>) -> BeatOutcome {
+        BeatOutcome::Success {
+            registered: false,
+            next_heartbeat_secs: next,
+        }
+    }
+
+    fn unreachable() -> BeatOutcome {
+        BeatOutcome::Unreachable("connection refused".into())
+    }
+
+    #[test]
+    fn success_returns_base_cadence() {
+        let (mut sched, _clock) = schedule();
+        assert_eq!(sched.record(&success(None)), Duration::from_secs(2));
+    }
+
+    #[test]
+    fn success_honors_server_cadence() {
+        let (mut sched, _clock) = schedule();
+        assert_eq!(sched.record(&success(Some(7))), Duration::from_secs(7));
+        // A zero from the server is nonsense — fall back to base.
+        assert_eq!(sched.record(&success(Some(0))), Duration::from_secs(2));
+    }
+
+    #[test]
+    fn unreachable_backs_off_exponentially_capped_at_30s() {
+        let (mut sched, _clock) = schedule();
+        let delays: Vec<u64> = (0..6)
+            .map(|_| sched.record(&unreachable()).as_secs())
+            .collect();
+        assert_eq!(delays, vec![2, 4, 8, 16, 30, 30]);
+        assert_eq!(sched.consecutive_failures(), 6);
+    }
+
+    #[test]
+    fn rejected_backs_off_like_unreachable() {
+        let (mut sched, _clock) = schedule();
+        let rejected = BeatOutcome::Rejected {
+            status: 401,
+            body: "bad token".into(),
+        };
+        assert_eq!(sched.record(&rejected), Duration::from_secs(2));
+        assert_eq!(sched.record(&rejected), Duration::from_secs(4));
+    }
+
+    #[test]
+    fn success_resets_backoff() {
+        let (mut sched, _clock) = schedule();
+        for _ in 0..4 {
+            sched.record(&unreachable());
+        }
+        assert_eq!(sched.record(&success(None)), Duration::from_secs(2));
+        assert_eq!(sched.consecutive_failures(), 0);
+        // Backoff restarts from the base after a success.
+        assert_eq!(sched.record(&unreachable()), Duration::from_secs(2));
+        assert_eq!(sched.record(&unreachable()), Duration::from_secs(4));
+    }
+
+    #[test]
+    fn deep_failure_count_does_not_overflow() {
+        let (mut sched, _clock) = schedule();
+        let mut last = Duration::ZERO;
+        for _ in 0..100 {
+            last = sched.record(&unreachable());
+        }
+        assert_eq!(last, MAX_BACKOFF);
+    }
+
+    #[test]
+    fn time_since_success_tracks_the_clock() {
+        let (mut sched, clock) = schedule();
+        assert!(sched.time_since_success().is_none());
+        sched.record(&success(None));
+        clock.advance(Duration::from_secs(12));
+        assert_eq!(sched.time_since_success(), Some(Duration::from_secs(12)));
+    }
+
+    #[test]
+    fn client_rejects_non_http_gateway() {
+        assert!(HeartbeatClient::new("ftp://gw:21", None).is_err());
+        assert!(HeartbeatClient::new("not a url", None).is_err());
+    }
+
+    #[test]
+    fn client_builds_endpoint_without_double_slash() {
+        let client = HeartbeatClient::new("http://gw:40114/", Some("tok".into())).unwrap();
+        assert_eq!(
+            client.endpoint,
+            "http://gw:40114/api/internal/nodes/heartbeat"
+        );
+        assert_eq!(client.token.as_deref(), Some("tok"));
+    }
+
+    #[test]
+    fn empty_token_is_treated_as_unset() {
+        let client = HeartbeatClient::new("http://gw:40114", Some(String::new())).unwrap();
+        assert!(client.token.is_none());
+    }
+
+    #[test]
+    fn heartbeat_reply_tolerates_unknown_and_missing_fields() {
+        let reply: HeartbeatReply = serde_json::from_str(
+            r#"{"registered":true,"deployments_assigned":[],"next_heartbeat_secs":2,"future_field":1}"#,
+        )
+        .unwrap();
+        assert!(reply.registered);
+        assert_eq!(reply.next_heartbeat_secs, Some(2));
+
+        let bare: HeartbeatReply = serde_json::from_str("{}").unwrap();
+        assert!(!bare.registered);
+        assert!(bare.next_heartbeat_secs.is_none());
+    }
+}

--- a/src/daemon/lifecycle.rs
+++ b/src/daemon/lifecycle.rs
@@ -1,0 +1,234 @@
+//! Local inference process probing for `herd agent`.
+//!
+//! v1.2 only *observes* an already-running backend (Ollama or
+//! llama-server/openai-compat); it does not spawn or supervise processes.
+//! Spawn/supervision — including the v1.4 `rpc-server` role for
+//! pipeline-parallel groups — slots in here when those PRs land. Probe paths
+//! mirror `backend/discovery.rs`: `/api/ps` for Ollama loaded models,
+//! `/v1/models` for OpenAI-compatible servers.
+
+use crate::config::BackendType;
+use serde::Deserialize;
+use std::time::Duration;
+
+/// Roles the local inference process can take.
+///
+/// v1.4 adds an `RpcServer` variant here (llama.cpp pipeline-parallel
+/// worker); it is intentionally absent until the daemon can actually spawn
+/// and supervise one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LocalBackend {
+    Ollama,
+    LlamaServer,
+    OpenAICompat,
+}
+
+impl LocalBackend {
+    pub fn backend_type(&self) -> BackendType {
+        match self {
+            LocalBackend::Ollama => BackendType::Ollama,
+            LocalBackend::LlamaServer => BackendType::LlamaServer,
+            LocalBackend::OpenAICompat => BackendType::OpenAICompat,
+        }
+    }
+}
+
+/// Result of probing the local backend for one heartbeat.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProbeOutcome {
+    pub backend: BackendType,
+    pub models_loaded: Vec<String>,
+    pub reachable: bool,
+}
+
+/// Ollama `/api/ps` response (currently loaded models).
+#[derive(Debug, Deserialize)]
+struct OllamaPs {
+    #[serde(default)]
+    models: Vec<OllamaPsModel>,
+}
+
+#[derive(Debug, Deserialize)]
+struct OllamaPsModel {
+    #[serde(default)]
+    name: String,
+    #[serde(default)]
+    model: String,
+}
+
+/// OpenAI-compatible `/v1/models` response (llama-server always reports its
+/// loaded model here).
+#[derive(Debug, Deserialize)]
+struct OpenAIModels {
+    #[serde(default)]
+    data: Vec<OpenAIModel>,
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenAIModel {
+    id: String,
+}
+
+/// Parse an Ollama `/api/ps` body into loaded model names. Prefers the
+/// fully-qualified `model` field, falling back to `name` (same preference as
+/// `backend/discovery.rs`).
+pub fn parse_ollama_ps(body: &str) -> Option<Vec<String>> {
+    let ps: OllamaPs = serde_json::from_str(body).ok()?;
+    Some(
+        ps.models
+            .into_iter()
+            .map(|m| if m.model.is_empty() { m.name } else { m.model })
+            .filter(|m| !m.is_empty())
+            .collect(),
+    )
+}
+
+/// Parse an OpenAI-compatible `/v1/models` body into model ids.
+pub fn parse_openai_models(body: &str) -> Option<Vec<String>> {
+    let models: OpenAIModels = serde_json::from_str(body).ok()?;
+    Some(models.data.into_iter().map(|m| m.id).collect())
+}
+
+/// Probes the local inference backend. With no explicit backend type, it
+/// auto-detects: `/api/ps` answers → Ollama; else `/v1/models` answers →
+/// llama-server. (Ollama also serves `/v1/models`, so the Ollama-only
+/// endpoint must be probed first.)
+pub struct LocalProbe {
+    client: reqwest::Client,
+    base_url: String,
+    override_backend: Option<BackendType>,
+}
+
+impl LocalProbe {
+    pub fn new(base_url: String, override_backend: Option<BackendType>) -> anyhow::Result<Self> {
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(3))
+            .build()?;
+        Ok(Self {
+            client,
+            base_url: base_url.trim_end_matches('/').to_string(),
+            override_backend,
+        })
+    }
+
+    async fn get_body(&self, path: &str) -> Option<String> {
+        let url = format!("{}{}", self.base_url, path);
+        let resp = self.client.get(&url).send().await.ok()?;
+        if !resp.status().is_success() {
+            return None;
+        }
+        resp.text().await.ok()
+    }
+
+    async fn probe_ollama(&self) -> Option<Vec<String>> {
+        let body = self.get_body("/api/ps").await?;
+        parse_ollama_ps(&body)
+    }
+
+    async fn probe_openai(&self) -> Option<Vec<String>> {
+        let body = self.get_body("/v1/models").await?;
+        parse_openai_models(&body)
+    }
+
+    pub async fn probe(&self) -> ProbeOutcome {
+        match self.override_backend {
+            Some(BackendType::Ollama) => {
+                self.outcome(BackendType::Ollama, self.probe_ollama().await)
+            }
+            Some(backend @ (BackendType::LlamaServer | BackendType::OpenAICompat)) => {
+                self.outcome(backend, self.probe_openai().await)
+            }
+            None => {
+                if let Some(models) = self.probe_ollama().await {
+                    return ProbeOutcome {
+                        backend: BackendType::Ollama,
+                        models_loaded: models,
+                        reachable: true,
+                    };
+                }
+                self.outcome(BackendType::LlamaServer, self.probe_openai().await)
+            }
+        }
+    }
+
+    fn outcome(&self, backend: BackendType, models: Option<Vec<String>>) -> ProbeOutcome {
+        match models {
+            Some(models_loaded) => ProbeOutcome {
+                backend,
+                models_loaded,
+                reachable: true,
+            },
+            None => ProbeOutcome {
+                backend,
+                models_loaded: Vec::new(),
+                reachable: false,
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_ollama_ps_preferring_model_field() {
+        let body = r#"{"models":[{"name":"qwen3:32b","model":"qwen3:32b-q4_K_M"},{"name":"gemma3:4b","model":""}]}"#;
+        assert_eq!(
+            parse_ollama_ps(body).unwrap(),
+            vec!["qwen3:32b-q4_K_M".to_string(), "gemma3:4b".to_string()]
+        );
+    }
+
+    #[test]
+    fn parses_ollama_ps_with_nothing_loaded() {
+        assert_eq!(
+            parse_ollama_ps(r#"{"models":[]}"#).unwrap(),
+            Vec::<String>::new()
+        );
+        assert_eq!(parse_ollama_ps(r#"{}"#).unwrap(), Vec::<String>::new());
+    }
+
+    #[test]
+    fn malformed_ollama_ps_returns_none() {
+        assert!(parse_ollama_ps("not json").is_none());
+    }
+
+    #[test]
+    fn parses_openai_models_body() {
+        let body = r#"{"object":"list","data":[{"id":"qwen3-32b.gguf","object":"model"}]}"#;
+        assert_eq!(
+            parse_openai_models(body).unwrap(),
+            vec!["qwen3-32b.gguf".to_string()]
+        );
+    }
+
+    #[test]
+    fn openai_models_missing_data_defaults_empty() {
+        assert_eq!(parse_openai_models(r#"{}"#).unwrap(), Vec::<String>::new());
+        assert!(parse_openai_models("not json").is_none());
+    }
+
+    #[test]
+    fn local_backend_maps_to_backend_type() {
+        assert_eq!(LocalBackend::Ollama.backend_type(), BackendType::Ollama);
+        assert_eq!(
+            LocalBackend::LlamaServer.backend_type(),
+            BackendType::LlamaServer
+        );
+        assert_eq!(
+            LocalBackend::OpenAICompat.backend_type(),
+            BackendType::OpenAICompat
+        );
+    }
+
+    #[tokio::test]
+    async fn unreachable_backend_yields_unreachable_outcome() {
+        // Port 9 (discard) on localhost is virtually never listening.
+        let probe = LocalProbe::new("http://127.0.0.1:9".into(), None).unwrap();
+        let outcome = probe.probe().await;
+        assert!(!outcome.reachable);
+        assert!(outcome.models_loaded.is_empty());
+        assert_eq!(outcome.backend, BackendType::LlamaServer);
+    }
+}

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -1,0 +1,178 @@
+//! Node-side daemon for `herd agent` (v1.2 distributed-inference foundation).
+//!
+//! Runs on each GPU node, probes the local inference process, and heartbeats a
+//! capability snapshot to the gateway's `POST /api/internal/nodes/heartbeat`
+//! every 2s (configurable). Named `daemon` (not `agent`) to avoid colliding
+//! with the existing `src/agent/` sessions module; the user-facing CLI term
+//! remains `herd agent`.
+
+pub mod capabilities;
+pub mod client;
+pub mod lifecycle;
+
+use crate::config::BackendType;
+use anyhow::Context;
+use std::time::Duration;
+
+/// Arguments for the `herd agent` subcommand.
+#[derive(clap::Args, Debug, Clone)]
+pub struct AgentArgs {
+    /// Gateway base URL (e.g. http://herd.starbase:40114). Required — no
+    /// auto-discovery in v1.2.
+    #[arg(long)]
+    pub gateway: String,
+
+    /// Node identifier. Defaults to hostname-derived (`hostname-gpu`, e.g.
+    /// citadel-5090).
+    #[arg(long)]
+    pub node_id: Option<String>,
+
+    /// Heartbeat cadence in seconds
+    #[arg(long, default_value = "2", env = "HERD_HEARTBEAT_SECS")]
+    pub heartbeat_secs: u64,
+
+    /// Local inference backend URL to probe and advertise
+    #[arg(long, default_value = "http://127.0.0.1:11434")]
+    pub backend_url: String,
+
+    /// Address the gateway should use to reach this node's inference backend
+    /// (defaults to --backend-url; set this when the backend listens on
+    /// localhost but is reachable via a Tailscale hostname)
+    #[arg(long)]
+    pub advertise_url: Option<String>,
+
+    /// Backend type override (ollama | llama-server | openai-compat).
+    /// Auto-detected by probing when omitted.
+    #[arg(long, value_parser = parse_backend_type)]
+    pub backend: Option<BackendType>,
+}
+
+fn parse_backend_type(s: &str) -> Result<BackendType, String> {
+    match s {
+        "ollama" => Ok(BackendType::Ollama),
+        "llama-server" => Ok(BackendType::LlamaServer),
+        "openai-compat" => Ok(BackendType::OpenAICompat),
+        other => Err(format!(
+            "unknown backend type '{other}' (expected ollama, llama-server, or openai-compat)"
+        )),
+    }
+}
+
+/// Entry point for `herd agent`. Probes static node facts once (GPU model,
+/// total VRAM, node identity), then loops: refresh dynamic state (free VRAM,
+/// loaded models), POST the snapshot to the gateway, and sleep for the delay
+/// the schedule state machine picks (steady cadence, exponential backoff while
+/// the gateway is unreachable).
+pub async fn run(args: AgentArgs) -> anyhow::Result<()> {
+    let token = std::env::var("HERD_AGENT_TOKEN")
+        .ok()
+        .filter(|s| !s.is_empty());
+    if token.is_none() {
+        tracing::warn!(
+            "HERD_AGENT_TOKEN not set — sending unauthenticated heartbeats \
+             (the gateway rejects these unless HERD_ALLOW_UNAUTHENTICATED_AGENT_HEARTBEAT=true)"
+        );
+    }
+
+    // Static facts: probed once at startup, not re-derived every beat.
+    let gpu = tokio::task::spawn_blocking(capabilities::detect_gpu_static)
+        .await
+        .context("GPU detection task panicked")?;
+    let hostname = hostname::get()
+        .map(|h| h.to_string_lossy().into_owned())
+        .unwrap_or_else(|_| "node".to_string());
+    let node_id = args
+        .node_id
+        .clone()
+        .unwrap_or_else(|| capabilities::default_node_id(&hostname, gpu.model.as_deref()));
+
+    tracing::info!(
+        "herd agent starting: node_id={} gateway={} gpu={} vram={}MB backend_url={}",
+        node_id,
+        args.gateway,
+        gpu.model.as_deref().unwrap_or("none"),
+        gpu.vram_total_mb,
+        args.backend_url
+    );
+
+    let advertise_url = args
+        .advertise_url
+        .clone()
+        .unwrap_or_else(|| args.backend_url.clone());
+    let snapshotter = capabilities::SnapshotBuilder::new(node_id, gpu.clone());
+    let probe = lifecycle::LocalProbe::new(args.backend_url.clone(), args.backend)
+        .context("failed to build local backend probe")?;
+    let heartbeat = client::HeartbeatClient::new(&args.gateway, token)
+        .context("failed to build heartbeat client")?;
+    let mut schedule =
+        client::HeartbeatSchedule::new(Duration::from_secs(args.heartbeat_secs.max(1)));
+
+    let mut last_vram_free_mb = gpu.vram_total_mb;
+    let mut gateway_up = false;
+    let mut backend_reachable = true;
+
+    loop {
+        let vendor = gpu.vendor;
+        if let Ok(Some(free)) =
+            tokio::task::spawn_blocking(move || capabilities::probe_vram_free_mb(vendor)).await
+        {
+            last_vram_free_mb = free;
+        }
+
+        let local = probe.probe().await;
+        if local.reachable != backend_reachable {
+            backend_reachable = local.reachable;
+            if backend_reachable {
+                tracing::info!(
+                    "local backend reachable at {} ({} models loaded)",
+                    args.backend_url,
+                    local.models_loaded.len()
+                );
+            } else {
+                tracing::warn!(
+                    "local backend unreachable at {} — heartbeating with empty model list",
+                    args.backend_url
+                );
+            }
+        }
+
+        let caps = snapshotter.snapshot(
+            local.backend,
+            advertise_url.clone(),
+            last_vram_free_mb,
+            local.models_loaded,
+        );
+
+        let outcome = heartbeat.send(&caps).await;
+        match &outcome {
+            client::BeatOutcome::Success { registered, .. } => {
+                if *registered {
+                    tracing::info!("registered with gateway {}", args.gateway);
+                } else if !gateway_up {
+                    tracing::info!("gateway {} reachable again", args.gateway);
+                }
+                gateway_up = true;
+            }
+            client::BeatOutcome::Rejected { status, body } => {
+                gateway_up = false;
+                tracing::error!("gateway rejected heartbeat: HTTP {} {}", status, body);
+            }
+            client::BeatOutcome::Unreachable(err) => {
+                if gateway_up || schedule.consecutive_failures() == 0 {
+                    tracing::warn!("gateway unreachable: {}", err);
+                }
+                gateway_up = false;
+            }
+        }
+
+        let delay = schedule.record(&outcome);
+        if !gateway_up && schedule.consecutive_failures() > 1 {
+            tracing::debug!(
+                "retrying heartbeat in {:?} ({} consecutive failures)",
+                delay,
+                schedule.consecutive_failures()
+            );
+        }
+        tokio::time::sleep(delay).await;
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ pub mod classifier;
 pub mod classifier_auto;
 pub mod cli;
 pub mod config;
+pub mod daemon;
 pub mod discovery;
 pub mod metrics;
 pub mod nodes;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,33 +1,8 @@
 use clap::Parser;
+use herd::cli::{Cli, Command, ServeArgs};
 use herd::config::Config;
 use herd::server;
-use std::path::PathBuf;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
-
-#[derive(Parser)]
-#[command(name = "herd")]
-#[command(about = "Intelligent Ollama router with GPU awareness", long_about = None)]
-struct Cli {
-    /// Path to config file
-    #[arg(short, long, value_name = "FILE")]
-    config: Option<PathBuf>,
-
-    /// Port to listen on
-    #[arg(short, long, default_value = "40114")]
-    port: u16,
-
-    /// Host to bind to
-    #[arg(long, default_value = "0.0.0.0")]
-    host: String,
-
-    /// Backend URLs (format: name=url:priority)
-    #[arg(short, long)]
-    backend: Vec<String>,
-
-    /// Check for updates and install if available
-    #[arg(long)]
-    update: bool,
-}
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
@@ -68,7 +43,15 @@ async fn main() -> anyhow::Result<()> {
         }
     }
 
-    let (mut config, config_path) = if let Some(config_path) = cli.config {
+    match cli.command {
+        Some(Command::Agent(args)) => herd::daemon::run(args).await,
+        Some(Command::Serve(args)) => serve(args).await,
+        None => serve(cli.serve).await,
+    }
+}
+
+async fn serve(args: ServeArgs) -> anyhow::Result<()> {
+    let (mut config, config_path) = if let Some(config_path) = args.config {
         let config = match Config::from_file(&config_path) {
             Ok(c) => c,
             Err(e) => {
@@ -80,10 +63,10 @@ async fn main() -> anyhow::Result<()> {
         (config, Some(config_path))
     } else {
         let mut config = Config::default();
-        config.server.host = cli.host;
-        config.server.port = cli.port;
+        config.server.host = args.host;
+        config.server.port = args.port;
 
-        for spec in cli.backend {
+        for spec in args.backend {
             match herd::cli::parse_backend_spec(&spec) {
                 Some(backend) => config.backends.push(backend),
                 None => tracing::warn!("Ignoring invalid backend spec: {}", spec),

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -22,9 +22,9 @@ pub trait ProviderAdapter: Send + Sync {
 
 /// Check if a model name belongs to any configured frontier provider
 pub fn is_frontier_model(model: &str, providers: &[ProviderConfig]) -> bool {
-    providers.iter().any(|p| {
-        p.models.iter().any(|m| m == model) || (p.models.is_empty() && !model.is_empty())
-    })
+    providers
+        .iter()
+        .any(|p| p.models.iter().any(|m| m == model) || (p.models.is_empty() && !model.is_empty()))
 }
 
 /// Find the provider that serves a given model (highest priority wins)

--- a/tasks/HERD-V1.2-SPRINT.md
+++ b/tasks/HERD-V1.2-SPRINT.md
@@ -2,7 +2,7 @@
 
 **Spec:** `docs/specs/v2-distributed-inference-spec.md`
 **Target:** v1.2 (foundation) — `herd agent` ships, single-node deployments only. No speculative, no pipeline.
-**Status:** PRs #1–#3 landed of 8 (last reconciled with implementation: 2026-06-05)
+**Status:** PRs #1–#4 landed of 8 (last reconciled with implementation: 2026-06-09)
 
 > This doc tracks the PR breakdown and acceptance checklist for the v1.2 milestone.
 > The architecture, data structures, and rationale live in the spec — this is the
@@ -17,7 +17,7 @@
 | #1 | Seed `Deployment` module | `Deployment::Single` variant in `src/router/deployment.rs`, `primary_backend()` accessor + unit tests | ✅ landed (`2960289`) |
 | #2 | `NodeRegistry` with TTL eviction | In-memory `NodeRegistry` keyed by `node_id`, heartbeat-only protocol, injectable `Clock` for deterministic time tests, 10 unit tests | ✅ landed (`be6f24e`) |
 | #3 | Gateway heartbeat ingestion | `NodeRegistry` onto `AppState`; stale-eviction background task; `POST /api/internal/nodes/heartbeat` with `HERD_AGENT_TOKEN` bearer auth; heartbeat protocol tests | ✅ landed |
-| #4 | `herd agent` CLI + daemon | Restructure CLI into `serve`/`agent` subcommands; `src/daemon/` (heartbeat client, capability detection, lifecycle); single-node deployment | ⬜ next |
+| #4 | `herd agent` CLI + daemon | Restructure CLI into `serve`/`agent` subcommands; `src/daemon/` (heartbeat client, capability detection, lifecycle); single-node deployment | ✅ landed |
 | #5 | Dashboard Fleet integration | Fleet tab projects `NodeRegistry` live agent state alongside SQLite operator nodes | ⬜ |
 | #6 | Heartbeat protocol hardening | Version-skew handling, deployments-assigned response plumbing, configurable TTL/cadence | ⬜ |
 | #7 | `BackendPool` integration | Agent-registered nodes route identically to static backends; `NodeRegistry::find_for_model()`; conflict resolution (agent overrides static only on exact node-identity match) | ⬜ |
@@ -29,17 +29,17 @@
 
 From the spec's "v1.2 — Agent/Gateway Foundation" acceptance block, annotated with PR ownership:
 
-- [ ] `herd agent --gateway <url> --node-id <id>` subcommand exists *(PR #4)*
-- [ ] Agent sends heartbeat every 2s with full capability snapshot *(PR #4)*
+- [x] `herd agent --gateway <url> --node-id <id>` subcommand exists *(PR #4 — node_id defaults to hostname-gpu, e.g. `citadel-5090`)*
+- [x] Agent sends heartbeat every 2s with full capability snapshot *(PR #4 — exponential backoff capped at 30s while gateway unreachable)*
 - [x] `POST /api/internal/nodes/heartbeat` is the only v1.2 agent-control endpoint; unknown `node_id` values are implicitly registered on first heartbeat *(PR #3)*
 - [x] Gateway maintains in-memory `NodeRegistry` keyed by `node_id` with TTL eviction (default 30s) *(struct in PR #2; on `AppState` + eviction task in PR #3)*
 - [ ] Agent-registered nodes appear in `BackendPool` and route identically to static backends *(PR #7)*
 - [x] Existing static-backend config path is unchanged *(maintained; verified PR #3)*
 - [ ] Dashboard Fleet tab shows agent-registered nodes with live state *(PR #5)*
-- [ ] Both modes can run on the same host (CITADEL self-test scenario) *(PR #4/#8)*
+- [~] Both modes can run on the same host (CITADEL self-test scenario) *(PR #4: guarded self-test in `tests/agent_daemon.rs` + manual smoke verified 2026-06-09; PR #8 extends to routed end-to-end)*
 - [x] Auth: shared bearer token via env var (`HERD_AGENT_TOKEN`) *(PR #3)*
 - [ ] Gateway returns 503 with clear error if all healthy backends — agent and static — are gone (no hidden fallback) *(PR #7)*
-- [~] Tests: `NodeRegistry` unit tests *(PR #2: 10 tests)*, heartbeat protocol tests *(PR #3: 8 tests, verified green 2026-06-05)*, integration test with gateway + 1 agent in same process *(PR #8)*
+- [~] Tests: `NodeRegistry` unit tests *(PR #2: 10 tests)*, heartbeat protocol tests *(PR #3: 8 tests, verified green 2026-06-05)*, daemon unit + heartbeat-client integration tests *(PR #4: 39 unit tests + `tests/agent_daemon.rs`)*, integration test with gateway + 1 agent in same process *(PR #8)*
 
 ---
 

--- a/tests/agent_daemon.rs
+++ b/tests/agent_daemon.rs
@@ -1,0 +1,198 @@
+//! Integration tests for the `herd agent` daemon (v1.2 PR #4).
+//!
+//! The non-guarded tests run the real `HeartbeatClient` against a stub
+//! gateway speaking the heartbeat contract, over real HTTP on an ephemeral
+//! port. The CITADEL "both modes on one host" self-test boots the full
+//! gateway (`server::run`) plus the daemon loop and is `#[ignore]`d — run it
+//! with `cargo test --test agent_daemon -- --ignored`.
+
+use axum::extract::State;
+use axum::http::HeaderMap;
+use axum::routing::post;
+use axum::{Json, Router};
+use herd::config::BackendType;
+use herd::daemon::capabilities::{GpuStatic, GpuVendor, SnapshotBuilder};
+use herd::daemon::client::{BeatOutcome, HeartbeatClient};
+use std::net::SocketAddr;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+/// (authorization header, request body) per received heartbeat.
+type ReceivedBeats = Arc<Mutex<Vec<(Option<String>, serde_json::Value)>>>;
+
+#[derive(Clone, Default)]
+struct StubGateway {
+    received: ReceivedBeats,
+}
+
+async fn stub_heartbeat(
+    State(stub): State<StubGateway>,
+    headers: HeaderMap,
+    Json(body): Json<serde_json::Value>,
+) -> Json<serde_json::Value> {
+    let auth = headers
+        .get("authorization")
+        .and_then(|v| v.to_str().ok())
+        .map(str::to_string);
+    let mut received = stub.received.lock().unwrap();
+    let registered = received.is_empty();
+    received.push((auth, body));
+    Json(serde_json::json!({
+        "registered": registered,
+        "deployments_assigned": [],
+        "next_heartbeat_secs": 2
+    }))
+}
+
+async fn spawn_stub_gateway() -> (StubGateway, SocketAddr) {
+    let stub = StubGateway::default();
+    let app = Router::new()
+        .route("/api/internal/nodes/heartbeat", post(stub_heartbeat))
+        .with_state(stub.clone());
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+    (stub, addr)
+}
+
+fn test_snapshot(node_id: &str) -> herd::nodes::AgentCapabilities {
+    let builder = SnapshotBuilder::new(
+        node_id.to_string(),
+        GpuStatic {
+            vendor: GpuVendor::Nvidia,
+            model: Some("NVIDIA GeForce RTX 5090".into()),
+            vram_total_mb: 32607,
+            driver_version: Some("572.83".into()),
+        },
+    );
+    builder.snapshot(
+        BackendType::LlamaServer,
+        "http://127.0.0.1:8080".into(),
+        30_000,
+        vec!["qwen3-32b.gguf".into()],
+    )
+}
+
+#[tokio::test]
+async fn heartbeat_round_trip_with_bearer_token() {
+    let (stub, addr) = spawn_stub_gateway().await;
+    let client =
+        HeartbeatClient::new(&format!("http://{addr}"), Some("test-token".into())).unwrap();
+    let caps = test_snapshot("citadel-5090");
+
+    let first = client.send(&caps).await;
+    assert_eq!(
+        first,
+        BeatOutcome::Success {
+            registered: true,
+            next_heartbeat_secs: Some(2)
+        }
+    );
+
+    let second = client.send(&caps).await;
+    assert_eq!(
+        second,
+        BeatOutcome::Success {
+            registered: false,
+            next_heartbeat_secs: Some(2)
+        }
+    );
+
+    let received = stub.received.lock().unwrap();
+    assert_eq!(received.len(), 2);
+    let (auth, body) = &received[0];
+    assert_eq!(auth.as_deref(), Some("Bearer test-token"));
+    assert_eq!(body["capabilities"]["node_id"], "citadel-5090");
+    assert_eq!(body["capabilities"]["backend"], "llama-server");
+    assert_eq!(body["capabilities"]["vram_total_mb"], 32607);
+    assert_eq!(body["capabilities"]["models_loaded"][0], "qwen3-32b.gguf");
+    assert!(
+        body["timestamp"].is_string(),
+        "timestamp field must be sent"
+    );
+}
+
+#[tokio::test]
+async fn heartbeat_omits_authorization_header_when_token_unset() {
+    let (stub, addr) = spawn_stub_gateway().await;
+    let client = HeartbeatClient::new(&format!("http://{addr}"), None).unwrap();
+
+    let outcome = client.send(&test_snapshot("minipc")).await;
+    assert!(matches!(outcome, BeatOutcome::Success { .. }));
+
+    let received = stub.received.lock().unwrap();
+    assert_eq!(received[0].0, None, "no Authorization header expected");
+}
+
+#[tokio::test]
+async fn unreachable_gateway_reports_unreachable() {
+    // Bind-then-drop to get a port with nothing listening.
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    drop(listener);
+
+    let client = HeartbeatClient::new(&format!("http://{addr}"), None).unwrap();
+    let outcome = client.send(&test_snapshot("ghost")).await;
+    assert!(matches!(outcome, BeatOutcome::Unreachable(_)));
+}
+
+/// CITADEL self-test: real gateway (`herd serve` internals) and the real
+/// daemon loop in one process on one host. Touches the user's herd SQLite/
+/// analytics paths and binds a real port, hence `#[ignore]`.
+#[tokio::test]
+#[ignore]
+async fn both_modes_on_one_host_self_test() {
+    std::env::set_var("HERD_AGENT_TOKEN", "self-test-token");
+
+    // Reserve an ephemeral port for the gateway.
+    let probe_listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = probe_listener.local_addr().unwrap().port();
+    drop(probe_listener);
+
+    let mut config = herd::config::Config::default();
+    config.server.host = "127.0.0.1".into();
+    config.server.port = port;
+    tokio::spawn(async move {
+        let _ = herd::server::run(config, None).await;
+    });
+
+    // Wait for the gateway to accept connections.
+    let gateway = format!("http://127.0.0.1:{port}");
+    let http = reqwest::Client::new();
+    let mut up = false;
+    for _ in 0..50 {
+        if http.get(&gateway).send().await.is_ok() {
+            up = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    assert!(up, "gateway did not come up on {gateway}");
+
+    // Run the real daemon loop against it for a few beats.
+    let args = herd::daemon::AgentArgs {
+        gateway: gateway.clone(),
+        node_id: Some("self-test-daemon".into()),
+        heartbeat_secs: 1,
+        backend_url: "http://127.0.0.1:1".into(), // no local backend in this test
+        advertise_url: Some("http://127.0.0.1:8080".into()),
+        backend: Some(BackendType::LlamaServer),
+    };
+    tokio::spawn(herd::daemon::run(args));
+    tokio::time::sleep(Duration::from_millis(2500)).await;
+
+    // The daemon must have registered the node: a manual heartbeat with the
+    // same node_id now reports registered=false (known node).
+    let client = HeartbeatClient::new(&gateway, Some("self-test-token".into())).unwrap();
+    let outcome = client.send(&test_snapshot("self-test-daemon")).await;
+    assert_eq!(
+        outcome,
+        BeatOutcome::Success {
+            registered: false,
+            next_heartbeat_secs: Some(2)
+        },
+        "daemon should already have registered this node_id"
+    );
+}


### PR DESCRIPTION
Node-side herd agent daemon: heartbeat client, GPU/VRAM capability detection (nvidia/rocm/cpu), local backend lifecycle probe. CLI restructured into serve/agent subcommands; legacy flags preserved. Single-node deployment. 39 new tests. Sprint: tasks/HERD-V1.2-SPRINT.md PR #4.