### PR TITLE
fix(nodes): hard-exclude agent rows from poller and routable pool (v1.2 PR #5.1)

### DIFF
--- a/src/nodes/db.rs
+++ b/src/nodes/db.rs
@@ -495,12 +495,18 @@ impl NodeDb {
     }
 
     /// Get nodes that should be health-checked (enabled, not disabled by operator).
+    /// Agent rows are excluded: their liveness comes from heartbeats via the
+    /// in-memory `NodeRegistry`, and only `upsert_agent_node`/`mark_agent_offline`
+    /// may mutate their status ('online'/'offline').
     pub fn get_pollable_nodes(&self) -> Result<Vec<Node>> {
         let conn = self
             .conn
             .lock()
             .map_err(|e| anyhow::anyhow!("DB lock: {}", e))?;
-        let sql = format!("SELECT {} FROM nodes WHERE enabled = 1", Self::NODE_COLUMNS);
+        let sql = format!(
+            "SELECT {} FROM nodes WHERE enabled = 1 AND source != 'agent'",
+            Self::NODE_COLUMNS
+        );
         let mut stmt = conn.prepare(&sql)?;
         let nodes = stmt
             .query_map([], Self::row_to_node)?
@@ -509,13 +515,16 @@ impl NodeDb {
     }
 
     /// Get nodes eligible for routing (enabled + healthy/degraded).
+    /// Agent rows are excluded by construction — agent routability is decided
+    /// by the in-memory `NodeRegistry` (PR #7), never by this SQLite path,
+    /// regardless of what status the row carries.
     pub fn get_routable_nodes(&self) -> Result<Vec<Node>> {
         let conn = self
             .conn
             .lock()
             .map_err(|e| anyhow::anyhow!("DB lock: {}", e))?;
         let sql = format!(
-            "SELECT {} FROM nodes WHERE enabled = 1 AND status IN ('healthy', 'degraded') ORDER BY priority ASC",
+            "SELECT {} FROM nodes WHERE enabled = 1 AND status IN ('healthy', 'degraded') AND source != 'agent' ORDER BY priority ASC",
             Self::NODE_COLUMNS
         );
         let mut stmt = conn.prepare(&sql)?;
@@ -529,8 +538,11 @@ impl NodeDb {
     //
     // Agent rows (`source='agent'`) are operator-visibility records for the
     // Fleet tab. Routing/liveness for agents lives in the in-memory
-    // `NodeRegistry`; these rows use status 'online'/'offline' — outside the
-    // 'healthy'/'degraded' set — so `get_routable_nodes()` never picks them up.
+    // `NodeRegistry`. These rows use status 'online'/'offline', and both
+    // `get_pollable_nodes()` and `get_routable_nodes()` exclude them by
+    // `source` explicitly — the health poller never touches them, and they
+    // can never enter the static routing pool even if a row's status is
+    // corrupted (e.g. by `update_node(enabled=true)` setting 'healthy').
 
     /// Insert or update a `source='agent'` row from a heartbeat capability
     /// snapshot, keyed on `node_id`. Persists durable fields only — dynamic
@@ -1138,9 +1150,41 @@ mod tests {
     #[test]
     fn agent_nodes_are_never_routable() {
         let db = test_db();
-        db.upsert_agent_node(&sample_agent_caps("node-a")).unwrap();
+        let (id, _) = db.upsert_agent_node(&sample_agent_caps("node-a")).unwrap();
         // status='online' is outside the 'healthy'/'degraded' routable set.
         assert!(db.get_routable_nodes().unwrap().is_empty());
+
+        // Decision 12 must hold even if the row's status is corrupted:
+        // update_node(enabled=true) sets status='healthy' on any row, which
+        // before the explicit source guard would have made the agent routable.
+        let update = NodeUpdate {
+            priority: None,
+            tags: None,
+            enabled: Some(true),
+        };
+        assert!(db.update_node(&id, &update).unwrap());
+        assert_eq!(db.get_node(&id).unwrap().unwrap().status, "healthy");
+        assert!(db.get_routable_nodes().unwrap().is_empty());
+    }
+
+    #[test]
+    fn pollable_nodes_exclude_agent_rows() {
+        let db = test_db();
+        db.upsert_agent_node(&sample_agent_caps("agent-node"))
+            .unwrap();
+        let reg = NodeRegistration {
+            hostname: "enrolled-node".to_string(),
+            ollama_url: "http://enrolled:11434".to_string(),
+            ..Default::default()
+        };
+        db.upsert_node(&reg).unwrap();
+
+        // The health poller must never pick up agent rows: polling would flip
+        // their status into the 'healthy'/'degraded' lifecycle, breaking the
+        // 'online'/'offline' contract owned by upsert_agent_node/mark_agent_offline.
+        let pollable = db.get_pollable_nodes().unwrap();
+        assert_eq!(pollable.len(), 1);
+        assert_eq!(pollable[0].hostname, "enrolled-node");
     }
 
     #[test]

--- a/src/nodes/health.rs
+++ b/src/nodes/health.rs
@@ -89,6 +89,8 @@ impl NodeHealthPoller {
 
     /// Syncs routable registered nodes into the BackendPool so existing
     /// routing strategies can route to them alongside static config backends.
+    /// Agent rows (`source='agent'`) never appear here: `get_routable_nodes()`
+    /// excludes them by source — they are registry-managed, not poll-managed.
     async fn sync_to_pool(&self, node_db: &NodeDb, pool: &BackendPool) {
         let nodes = match node_db.get_routable_nodes() {
             Ok(n) => n,
@@ -156,6 +158,9 @@ impl NodeHealthPoller {
     }
 
     async fn poll_all(&self, node_db: &NodeDb, check_tags: bool) {
+        // get_pollable_nodes excludes agent rows — their liveness is driven by
+        // heartbeats into the in-memory NodeRegistry, not by HTTP polling, and
+        // polling them would corrupt their 'online'/'offline' status lifecycle.
         let nodes = match node_db.get_pollable_nodes() {
             Ok(n) => n,
             Err(e) => {
@@ -344,6 +349,41 @@ impl NodeHealthPoller {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn sync_to_pool_never_adds_agent_rows() {
+        let node_db = NodeDb::open_in_memory().unwrap();
+        let caps = crate::nodes::AgentCapabilities {
+            node_id: "agent-node".to_string(),
+            backend: crate::config::BackendType::LlamaServer,
+            address: "http://10.0.0.5:8080".to_string(),
+            gpu_model: Some("RTX 5090".to_string()),
+            vram_total_mb: 32_768,
+            vram_free_mb: 30_000,
+            models_loaded: vec!["llama-3-8b".to_string()],
+            queue_depth: 0,
+            ttft_p50_ms: None,
+            rpc_capable: false,
+            rpc_port: None,
+            agent_version: "1.2.0".to_string(),
+        };
+        let (id, _) = node_db.upsert_agent_node(&caps).unwrap();
+
+        // Force the worst case: an operator update flips the row's status to
+        // 'healthy'. The source guard must still keep it out of the pool.
+        let update = crate::nodes::NodeUpdate {
+            priority: None,
+            tags: None,
+            enabled: Some(true),
+        };
+        assert!(node_db.update_node(&id, &update).unwrap());
+
+        let pool = Arc::new(BackendPool::new(vec![], 3, Duration::from_secs(30)));
+        let poller = NodeHealthPoller::new(15, 300);
+        poller.sync_to_pool(&node_db, &pool).await;
+
+        assert!(pool.all().await.is_empty());
+    }
 
     #[test]
     fn parse_llama_server_models_response() {

--- a/tasks/HERD-V1.2-SPRINT.md
+++ b/tasks/HERD-V1.2-SPRINT.md
@@ -19,8 +19,9 @@
 | #3 | Gateway heartbeat ingestion | `NodeRegistry` onto `AppState`; stale-eviction background task; `POST /api/internal/nodes/heartbeat` with `HERD_AGENT_TOKEN` bearer auth; heartbeat protocol tests | ✅ landed |
 | #4 | `herd agent` CLI + daemon | Restructure CLI into `serve`/`agent` subcommands; `src/daemon/` (heartbeat client, capability detection, lifecycle); single-node deployment | ✅ landed |
 | #5 | Agent node persistence + Fleet | Migration v5 (`source`, `agent_version`); write-through on transition; soft-evict (mark offline) + reaper for stale agent rows; Fleet tab reads unified SQLite store | ✅ |
+| #5.1 | Hard-exclude agent rows from poller + SQLite routing | Live-test fix: `get_pollable_nodes` and `get_routable_nodes` now filter `source != 'agent'` explicitly. Previously the health poller picked up agent rows (`enabled=1`), `update_health` flipped them 'online'→'healthy', and they entered the routable pool — decision 12 was implied by status convention, never enforced. Also closes the `update_node(enabled=true)` side door that sets `status='healthy'` on any row. | ✅ |
 | #6 | Heartbeat protocol hardening | Version-skew handling, deployments-assigned response plumbing, configurable TTL/cadence | ⬜ |
-| #7 | `BackendPool` integration | Agent-registered nodes route identically to static backends; `NodeRegistry::find_for_model()`; conflict resolution (agent overrides static only on exact node-identity match) | ⬜ |
+| #7 | `BackendPool` integration | Agent-registered nodes route identically to static backends; `NodeRegistry::find_for_model()`; conflict resolution (agent overrides static only on exact node-identity match). **Note (PR #5.1):** agents are now hard-excluded from `get_routable_nodes` by `source`; PR #7 must source agent routability from the in-memory registry's heartbeat freshness, not by falling through the SQLite pool path. | ⬜ |
 | #8 | Integration test + smoke | Gateway + 1 agent in same process; request routes through agent's (stub) llama-server end-to-end | ⬜ |
 
 ---
@@ -87,6 +88,10 @@ Locked decisions (extend the list above):
     routable set ('online'/'offline', never 'healthy'/'degraded'), so
     `get_routable_nodes()` cannot pull an agent node into the static routing path before
     PR #7 wires it deliberately through the in-memory registry.
+    *Hardened in PR #5.1:* the status convention alone didn't enforce this — the health
+    poller polled agent rows and flipped them 'healthy'. Both `get_pollable_nodes()` and
+    `get_routable_nodes()` now exclude `source='agent'` explicitly, so the exclusion holds
+    by construction regardless of a row's status.
 13. **Persist durable fields only.** Map node_id→node_id (and hostname, since hostname is
     NOT NULL UNIQUE and agents have no separate hostname), address→backend_url (on-disk
     column is the legacy `ollama_url` — mirror existing `upsert_node`), backend, gpu_model,


### PR DESCRIPTION
Found in live test: agent rows were excluded from routing only as a side effect of status='online' being outside the routable set, not by an explicit guard. The health poller flipped status to 'healthy' and routed them on poll cadence. Adds explicit source != 'agent' guards to get_pollable_nodes and get_routable_nodes, closing the update_node(enabled=true) side door. 3 tests; 412 passing.