### PR TITLE
feat(nodes): persist agent-heartbeat nodes to SQLite for Fleet (v1.2 PR #5, re-targeted)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -131,7 +131,7 @@ No cloud dependency. No API keys exposed. Full local control.
 
 Three-phase delivery introduces self-registering node agents and deployment-aware routing:
 
-- **v1.2** — Agent/Gateway foundation. `herd agent` subcommand, `NodeRegistry`, single-node deployments. Sprint plan: `tasks/HERD-V1.2-SPRINT.md`. *Status: PRs #1–#4 of 8 landed — `Deployment` module, `NodeRegistry` with TTL eviction, gateway heartbeat endpoint (`HERD_AGENT_TOKEN` auth), and the node-side `herd agent` daemon (GPU/VRAM detection, local backend probe, 2s heartbeat with backoff). Remaining: dashboard Fleet integration, protocol hardening, `BackendPool` routing integration, end-to-end test.*
+- **v1.2** — Agent/Gateway foundation. `herd agent` subcommand, `NodeRegistry`, single-node deployments. Sprint plan: `tasks/HERD-V1.2-SPRINT.md`. *Status: PRs #1–#5 of 8 landed — `Deployment` module, `NodeRegistry` with TTL eviction, gateway heartbeat endpoint (`HERD_AGENT_TOKEN` auth), the node-side `herd agent` daemon (GPU/VRAM detection, local backend probe, 2s heartbeat with backoff), and agent node persistence (migration v5 `source`/`agent_version`, write-through on transitions, soft-evict + reaper, Fleet tab reads unified SQLite store). Remaining: protocol hardening, `BackendPool` routing integration, end-to-end test.*
 - **v1.3** — Speculative decoding deployments. Draft/verifier pairs across nodes via llama.cpp's `--model-draft` for 2-3x throughput on daily-driver models.
 - **v1.4** — Pipeline parallel deployments. llama.cpp RPC integration to serve models that don't fit on any single GPU (Qwen2.5-72B-class).
 

--- a/dashboard.html
+++ b/dashboard.html
@@ -450,6 +450,7 @@
         .badge-backend.ollama { background: rgba(96, 165, 250, 0.15); color: #60a5fa; }
         .badge-backend.llama-server { background: rgba(74, 222, 128, 0.15); color: #4ade80; }
         .badge-backend.unknown { background: rgba(100, 116, 139, 0.15); color: #94a3b8; }
+        .badge-backend.agent { background: rgba(167, 139, 250, 0.15); color: #a78bfa; }
 
         /* GPU Info Tags */
         .gpu-info-row { display: flex; gap: 6px; flex-wrap: wrap; margin-bottom: 10px; }
@@ -2187,9 +2188,9 @@ Content-Type: application/json
             }
 
             tbody.innerHTML = fleetNodes.map(node => {
-                const statusClass = node.status === 'healthy' ? 'status-healthy' :
+                const statusClass = (node.status === 'healthy' || node.status === 'online') ? 'status-healthy' :
                                    node.status === 'degraded' ? 'status-degraded' :
-                                   node.status === 'disabled' ? 'status-disabled' : 'status-unreachable';
+                                   (node.status === 'disabled' || node.status === 'offline') ? 'status-disabled' : 'status-unreachable';
                 const statusDot = `<span class="status-dot ${statusClass}"></span>`;
                 const vramGB = node.vram_mb ? (node.vram_mb / 1024).toFixed(1) + ' GB' : '\u2014';
                 const ramGB = node.ram_mb ? (node.ram_mb / 1024).toFixed(1) + ' GB' : '\u2014';
@@ -2203,6 +2204,13 @@ Content-Type: application/json
                 const btClass = bt === 'llama-server' ? 'llama-server' : bt === 'ollama' ? 'ollama' : 'unknown';
                 const btLabel = bt === 'llama-server' ? 'llama-server' : 'Ollama';
                 const backendBadge = `<span class="badge-backend ${btClass}">${btLabel}</span>`;
+
+                // Source badge: 'agent' rows come from herd agent heartbeats
+                // (live state in the gateway registry); enrolled rows from herd-tune.
+                const agentVer = node.agent_version ? ' v' + node.agent_version : '';
+                const sourceBadge = node.source === 'agent'
+                    ? ` <span class="badge-backend agent" title="Registered via herd agent heartbeat${escapeHtml(agentVer)}">agent</span>`
+                    : '';
                 const backendVer = node.backend_version ? `<br><small style="color:#64748b;">${escapeHtml(node.backend_version)}</small>` : '';
 
                 // GPU info
@@ -2243,7 +2251,7 @@ Content-Type: application/json
                 }
 
                 return `<tr class="${!node.enabled ? 'row-disabled' : ''}">
-                    <td><strong>${escapeHtml(node.hostname || '')}</strong><br><small style="color:#64748b;">${escapeHtml(node.ollama_url || '')}</small></td>
+                    <td><strong>${escapeHtml(node.hostname || '')}</strong>${sourceBadge}<br><small style="color:#64748b;">${escapeHtml(node.ollama_url || node.backend_url || '')}</small></td>
                     <td>${backendBadge}${backendVer}</td>
                     <td>${gpuInfoHtml}</td>
                     <td>${vramGB}</td>

--- a/src/api/internal.rs
+++ b/src/api/internal.rs
@@ -6,11 +6,17 @@
 //! in-memory `NodeRegistry`. Unknown `node_id` values are registered implicitly on
 //! first heartbeat; there is no separate registration endpoint.
 //!
+//! Persistence: the handler also writes a `source='agent'` row to the SQLite
+//! `nodes` table for Fleet-tab visibility — on registration and on material
+//! capability change only (steady beats stay in-memory). The `NodeRegistry`
+//! itself has no DB dependency; this glue lives here and in `server.rs`'s
+//! evictor/reaper tasks.
+//!
 //! Auth: shared bearer token via the `HERD_AGENT_TOKEN` env var. The token is
 //! required by default. Local self-tests can opt into an unauthenticated mode by
 //! setting `HERD_ALLOW_UNAUTHENTICATED_AGENT_HEARTBEAT=true`.
 
-use crate::nodes::{AgentCapabilities, HeartbeatOutcome, NodeRegistry};
+use crate::nodes::{AgentCapabilities, HeartbeatOutcome, NodeDb, NodeRegistry};
 use crate::server::{constant_time_eq, AppState};
 use axum::{
     extract::State,
@@ -162,8 +168,14 @@ fn validate_capabilities(caps: &AgentCapabilities) -> Result<(), String> {
 /// Core heartbeat logic, decoupled from axum extractors so it can be unit-tested
 /// without constructing a full `AppState`. Checks auth, then records the
 /// heartbeat in the registry (registering unknown nodes implicitly).
+///
+/// `node_db` is the SQLite write-through for Fleet visibility: rows are upserted
+/// on registration and on material capability change (`models_loaded` set
+/// differs), never on steady unchanged beats. A DB failure is logged and does
+/// not fail the heartbeat — liveness must not depend on persistence.
 async fn process_heartbeat(
     registry: &NodeRegistry,
+    node_db: Option<&NodeDb>,
     expected_token: Option<&str>,
     allow_unauthenticated: bool,
     headers: &HeaderMap,
@@ -178,6 +190,7 @@ async fn process_heartbeat(
     })?;
 
     let node_id = req.capabilities.node_id.clone();
+    let caps_for_db = node_db.map(|_| req.capabilities.clone());
     let outcome = registry.heartbeat(req.capabilities).await.map_err(|e| {
         (
             StatusCode::SERVICE_UNAVAILABLE,
@@ -187,6 +200,21 @@ async fn process_heartbeat(
     let registered = matches!(outcome, HeartbeatOutcome::Registered);
     if registered {
         tracing::info!("Agent node registered via heartbeat: {}", node_id);
+    }
+
+    let persist = registered
+        || matches!(
+            outcome,
+            HeartbeatOutcome::Updated {
+                models_changed: true
+            }
+        );
+    if persist {
+        if let (Some(db), Some(caps)) = (node_db, caps_for_db) {
+            if let Err(e) = db.upsert_agent_node(&caps) {
+                tracing::error!("Failed to persist agent node {}: {}", node_id, e);
+            }
+        }
     }
 
     Ok(HeartbeatResponse {
@@ -235,6 +263,7 @@ pub async fn heartbeat(
 
     process_heartbeat(
         &state.node_registry,
+        Some(&state.node_db),
         expected.as_deref(),
         allow_unauthenticated,
         &headers,
@@ -280,7 +309,8 @@ mod tests {
             capabilities: sample_caps("a", "1.2.0"),
             timestamp: None,
         };
-        let res = process_heartbeat(&reg, Some("secret"), false, &HeaderMap::new(), req).await;
+        let res =
+            process_heartbeat(&reg, None, Some("secret"), false, &HeaderMap::new(), req).await;
         let err = res.unwrap_err();
         assert_eq!(err.0, StatusCode::UNAUTHORIZED);
         assert_eq!(reg.len().await, 0, "rejected heartbeat must not register");
@@ -293,7 +323,7 @@ mod tests {
             capabilities: sample_caps("a", "1.2.0"),
             timestamp: None,
         };
-        let res = process_heartbeat(&reg, Some("secret"), false, &bearer("wrong"), req).await;
+        let res = process_heartbeat(&reg, None, Some("secret"), false, &bearer("wrong"), req).await;
         assert_eq!(res.unwrap_err().0, StatusCode::UNAUTHORIZED);
     }
 
@@ -304,7 +334,7 @@ mod tests {
             capabilities: sample_caps("a", "1.2.0"),
             timestamp: None,
         };
-        let res = process_heartbeat(&reg, None, false, &HeaderMap::new(), req).await;
+        let res = process_heartbeat(&reg, None, None, false, &HeaderMap::new(), req).await;
         assert_eq!(res.unwrap_err().0, StatusCode::UNAUTHORIZED);
         assert_eq!(reg.len().await, 0);
     }
@@ -316,7 +346,7 @@ mod tests {
             capabilities: sample_caps("citadel-5090", "1.2.0"),
             timestamp: None,
         };
-        let resp = process_heartbeat(&reg, Some("secret"), false, &bearer("secret"), req)
+        let resp = process_heartbeat(&reg, None, Some("secret"), false, &bearer("secret"), req)
             .await
             .unwrap();
         assert!(resp.registered);
@@ -334,7 +364,7 @@ mod tests {
             capabilities: sample_caps("a", "1.2.0"),
             timestamp: None,
         };
-        let resp = process_heartbeat(&reg, Some("secret"), false, &headers, req)
+        let resp = process_heartbeat(&reg, None, Some("secret"), false, &headers, req)
             .await
             .unwrap();
         assert!(resp.registered);
@@ -347,7 +377,7 @@ mod tests {
             capabilities: sample_caps("a", "1.2.0"),
             timestamp: None,
         };
-        let resp = process_heartbeat(&reg, None, true, &HeaderMap::new(), req)
+        let resp = process_heartbeat(&reg, None, None, true, &HeaderMap::new(), req)
             .await
             .unwrap();
         assert!(resp.registered);
@@ -362,11 +392,12 @@ mod tests {
                 capabilities: sample_caps("a", "1.2.0"),
                 timestamp: None,
             };
-            let _ = process_heartbeat(&reg, None, true, &HeaderMap::new(), req).await;
+            let _ = process_heartbeat(&reg, None, None, true, &HeaderMap::new(), req).await;
         }
         // First registers, second updates.
         let resp = process_heartbeat(
             &reg,
+            None,
             None,
             true,
             &HeaderMap::new(),
@@ -391,7 +422,7 @@ mod tests {
             capabilities: sample_caps("bad/id", "1.2.0"),
             timestamp: None,
         };
-        let res = process_heartbeat(&reg, None, true, &HeaderMap::new(), req).await;
+        let res = process_heartbeat(&reg, None, None, true, &HeaderMap::new(), req).await;
         assert_eq!(res.unwrap_err().0, StatusCode::BAD_REQUEST);
         assert_eq!(reg.len().await, 0);
     }
@@ -405,7 +436,7 @@ mod tests {
             capabilities: caps,
             timestamp: None,
         };
-        let res = process_heartbeat(&reg, None, true, &HeaderMap::new(), req).await;
+        let res = process_heartbeat(&reg, None, None, true, &HeaderMap::new(), req).await;
         assert_eq!(res.unwrap_err().0, StatusCode::BAD_REQUEST);
         assert_eq!(reg.len().await, 0);
     }
@@ -417,7 +448,7 @@ mod tests {
             capabilities: sample_caps("a", "1.2.0"),
             timestamp: None,
         };
-        process_heartbeat(&reg, None, true, &HeaderMap::new(), first)
+        process_heartbeat(&reg, None, None, true, &HeaderMap::new(), first)
             .await
             .unwrap();
 
@@ -425,9 +456,119 @@ mod tests {
             capabilities: sample_caps("b", "1.2.0"),
             timestamp: None,
         };
-        let res = process_heartbeat(&reg, None, true, &HeaderMap::new(), second).await;
+        let res = process_heartbeat(&reg, None, None, true, &HeaderMap::new(), second).await;
         assert_eq!(res.unwrap_err().0, StatusCode::SERVICE_UNAVAILABLE);
         assert_eq!(reg.len().await, 1);
+    }
+
+    fn beat(caps: AgentCapabilities) -> HeartbeatRequest {
+        HeartbeatRequest {
+            capabilities: caps,
+            timestamp: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn first_heartbeat_persists_agent_row() {
+        let reg = NodeRegistry::new(Duration::from_secs(30));
+        let db = NodeDb::open_in_memory().unwrap();
+        let resp = process_heartbeat(
+            &reg,
+            Some(&db),
+            None,
+            true,
+            &HeaderMap::new(),
+            beat(sample_caps("citadel-5090", "1.2.0")),
+        )
+        .await
+        .unwrap();
+        assert!(resp.registered);
+
+        let nodes = db.list_nodes().unwrap();
+        assert_eq!(nodes.len(), 1);
+        assert_eq!(nodes[0].source, "agent");
+        assert_eq!(nodes[0].status, "online");
+        assert_eq!(nodes[0].agent_version.as_deref(), Some("1.2.0"));
+    }
+
+    #[tokio::test]
+    async fn unchanged_beat_does_not_touch_db() {
+        let reg = NodeRegistry::new(Duration::from_secs(30));
+        let db = NodeDb::open_in_memory().unwrap();
+        process_heartbeat(
+            &reg,
+            Some(&db),
+            None,
+            true,
+            &HeaderMap::new(),
+            beat(sample_caps("a", "1.2.0")),
+        )
+        .await
+        .unwrap();
+
+        // Sentinel: if the handler wrote on this beat, the upsert would flip
+        // the row back to 'online'.
+        db.mark_agent_offline("a").unwrap();
+
+        // Same capability snapshot — steady-state beat must not write.
+        let mut caps = sample_caps("a", "1.2.0");
+        caps.vram_free_mb = 1; // dynamic field churn is not material
+        process_heartbeat(&reg, Some(&db), None, true, &HeaderMap::new(), beat(caps))
+            .await
+            .unwrap();
+
+        let nodes = db.list_nodes().unwrap();
+        assert_eq!(nodes.len(), 1);
+        assert_eq!(
+            nodes[0].status, "offline",
+            "unchanged beat must not write to SQLite"
+        );
+    }
+
+    #[tokio::test]
+    async fn model_change_beat_updates_db() {
+        let reg = NodeRegistry::new(Duration::from_secs(30));
+        let db = NodeDb::open_in_memory().unwrap();
+        process_heartbeat(
+            &reg,
+            Some(&db),
+            None,
+            true,
+            &HeaderMap::new(),
+            beat(sample_caps("a", "1.2.0")),
+        )
+        .await
+        .unwrap();
+
+        let mut caps = sample_caps("a", "1.2.0");
+        caps.models_loaded = vec!["llama-3-8b".to_string(), "qwen3-32b".to_string()];
+        process_heartbeat(&reg, Some(&db), None, true, &HeaderMap::new(), beat(caps))
+            .await
+            .unwrap();
+
+        let nodes = db.list_nodes().unwrap();
+        assert_eq!(nodes.len(), 1);
+        assert_eq!(
+            nodes[0].models_loaded,
+            vec!["llama-3-8b".to_string(), "qwen3-32b".to_string()]
+        );
+    }
+
+    #[tokio::test]
+    async fn rejected_heartbeat_does_not_persist() {
+        let reg = NodeRegistry::new(Duration::from_secs(30));
+        let db = NodeDb::open_in_memory().unwrap();
+        let res = process_heartbeat(
+            &reg,
+            Some(&db),
+            Some("secret"),
+            false,
+            &HeaderMap::new(),
+            beat(sample_caps("a", "1.2.0")),
+        )
+        .await;
+        assert!(res.is_err());
+        assert!(db.list_nodes().unwrap().is_empty());
     }
 
     #[test]

--- a/src/api/models.rs
+++ b/src/api/models.rs
@@ -820,6 +820,8 @@ mod tests {
             last_health_check: None,
             registered_at: "2026-04-08T00:00:00Z".to_string(),
             updated_at: "2026-04-08T00:00:00Z".to_string(),
+            source: "enrolled".to_string(),
+            agent_version: None,
         }
     }
 

--- a/src/nodes/db.rs
+++ b/src/nodes/db.rs
@@ -1,3 +1,4 @@
+use super::registry::AgentCapabilities;
 use super::types::*;
 use anyhow::Result;
 use rusqlite::Connection;
@@ -65,6 +66,17 @@ impl NodeDb {
         let db_path = herd_dir.join("herd.db");
         let conn = Connection::open(&db_path)?;
         conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;")?;
+        let db = Self {
+            conn: Mutex::new(conn),
+        };
+        db.migrate()?;
+        Ok(db)
+    }
+
+    /// In-memory database for unit tests (no filesystem access).
+    #[cfg(test)]
+    pub fn open_in_memory() -> Result<Self> {
+        let conn = Connection::open_in_memory()?;
         let db = Self {
             conn: Mutex::new(conn),
         };
@@ -157,6 +169,14 @@ impl NodeDb {
             );",
         )?;
 
+        // Migration v5: agent-heartbeat node persistence. `source` discriminates
+        // how a node entered the registry; the DEFAULT backfills all existing
+        // rows as 'enrolled'.
+        conn.execute_batch("ALTER TABLE nodes ADD COLUMN source TEXT NOT NULL DEFAULT 'enrolled';")
+            .ok();
+        conn.execute_batch("ALTER TABLE nodes ADD COLUMN agent_version TEXT;")
+            .ok();
+
         Ok(())
     }
 
@@ -204,6 +224,8 @@ impl NodeDb {
             last_health_check: row.get("last_health_check")?,
             registered_at: row.get("registered_at")?,
             updated_at: row.get("updated_at")?,
+            source: row.get("source")?,
+            agent_version: row.get("agent_version")?,
         })
     }
 
@@ -214,7 +236,7 @@ impl NodeDb {
          ollama_version, os, status, priority, enabled, tags, models_available,
          models_loaded, model_paths, capabilities, gpu_driver_version, max_context_len,
          recommended_config, config_applied, last_health_check,
-         registered_at, updated_at";
+         registered_at, updated_at, source, agent_version";
 
     /// Insert or update a node by hostname (idempotent registration).
     /// Returns (node_id, is_new).
@@ -503,6 +525,119 @@ impl NodeDb {
         Ok(nodes)
     }
 
+    // ── Agent-heartbeat node persistence (v1.2) ──────────────────────
+    //
+    // Agent rows (`source='agent'`) are operator-visibility records for the
+    // Fleet tab. Routing/liveness for agents lives in the in-memory
+    // `NodeRegistry`; these rows use status 'online'/'offline' — outside the
+    // 'healthy'/'degraded' set — so `get_routable_nodes()` never picks them up.
+
+    /// Insert or update a `source='agent'` row from a heartbeat capability
+    /// snapshot, keyed on `node_id`. Persists durable fields only — dynamic
+    /// perf data (vram_free, queue_depth, ttft) stays in-memory.
+    /// Returns (row_id, is_new).
+    pub fn upsert_agent_node(&self, caps: &AgentCapabilities) -> Result<(String, bool)> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| anyhow::anyhow!("DB lock: {}", e))?;
+        let now = chrono::Utc::now().to_rfc3339();
+        let models_loaded_json = serde_json::to_string(&caps.models_loaded)?;
+        let backend_str = caps.backend.to_string();
+        let vram_mb = caps.vram_total_mb.min(u32::MAX as u64) as u32;
+
+        let existing_id: Option<String> = conn
+            .query_row(
+                "SELECT id FROM nodes WHERE node_id = ?1 AND source = 'agent'",
+                rusqlite::params![caps.node_id],
+                |row| row.get(0),
+            )
+            .ok();
+
+        if let Some(id) = existing_id {
+            conn.execute(
+                "UPDATE nodes SET
+                    hostname = ?1, ollama_url = ?2, backend_url = ?2, backend = ?3,
+                    gpu_model = ?4, vram_mb = ?5, models_loaded = ?6,
+                    agent_version = ?7, status = 'online', updated_at = ?8
+                WHERE id = ?9",
+                rusqlite::params![
+                    caps.node_id,
+                    caps.address,
+                    backend_str,
+                    caps.gpu_model,
+                    vram_mb,
+                    models_loaded_json,
+                    caps.agent_version,
+                    now,
+                    id
+                ],
+            )?;
+            Ok((id, false))
+        } else {
+            // Agents have no separate hostname — node_id doubles as the
+            // hostname (NOT NULL UNIQUE). The on-disk URL column is the legacy
+            // `ollama_url`; mirror upsert_node and write both it and backend_url.
+            let id = uuid::Uuid::new_v4().to_string();
+            conn.execute(
+                "INSERT INTO nodes (id, node_id, hostname, ollama_url, backend_url, backend,
+                    gpu_model, vram_mb, models_loaded, agent_version,
+                    status, source, registered_at, updated_at)
+                VALUES (?1, ?2, ?3, ?4, ?4, ?5, ?6, ?7, ?8, ?9, 'online', 'agent', ?10, ?10)",
+                rusqlite::params![
+                    id,
+                    caps.node_id,
+                    caps.node_id,
+                    caps.address,
+                    backend_str,
+                    caps.gpu_model,
+                    vram_mb,
+                    models_loaded_json,
+                    caps.agent_version,
+                    now
+                ],
+            )?;
+            Ok((id, true))
+        }
+    }
+
+    /// Mark an agent row offline after in-memory TTL eviction. Soft eviction:
+    /// the row stays for the Fleet tab until the reaper's grace window lapses.
+    /// Returns true if a row was updated.
+    pub fn mark_agent_offline(&self, node_id: &str) -> Result<bool> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| anyhow::anyhow!("DB lock: {}", e))?;
+        let now = chrono::Utc::now().to_rfc3339();
+        let rows = conn.execute(
+            "UPDATE nodes SET status = 'offline', updated_at = ?1
+             WHERE node_id = ?2 AND source = 'agent'",
+            rusqlite::params![now, node_id],
+        )?;
+        Ok(rows > 0)
+    }
+
+    /// Hard-delete `source='agent'` rows that have been offline longer than
+    /// `grace`. Enrolled rows are never touched. Returns the number deleted.
+    pub fn reap_offline_agents(&self, grace: std::time::Duration) -> Result<usize> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| anyhow::anyhow!("DB lock: {}", e))?;
+        let grace = chrono::Duration::from_std(grace)
+            .map_err(|e| anyhow::anyhow!("Invalid reap grace duration: {}", e))?;
+        // `updated_at` was stamped by mark_agent_offline, so it anchors the
+        // start of the offline period. RFC3339 UTC strings compare lexically.
+        let cutoff = (chrono::Utc::now() - grace).to_rfc3339();
+        let rows = conn.execute(
+            "DELETE FROM nodes
+             WHERE source = 'agent' AND status = 'offline' AND updated_at < ?1",
+            rusqlite::params![cutoff],
+        )?;
+        Ok(rows)
+    }
+
     // ── Model download tracking ──────────────────────────────────────
 
     /// Create a new download tracking entry. Returns the download ID.
@@ -632,14 +767,7 @@ mod tests {
     use crate::config::BackendType;
 
     fn test_db() -> NodeDb {
-        let conn = Connection::open_in_memory().unwrap();
-        conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;")
-            .unwrap();
-        let db = NodeDb {
-            conn: Mutex::new(conn),
-        };
-        db.migrate().unwrap();
-        db
+        NodeDb::open_in_memory().unwrap()
     }
 
     #[test]
@@ -912,12 +1040,188 @@ mod tests {
 
     #[test]
     fn node_columns_count_matches_row_to_node() {
-        // Verify NODE_COLUMNS has exactly 31 columns matching row_to_node expectations
+        // Verify NODE_COLUMNS has exactly 33 columns matching row_to_node expectations
         let col_count = NodeDb::NODE_COLUMNS
             .split(',')
             .filter(|s| !s.trim().is_empty())
             .count();
-        assert_eq!(col_count, 31, "NODE_COLUMNS should have 31 columns");
+        assert_eq!(col_count, 33, "NODE_COLUMNS should have 33 columns");
+    }
+
+    fn sample_agent_caps(node_id: &str) -> AgentCapabilities {
+        AgentCapabilities {
+            node_id: node_id.to_string(),
+            backend: BackendType::LlamaServer,
+            address: "http://10.0.0.5:8080".to_string(),
+            gpu_model: Some("RTX 5090".to_string()),
+            vram_total_mb: 32_768,
+            vram_free_mb: 30_000,
+            models_loaded: vec!["llama-3-8b".to_string()],
+            queue_depth: 3,
+            ttft_p50_ms: Some(42),
+            rpc_capable: false,
+            rpc_port: None,
+            agent_version: "1.2.0".to_string(),
+        }
+    }
+
+    /// Re-stamp an agent row's updated_at so reaper tests can age it without
+    /// sleeping.
+    fn backdate_agent(db: &NodeDb, node_id: &str, secs_ago: i64) {
+        let ts = (chrono::Utc::now() - chrono::Duration::seconds(secs_ago)).to_rfc3339();
+        let conn = db.conn.lock().unwrap();
+        conn.execute(
+            "UPDATE nodes SET updated_at = ?1 WHERE node_id = ?2",
+            rusqlite::params![ts, node_id],
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn migrate_v5_backfills_existing_rows_as_enrolled() {
+        let db = test_db();
+        let reg = NodeRegistration {
+            hostname: "legacy-node".to_string(),
+            ollama_url: "http://legacy:11434".to_string(),
+            ..Default::default()
+        };
+        let (id, _) = db.upsert_node(&reg).unwrap();
+
+        // Re-running migrations must be safe and must not disturb the row.
+        db.migrate().unwrap();
+
+        let node = db.get_node(&id).unwrap().unwrap();
+        assert_eq!(node.source, "enrolled");
+        assert!(node.agent_version.is_none());
+    }
+
+    #[test]
+    fn upsert_agent_node_round_trip() {
+        let db = test_db();
+        let (id, is_new) = db
+            .upsert_agent_node(&sample_agent_caps("citadel-5090"))
+            .unwrap();
+        assert!(is_new);
+
+        let node = db.get_node(&id).unwrap().unwrap();
+        assert_eq!(node.source, "agent");
+        assert_eq!(node.status, "online");
+        assert_eq!(node.node_id.as_deref(), Some("citadel-5090"));
+        assert_eq!(node.hostname, "citadel-5090");
+        assert_eq!(node.backend_url, "http://10.0.0.5:8080");
+        assert_eq!(node.backend, BackendType::LlamaServer);
+        assert_eq!(node.gpu_model.as_deref(), Some("RTX 5090"));
+        assert_eq!(node.vram_mb, 32_768);
+        assert_eq!(node.models_loaded, vec!["llama-3-8b"]);
+        assert_eq!(node.agent_version.as_deref(), Some("1.2.0"));
+    }
+
+    #[test]
+    fn upsert_agent_node_is_idempotent_and_updates() {
+        let db = test_db();
+        let (id1, new1) = db.upsert_agent_node(&sample_agent_caps("node-a")).unwrap();
+        assert!(new1);
+
+        let mut caps = sample_agent_caps("node-a");
+        caps.models_loaded = vec!["qwen3-32b".to_string()];
+        caps.agent_version = "1.2.1".to_string();
+        let (id2, new2) = db.upsert_agent_node(&caps).unwrap();
+        assert!(!new2);
+        assert_eq!(id1, id2);
+
+        let node = db.get_node(&id2).unwrap().unwrap();
+        assert_eq!(node.models_loaded, vec!["qwen3-32b"]);
+        assert_eq!(node.agent_version.as_deref(), Some("1.2.1"));
+        assert_eq!(node.status, "online");
+    }
+
+    #[test]
+    fn agent_nodes_are_never_routable() {
+        let db = test_db();
+        db.upsert_agent_node(&sample_agent_caps("node-a")).unwrap();
+        // status='online' is outside the 'healthy'/'degraded' routable set.
+        assert!(db.get_routable_nodes().unwrap().is_empty());
+    }
+
+    #[test]
+    fn mark_agent_offline_flips_status_and_scopes_to_agents() {
+        let db = test_db();
+        db.upsert_agent_node(&sample_agent_caps("node-a")).unwrap();
+        assert!(db.mark_agent_offline("node-a").unwrap());
+
+        let nodes = db.list_nodes().unwrap();
+        assert_eq!(nodes[0].status, "offline");
+
+        // Unknown node: no-op.
+        assert!(!db.mark_agent_offline("ghost").unwrap());
+
+        // Enrolled node with the same node_id is untouched.
+        let reg = NodeRegistration {
+            hostname: "enrolled-host".to_string(),
+            node_id: Some("enrolled-nid".to_string()),
+            ollama_url: "http://enrolled:11434".to_string(),
+            ..Default::default()
+        };
+        let (eid, _) = db.upsert_node(&reg).unwrap();
+        assert!(!db.mark_agent_offline("enrolled-nid").unwrap());
+        assert_eq!(db.get_node(&eid).unwrap().unwrap().status, "healthy");
+    }
+
+    #[test]
+    fn agent_re_heartbeat_after_offline_comes_back_online() {
+        let db = test_db();
+        let (id, _) = db.upsert_agent_node(&sample_agent_caps("node-a")).unwrap();
+        db.mark_agent_offline("node-a").unwrap();
+        let (id2, is_new) = db.upsert_agent_node(&sample_agent_caps("node-a")).unwrap();
+        assert!(!is_new);
+        assert_eq!(id, id2);
+        assert_eq!(db.get_node(&id).unwrap().unwrap().status, "online");
+    }
+
+    #[test]
+    fn reaper_deletes_only_stale_offline_agents() {
+        let db = test_db();
+        let grace = std::time::Duration::from_secs(3600);
+
+        // Stale offline agent — should be reaped.
+        db.upsert_agent_node(&sample_agent_caps("stale-agent"))
+            .unwrap();
+        db.mark_agent_offline("stale-agent").unwrap();
+        backdate_agent(&db, "stale-agent", 7200);
+
+        // Fresh offline agent — inside grace, kept.
+        db.upsert_agent_node(&sample_agent_caps("fresh-agent"))
+            .unwrap();
+        db.mark_agent_offline("fresh-agent").unwrap();
+
+        // Online agent — kept regardless of age.
+        db.upsert_agent_node(&sample_agent_caps("online-agent"))
+            .unwrap();
+        backdate_agent(&db, "online-agent", 7200);
+
+        // Enrolled node — never reaped, even if ancient.
+        let reg = NodeRegistration {
+            hostname: "enrolled-host".to_string(),
+            node_id: Some("enrolled-nid".to_string()),
+            ollama_url: "http://enrolled:11434".to_string(),
+            ..Default::default()
+        };
+        db.upsert_node(&reg).unwrap();
+        backdate_agent(&db, "enrolled-nid", 999_999);
+
+        let reaped = db.reap_offline_agents(grace).unwrap();
+        assert_eq!(reaped, 1);
+
+        let remaining: Vec<String> = db
+            .list_nodes()
+            .unwrap()
+            .into_iter()
+            .map(|n| n.hostname)
+            .collect();
+        assert!(!remaining.contains(&"stale-agent".to_string()));
+        assert!(remaining.contains(&"fresh-agent".to_string()));
+        assert!(remaining.contains(&"online-agent".to_string()));
+        assert!(remaining.contains(&"enrolled-host".to_string()));
     }
 
     #[test]

--- a/src/nodes/registry.rs
+++ b/src/nodes/registry.rs
@@ -48,7 +48,13 @@ impl AgentState {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum HeartbeatOutcome {
     Registered,
-    Updated,
+    Updated {
+        /// True when this beat's `models_loaded` set differs from the previous
+        /// one. Lets callers persist on material change without diffing state
+        /// themselves (the registry already holds both snapshots under the
+        /// write lock).
+        models_changed: bool,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -69,6 +75,19 @@ impl std::fmt::Display for RegistryError {
 impl std::error::Error for RegistryError {}
 
 type Clock = Arc<dyn Fn() -> Instant + Send + Sync>;
+
+/// Order-insensitive comparison of two `models_loaded` lists. Agents may report
+/// the same set in a different order between beats; that is not a material change.
+fn same_model_set(a: &[String], b: &[String]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut a_sorted: Vec<&str> = a.iter().map(String::as_str).collect();
+    let mut b_sorted: Vec<&str> = b.iter().map(String::as_str).collect();
+    a_sorted.sort_unstable();
+    b_sorted.sort_unstable();
+    a_sorted == b_sorted
+}
 
 #[derive(Clone)]
 pub struct NodeRegistry {
@@ -109,9 +128,11 @@ impl NodeRegistry {
         let node_id = caps.node_id.clone();
         match nodes.get_mut(&node_id) {
             Some(existing) => {
+                let models_changed =
+                    !same_model_set(&existing.capabilities.models_loaded, &caps.models_loaded);
                 existing.capabilities = caps;
                 existing.last_heartbeat = now;
-                Ok(HeartbeatOutcome::Updated)
+                Ok(HeartbeatOutcome::Updated { models_changed })
             }
             None => {
                 if nodes.len() >= self.max_nodes {
@@ -249,8 +270,50 @@ mod tests {
         let (reg, _clock) = registry_with_clock(Duration::from_secs(30));
         reg.heartbeat(sample_caps("a")).await.unwrap();
         let outcome = reg.heartbeat(sample_caps("a")).await.unwrap();
-        assert_eq!(outcome, HeartbeatOutcome::Updated);
+        assert_eq!(
+            outcome,
+            HeartbeatOutcome::Updated {
+                models_changed: false
+            }
+        );
         assert_eq!(reg.len().await, 1);
+    }
+
+    #[tokio::test]
+    async fn heartbeat_reports_models_changed_on_set_difference() {
+        let (reg, _clock) = registry_with_clock(Duration::from_secs(30));
+        reg.heartbeat(sample_caps("a")).await.unwrap();
+
+        let mut caps = sample_caps("a");
+        caps.models_loaded = vec!["llama-3-8b".to_string(), "qwen3-32b".to_string()];
+        let outcome = reg.heartbeat(caps).await.unwrap();
+        assert_eq!(
+            outcome,
+            HeartbeatOutcome::Updated {
+                models_changed: true
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn heartbeat_ignores_model_order_and_dynamic_fields() {
+        let (reg, _clock) = registry_with_clock(Duration::from_secs(30));
+        let mut caps = sample_caps("a");
+        caps.models_loaded = vec!["m1".to_string(), "m2".to_string()];
+        reg.heartbeat(caps).await.unwrap();
+
+        // Same set, different order, different dynamic load — not material.
+        let mut caps = sample_caps("a");
+        caps.models_loaded = vec!["m2".to_string(), "m1".to_string()];
+        caps.vram_free_mb = 1;
+        caps.queue_depth = 99;
+        let outcome = reg.heartbeat(caps).await.unwrap();
+        assert_eq!(
+            outcome,
+            HeartbeatOutcome::Updated {
+                models_changed: false
+            }
+        );
     }
 
     #[tokio::test]
@@ -352,7 +415,12 @@ mod tests {
         reg.heartbeat(sample_caps("a")).await.unwrap();
 
         let outcome = reg.heartbeat(sample_caps("a")).await.unwrap();
-        assert_eq!(outcome, HeartbeatOutcome::Updated);
+        assert_eq!(
+            outcome,
+            HeartbeatOutcome::Updated {
+                models_changed: false
+            }
+        );
         assert_eq!(reg.len().await, 1);
     }
 }

--- a/src/nodes/types.rs
+++ b/src/nodes/types.rs
@@ -164,6 +164,19 @@ pub struct Node {
     pub last_health_check: Option<String>,
     pub registered_at: String,
     pub updated_at: String,
+    /// How this node entered the registry: 'enrolled' (herd-tune / manual
+    /// registration) or 'agent' (herd agent heartbeat). Agent rows are
+    /// operator-visibility records — routing for them stays in the in-memory
+    /// `NodeRegistry`.
+    #[serde(default = "default_node_source")]
+    pub source: String,
+    /// Version of the `herd agent` daemon, for `source='agent'` rows only.
+    #[serde(default)]
+    pub agent_version: Option<String>,
+}
+
+fn default_node_source() -> String {
+    "enrolled".to_string()
 }
 
 /// Entry in a node's model registry, derived from model_paths and models_loaded.
@@ -328,6 +341,8 @@ mod tests {
             last_health_check: None,
             registered_at: "2026-01-01T00:00:00Z".to_string(),
             updated_at: "2026-01-01T00:00:00Z".to_string(),
+            source: "enrolled".to_string(),
+            agent_version: None,
         };
         let registry = node.model_registry();
         // "qwen" should NOT match "qwen3-32b.gguf" (no contains matching)
@@ -382,6 +397,8 @@ mod tests {
             last_health_check: None,
             registered_at: "2026-01-01T00:00:00Z".to_string(),
             updated_at: "2026-01-01T00:00:00Z".to_string(),
+            source: "enrolled".to_string(),
+            agent_version: None,
         };
         let registry = node.model_registry();
         // Match by filename

--- a/src/server.rs
+++ b/src/server.rs
@@ -516,9 +516,11 @@ impl Server {
 
         // Start agent-node stale eviction (every 10s). Removes agent nodes that
         // have missed heartbeats past the registry TTL so the gateway never routes
-        // to a dead agent. Cheap no-op when no agents are registered.
+        // to a dead agent, and soft-evicts the SQLite row (status='offline') so the
+        // Fleet tab reflects it. Cheap no-op when no agents are registered.
         {
             let registry = Arc::clone(&state.node_registry);
+            let node_db = Arc::clone(&state.node_db);
             tokio::spawn(async move {
                 let mut ticker = tokio::time::interval(Duration::from_secs(10));
                 loop {
@@ -526,6 +528,43 @@ impl Server {
                     let evicted = registry.evict_stale().await;
                     if !evicted.is_empty() {
                         tracing::info!("Evicted stale agent nodes: {}", evicted.join(", "));
+                        for node_id in &evicted {
+                            if let Err(e) = node_db.mark_agent_offline(node_id) {
+                                tracing::error!(
+                                    "Failed to mark agent node {} offline in SQLite: {}",
+                                    node_id,
+                                    e
+                                );
+                            }
+                        }
+                    }
+                }
+            });
+        }
+
+        // Start agent-row reaper (hourly). Hard-deletes source='agent' rows that
+        // have sat offline past the grace window (default 24h, override via
+        // HERD_AGENT_REAP_GRACE_SECS). Enrolled rows are never reaped.
+        {
+            const DEFAULT_REAP_GRACE_SECS: u64 = 24 * 3600;
+            let grace_secs = std::env::var("HERD_AGENT_REAP_GRACE_SECS")
+                .ok()
+                .and_then(|v| v.parse::<u64>().ok())
+                .unwrap_or(DEFAULT_REAP_GRACE_SECS);
+            let node_db = Arc::clone(&state.node_db);
+            tokio::spawn(async move {
+                let grace = Duration::from_secs(grace_secs);
+                let mut ticker = tokio::time::interval(Duration::from_secs(3600));
+                loop {
+                    ticker.tick().await;
+                    match node_db.reap_offline_agents(grace) {
+                        Ok(0) => {}
+                        Ok(n) => tracing::info!(
+                            "Reaped {} agent node row(s) offline longer than {}s",
+                            n,
+                            grace_secs
+                        ),
+                        Err(e) => tracing::error!("Agent node reaper failed: {}", e),
                     }
                 }
             });

--- a/tasks/HERD-V1.2-SPRINT.md
+++ b/tasks/HERD-V1.2-SPRINT.md
@@ -2,7 +2,7 @@
 
 **Spec:** `docs/specs/v2-distributed-inference-spec.md`
 **Target:** v1.2 (foundation) — `herd agent` ships, single-node deployments only. No speculative, no pipeline.
-**Status:** PRs #1–#4 landed of 8 (last reconciled with implementation: 2026-06-09)
+**Status:** PRs #1–#5 landed of 8 (last reconciled with implementation: 2026-06-10)
 
 > This doc tracks the PR breakdown and acceptance checklist for the v1.2 milestone.
 > The architecture, data structures, and rationale live in the spec — this is the
@@ -18,7 +18,7 @@
 | #2 | `NodeRegistry` with TTL eviction | In-memory `NodeRegistry` keyed by `node_id`, heartbeat-only protocol, injectable `Clock` for deterministic time tests, 10 unit tests | ✅ landed (`be6f24e`) |
 | #3 | Gateway heartbeat ingestion | `NodeRegistry` onto `AppState`; stale-eviction background task; `POST /api/internal/nodes/heartbeat` with `HERD_AGENT_TOKEN` bearer auth; heartbeat protocol tests | ✅ landed |
 | #4 | `herd agent` CLI + daemon | Restructure CLI into `serve`/`agent` subcommands; `src/daemon/` (heartbeat client, capability detection, lifecycle); single-node deployment | ✅ landed |
-| #5 | Dashboard Fleet integration | Fleet tab projects `NodeRegistry` live agent state alongside SQLite operator nodes | ⬜ |
+| #5 | Agent node persistence + Fleet | Migration v5 (`source`, `agent_version`); write-through on transition; soft-evict (mark offline) + reaper for stale agent rows; Fleet tab reads unified SQLite store | ✅ |
 | #6 | Heartbeat protocol hardening | Version-skew handling, deployments-assigned response plumbing, configurable TTL/cadence | ⬜ |
 | #7 | `BackendPool` integration | Agent-registered nodes route identically to static backends; `NodeRegistry::find_for_model()`; conflict resolution (agent overrides static only on exact node-identity match) | ⬜ |
 | #8 | Integration test + smoke | Gateway + 1 agent in same process; request routes through agent's (stub) llama-server end-to-end | ⬜ |
@@ -35,7 +35,7 @@ From the spec's "v1.2 — Agent/Gateway Foundation" acceptance block, annotated 
 - [x] Gateway maintains in-memory `NodeRegistry` keyed by `node_id` with TTL eviction (default 30s) *(struct in PR #2; on `AppState` + eviction task in PR #3)*
 - [ ] Agent-registered nodes appear in `BackendPool` and route identically to static backends *(PR #7)*
 - [x] Existing static-backend config path is unchanged *(maintained; verified PR #3)*
-- [ ] Dashboard Fleet tab shows agent-registered nodes with live state *(PR #5)*
+- [x] Dashboard Fleet tab shows agent-registered nodes with live state *(PR #5 — agent rows persisted to SQLite with `source='agent'`, online/offline status + source badge in the Fleet table; written on register/model-change/eviction, steady beats stay in-memory)*
 - [~] Both modes can run on the same host (CITADEL self-test scenario) *(PR #4: guarded self-test in `tests/agent_daemon.rs` + manual smoke verified 2026-06-09; PR #8 extends to routed end-to-end)*
 - [x] Auth: shared bearer token via env var (`HERD_AGENT_TOKEN`) *(PR #3)*
 - [ ] Gateway returns 503 with clear error if all healthy backends — agent and static — are gone (no hidden fallback) *(PR #7)*
@@ -54,6 +54,46 @@ These resolve the spec's "Open Questions for Tom":
 5. **Deployment manifest source** — deferred beyond v1.2 (single-node only ships here). Recommended: top-level `deployments:` in `herd.yaml` when it lands (v1.3).
 6. **Conflict resolution** — agent registration overrides a static backend only on exact logical-node identity match (`node_id` + advertised inference address); otherwise both remain visible and a duplication warning is logged *(enforced in PR #7)*.
 7. **Gateway discovery** — explicit `--gateway <url>` required on the agent. `herd.starbase` (Tailscale DNS) documented as recommended value; no auto-discovery.
+
+---
+
+## PR #5 — Agent Node Persistence + Fleet Integration (revised scope)
+
+Supersedes the original "project NodeRegistry alongside SQLite" framing. Agent nodes
+are persisted to `node_db`, so the Fleet tab reads a single store and no render-time
+merge of two stores is needed. The in-memory `NodeRegistry` remains the routing/liveness
+layer (PR #7); SQLite persistence here is operator-visibility + housekeeping.
+
+Locked decisions (extend the list above):
+
+8.  **Persistence + discriminator.** Agent heartbeats persist to the SQLite `nodes`
+    table, discriminated by a new `source` column ('enrolled' | 'agent'). Migration v5
+    adds `source` (DEFAULT 'enrolled', so all existing rows are correctly tagged
+    enrolled) and `agent_version`. Fleet tab reads SQLite only.
+9.  **Soft eviction (mark-offline-then-reap).** In-memory TTL eviction sets the SQLite
+    row's `status='offline'` — it does NOT delete. A separate reaper hard-deletes
+    `source='agent'` rows offline beyond a grace window (default 24h, configurable via
+    `HERD_AGENT_REAP_GRACE_SECS`). Enrolled rows are never auto-reaped. Routing ignores
+    SQLite for agents, so an 'offline' row is never a routing hazard.
+10. **Write-through on transitions only.** SQLite is written on: first heartbeat
+    (register), material capability change (models_loaded set changes), and eviction.
+    Steady unchanged 2s beats stay in-memory only and never touch the DB.
+11. **NodeRegistry stays DB-free.** Persistence glue lives in the heartbeat handler
+    (`api/internal.rs`) and the evictor + new reaper tasks (`server.rs`), which already
+    hold `AppState` with both stores. The registry keeps its injectable-Clock
+    determinism with no `NodeDb` dependency. The evictor must surface evicted node_ids
+    so the glue can mark them offline.
+12. **Fleet-visible, not SQLite-routable.** Agent rows use status values OUTSIDE the
+    routable set ('online'/'offline', never 'healthy'/'degraded'), so
+    `get_routable_nodes()` cannot pull an agent node into the static routing path before
+    PR #7 wires it deliberately through the in-memory registry.
+13. **Persist durable fields only.** Map node_id→node_id (and hostname, since hostname is
+    NOT NULL UNIQUE and agents have no separate hostname), address→backend_url (on-disk
+    column is the legacy `ollama_url` — mirror existing `upsert_node`), backend, gpu_model,
+    vram_total_mb→vram_mb, models_loaded, agent_version→new column. Dynamic perf fields
+    (vram_free, queue_depth, ttft_p50) stay in-memory only — routing inputs, not records.
+14. **No agent/enrolled merge in v1.2.** If one physical host is both enrolled and running
+    an agent, two rows coexist (different hostname/source). Dedup deferred.
 
 ---
 


### PR DESCRIPTION
Re-target of the orphaned PR #8 onto main. PR #8 merged into the pr4 branch instead of main because the base branch was not deleted on PR #7 merge, so it never retargeted. This brings affa06f (migration v5, write-through, reaper, Fleet badges) onto main. Single commit; merge-base 3eb806e already in main.