### PR TITLE
feat(cli): herd publish — promote a binary into the fleet publish-dir (PR #6c)

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,7 @@ Herd is a **smart stateless proxy with a stateful routing cache**. It is not HA 
 - **Blackwell detection** — Identifies RTX 5000-series GPUs requiring CUDA 13.x
 - **llama-server provisioning** — herd-tune downloads the correct llama-server binary per GPU vendor
 - **SQLite node registry** — Persistent fleet state with health polling
+- **Agent self-update** — The gateway is the fleet's version authority: agents (`herd agent`) heartbeat their version and self-update to the published target. Promote a build with `herd publish [BINARY] --version <V>` (defaults to the running binary and host os/arch), then set `fleet.target_agent_version: <V>` in `herd.yaml` (hot-reloaded). `publish` prints the sha256 the gateway will advertise and refuses to overwrite differing bytes without `--force`.
 - **HuggingFace model search** — Search GGUF models with VRAM compatibility per-node
 - **Model download** — Pull models to Ollama nodes via API (llama-server download in roadmap)
 - **Ollama blob extraction** — Extract raw GGUF from Ollama blob storage for llama-server reuse

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -27,6 +27,39 @@ pub enum Command {
     Serve(ServeArgs),
     /// Run the node-side agent daemon that heartbeats a gateway
     Agent(AgentArgs),
+    /// Promote a binary into the fleet publish-dir for an os/arch
+    Publish(PublishArgs),
+}
+
+#[derive(clap::Args)]
+pub struct PublishArgs {
+    /// Binary to publish (default: the currently running herd executable)
+    #[arg(value_name = "BINARY")]
+    pub binary: Option<PathBuf>,
+
+    /// Version to publish under (path component: fleet.target_agent_version)
+    #[arg(long, value_name = "VERSION")]
+    pub version: String,
+
+    /// Target OS (default: host OS, e.g. linux/windows/macos)
+    #[arg(long, value_name = "OS")]
+    pub os: Option<String>,
+
+    /// Target arch (default: host arch, e.g. x86_64/aarch64)
+    #[arg(long, value_name = "ARCH")]
+    pub arch: Option<String>,
+
+    /// Publish directory root (overrides HERD_AGENT_PUBLISH_DIR and config)
+    #[arg(long, value_name = "DIR")]
+    pub publish_dir: Option<PathBuf>,
+
+    /// Read fleet.publish_dir from this config file when --publish-dir is unset
+    #[arg(short, long, value_name = "FILE")]
+    pub config: Option<PathBuf>,
+
+    /// Overwrite an existing binary even if its bytes (sha256) differ
+    #[arg(long)]
+    pub force: bool,
 }
 
 #[derive(clap::Args)]
@@ -215,6 +248,72 @@ mod cli_tests {
             "vllm"
         ])
         .is_err());
+    }
+
+    #[test]
+    fn publish_subcommand_parses_with_defaults() {
+        let cli = Cli::try_parse_from(["herd", "publish", "--version", "1.2.0"]).unwrap();
+        match cli.command {
+            Some(Command::Publish(args)) => {
+                assert!(args.binary.is_none());
+                assert_eq!(args.version, "1.2.0");
+                assert!(args.os.is_none());
+                assert!(args.arch.is_none());
+                assert!(args.publish_dir.is_none());
+                assert!(args.config.is_none());
+                assert!(!args.force);
+            }
+            _ => panic!("expected publish subcommand"),
+        }
+    }
+
+    #[test]
+    fn publish_accepts_positional_and_overrides() {
+        let cli = Cli::try_parse_from([
+            "herd",
+            "publish",
+            "./herd-arm",
+            "--version",
+            "1.2.0",
+            "--os",
+            "linux",
+            "--arch",
+            "aarch64",
+            "--publish-dir",
+            "/srv/bin",
+            "--force",
+        ])
+        .unwrap();
+        match cli.command {
+            Some(Command::Publish(args)) => {
+                use std::path::Path;
+                assert_eq!(args.binary.as_deref().unwrap(), Path::new("./herd-arm"));
+                assert_eq!(args.version, "1.2.0");
+                assert_eq!(args.os.as_deref(), Some("linux"));
+                assert_eq!(args.arch.as_deref(), Some("aarch64"));
+                assert_eq!(args.publish_dir.as_deref().unwrap(), Path::new("/srv/bin"));
+                assert!(args.force);
+            }
+            _ => panic!("expected publish subcommand"),
+        }
+    }
+
+    #[test]
+    fn publish_requires_version() {
+        assert!(Cli::try_parse_from(["herd", "publish"]).is_err());
+    }
+
+    #[test]
+    fn publish_config_short_flag() {
+        let cli = Cli::try_parse_from(["herd", "publish", "--version", "1.2.0", "-c", "herd.yaml"])
+            .unwrap();
+        match cli.command {
+            Some(Command::Publish(args)) => {
+                use std::path::Path;
+                assert_eq!(args.config.as_deref().unwrap(), Path::new("herd.yaml"));
+            }
+            _ => panic!("expected publish subcommand"),
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ pub mod metrics;
 pub mod nodes;
 pub mod profiles;
 pub mod providers;
+pub mod publish;
 pub mod rate_limit;
 pub mod router;
 pub mod server;

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,6 +46,7 @@ async fn main() -> anyhow::Result<()> {
     match cli.command {
         Some(Command::Agent(args)) => herd::daemon::run(args).await,
         Some(Command::Serve(args)) => serve(args).await,
+        Some(Command::Publish(args)) => herd::publish::run(args),
         None => serve(cli.serve).await,
     }
 }

--- a/src/publish.rs
+++ b/src/publish.rs
@@ -1,0 +1,359 @@
+//! `herd publish` — the operator-facing write side of the fleet BinaryStore (v1.2 PR #6c).
+//! Copies a binary into {publish_dir}/{version}/{os}-{arch}/herd[.exe] and prints the sha256
+//! the gateway will advertise. Thin promote only: no config validate(), no HTTP, no async.
+
+use crate::config::{Config, FleetConfig};
+use crate::nodes::binary_store::{self, BinaryStore};
+use anyhow::{bail, Context};
+use std::path::{Path, PathBuf};
+
+/// Result of a publish: the bytes were written, or an identical copy already existed.
+#[derive(Debug, PartialEq, Eq)]
+pub enum Outcome {
+    Written(String),   // sha256
+    Unchanged(String), // sha256 (idempotent: dest already held identical bytes)
+}
+
+impl Outcome {
+    pub fn sha256(&self) -> &str {
+        match self {
+            Outcome::Written(s) | Outcome::Unchanged(s) => s,
+        }
+    }
+}
+
+/// Testable core: validate, resolve dest, hash, apply overwrite policy, copy.
+fn publish_inner(
+    source: &Path,
+    publish_dir: &Path,
+    version: &str,
+    os: &str,
+    arch: &str,
+    force: bool,
+) -> anyhow::Result<Outcome> {
+    // 1. Validate components.
+    if !binary_store::version_shaped(version) {
+        bail!(
+            "invalid version '{}': must match [A-Za-z0-9.-_+], no empty dot-segments",
+            version
+        );
+    }
+    if !binary_store::platform_shaped(os) {
+        bail!(
+            "invalid os '{}': must be lowercase alphanumeric/underscore only (e.g. linux, windows, macos)",
+            os
+        );
+    }
+    if !binary_store::platform_shaped(arch) {
+        bail!(
+            "invalid arch '{}': must be lowercase alphanumeric/underscore only (e.g. x86_64, aarch64)",
+            arch
+        );
+    }
+
+    // 2. Source must exist and be a file.
+    if !source.exists() || !source.is_file() {
+        bail!("source binary not found: {}", source.display());
+    }
+
+    // 3. Resolve destination path.
+    let dest = binary_store::binary_path(publish_dir, version, os, arch)
+        .context("internal: binary_path rejected validated components")?;
+
+    // 4. Hash the source.
+    let store = BinaryStore::new();
+    let new_sha = store
+        .sha256_of(source)
+        .with_context(|| format!("hashing source {}", source.display()))?;
+
+    // 5. Overwrite policy.
+    if dest.exists() {
+        let old_sha = store
+            .sha256_of(&dest)
+            .with_context(|| format!("hashing existing dest {}", dest.display()))?;
+        if old_sha == new_sha {
+            return Ok(Outcome::Unchanged(new_sha));
+        }
+        if !force {
+            bail!(
+                "refusing to overwrite {} (published sha {} != new {}); pass --force to replace",
+                dest.display(),
+                old_sha,
+                new_sha
+            );
+        }
+        tracing::warn!(
+            "overwriting {} (sha {} → {}); gateway advertised sha is changing",
+            dest.display(),
+            old_sha,
+            new_sha
+        );
+    }
+
+    // 6. Ensure parent directory exists.
+    if let Some(parent) = dest.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("creating directory {}", parent.display()))?;
+    }
+
+    // 7. Copy. std::fs::copy preserves Unix +x bits on Unix.
+    std::fs::copy(source, &dest).with_context(|| format!("copying to {}", dest.display()))?;
+
+    Ok(Outcome::Written(new_sha))
+}
+
+/// Read-only fleet.publish_dir from a config file (no validate(), explicit-command error path).
+fn publish_dir_from_config(path: &Path) -> anyhow::Result<Option<String>> {
+    Config::from_file(path)
+        .map(|c| c.fleet.publish_dir)
+        .with_context(|| format!("could not read fleet.publish_dir from {}", path.display()))
+}
+
+/// CLI entry: resolve args, call publish_inner, print sha to stdout + narration to stderr.
+pub fn run(args: crate::cli::PublishArgs) -> anyhow::Result<()> {
+    // 1. Resolve OS and arch.
+    let os = args.os.unwrap_or_else(|| std::env::consts::OS.to_string());
+    let arch = args
+        .arch
+        .unwrap_or_else(|| std::env::consts::ARCH.to_string());
+
+    // 2. Resolve source binary.
+    let source = match args.binary {
+        Some(p) => p,
+        None => std::env::current_exe().context("could not determine current executable")?,
+    };
+
+    // 3. Resolve publish_dir: --publish-dir > HERD_AGENT_PUBLISH_DIR > config > default.
+    let publish_dir: PathBuf = if let Some(dir) = args.publish_dir {
+        dir
+    } else {
+        let cfg_val = match &args.config {
+            Some(p) => publish_dir_from_config(p)?,
+            None => None,
+        };
+        FleetConfig::publish_dir_from(
+            std::env::var("HERD_AGENT_PUBLISH_DIR").ok().as_deref(),
+            cfg_val.as_deref(),
+        )
+    };
+
+    // 4. Publish.
+    let outcome = publish_inner(&source, &publish_dir, &args.version, &os, &arch, args.force)?;
+
+    // 5. For the narration message, reconstruct the dest path (already validated above).
+    let dest =
+        binary_store::binary_path(&publish_dir, &args.version, &os, &arch).unwrap_or_default();
+
+    // Scriptable sha on stdout.
+    println!("{}", outcome.sha256());
+
+    // Human-readable narration on stderr.
+    match &outcome {
+        Outcome::Written(_) => {
+            eprintln!("published {}", dest.display());
+        }
+        Outcome::Unchanged(_) => {
+            eprintln!(
+                "already published (identical), no change: {}",
+                dest.display()
+            );
+        }
+    }
+    eprintln!("  sha256: {}", outcome.sha256());
+    eprintln!(
+        "  -> now set fleet.target_agent_version: {} (config hot-reload picks it up; no restart)",
+        args.version
+    );
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    fn tmp_dir(label: &str) -> PathBuf {
+        let dir =
+            std::env::temp_dir().join(format!("herd-pub-test-{}-{}", label, std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    /// Write `content` to a temp file inside `dir` named `name`, return its path.
+    fn write_file(dir: &Path, name: &str, content: &[u8]) -> PathBuf {
+        let p = dir.join(name);
+        std::fs::write(&p, content).unwrap();
+        p
+    }
+
+    #[test]
+    fn publishes_to_expected_layout() {
+        let dir = tmp_dir("layout");
+        let src = write_file(&dir, "herd", b"binary");
+
+        let outcome = publish_inner(&src, &dir, "1.2.0", "linux", "x86_64", false).unwrap();
+        let dest = dir.join("1.2.0").join("linux-x86_64").join("herd");
+        assert!(dest.exists(), "dest should exist");
+        assert!(matches!(outcome, Outcome::Written(_)));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn windows_dest_gets_exe_suffix() {
+        let dir = tmp_dir("winsuffix");
+        let src = write_file(&dir, "herd.exe", b"windows-binary");
+
+        let outcome = publish_inner(&src, &dir, "1.2.0", "windows", "x86_64", false).unwrap();
+        let dest = dir.join("1.2.0").join("windows-x86_64").join("herd.exe");
+        assert!(dest.exists(), "herd.exe should exist");
+        assert!(matches!(outcome, Outcome::Written(_)));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn returned_sha_matches_binarystore() {
+        let dir = tmp_dir("sha");
+        let src = write_file(&dir, "herd", b"abc");
+
+        let outcome = publish_inner(&src, &dir, "1.2.0", "linux", "x86_64", false).unwrap();
+        let dest = dir.join("1.2.0").join("linux-x86_64").join("herd");
+
+        let expected = "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad";
+        assert_eq!(outcome.sha256(), expected);
+        assert_eq!(BinaryStore::new().sha256_of(&dest).unwrap(), expected);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn idempotent_rehash_same_bytes() {
+        let dir = tmp_dir("idempotent");
+        let src = write_file(&dir, "herd", b"same");
+
+        let first = publish_inner(&src, &dir, "1.2.0", "linux", "x86_64", false).unwrap();
+        assert!(matches!(first, Outcome::Written(_)));
+
+        let second = publish_inner(&src, &dir, "1.2.0", "linux", "x86_64", false).unwrap();
+        assert!(matches!(second, Outcome::Unchanged(_)));
+        assert_eq!(first.sha256(), second.sha256());
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn refuses_overwrite_differing_bytes_without_force() {
+        let dir = tmp_dir("noforce");
+        let src1 = write_file(&dir, "herd-v1", b"v1");
+        publish_inner(&src1, &dir, "1.2.0", "linux", "x86_64", false).unwrap();
+
+        let src2 = write_file(&dir, "herd-v2", b"v2");
+        let result = publish_inner(&src2, &dir, "1.2.0", "linux", "x86_64", false);
+        assert!(result.is_err(), "should refuse without --force");
+
+        // Dest still holds v1 bytes.
+        let dest = dir.join("1.2.0").join("linux-x86_64").join("herd");
+        assert_eq!(std::fs::read(&dest).unwrap(), b"v1");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn force_overwrites_differing_bytes() {
+        let dir = tmp_dir("force");
+        let src1 = write_file(&dir, "herd-v1", b"v1");
+        publish_inner(&src1, &dir, "1.2.0", "linux", "x86_64", false).unwrap();
+
+        let src2 = write_file(&dir, "herd-v2", b"v2");
+        let result = publish_inner(&src2, &dir, "1.2.0", "linux", "x86_64", true).unwrap();
+        assert!(matches!(result, Outcome::Written(_)));
+
+        let dest = dir.join("1.2.0").join("linux-x86_64").join("herd");
+        assert_eq!(std::fs::read(&dest).unwrap(), b"v2");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn rejects_malformed_version() {
+        let dir = tmp_dir("badver");
+        // Need a real source file since validation happens before source check.
+        let src = write_file(&dir, "herd", b"bin");
+
+        let result = publish_inner(&src, &dir, "../etc", "linux", "x86_64", false);
+        assert!(result.is_err());
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn rejects_malformed_os() {
+        let dir = tmp_dir("bados");
+        let src = write_file(&dir, "herd", b"bin");
+
+        // Uppercase not allowed by platform_shaped
+        let result = publish_inner(&src, &dir, "1.2.0", "LINUX", "x86_64", false);
+        assert!(result.is_err());
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn rejects_malformed_arch() {
+        let dir = tmp_dir("badarch");
+        let src = write_file(&dir, "herd", b"bin");
+
+        let result = publish_inner(&src, &dir, "1.2.0", "linux", "x86_64/..", false);
+        assert!(result.is_err());
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn missing_source_errors() {
+        let dir = tmp_dir("nosrc");
+
+        let absent = dir.join("does-not-exist");
+        let result = publish_inner(&absent, &dir, "1.2.0", "linux", "x86_64", false);
+        assert!(result.is_err());
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn creates_missing_parent_dirs() {
+        let dir = tmp_dir("mkdirs");
+        let src = write_file(&dir, "herd", b"nested");
+
+        // The version/platform subdirs don't exist yet — publish_inner should create them.
+        let outcome = publish_inner(&src, &dir, "2.0.0", "linux", "aarch64", false).unwrap();
+        assert!(matches!(outcome, Outcome::Written(_)));
+        let dest = dir.join("2.0.0").join("linux-aarch64").join("herd");
+        assert!(dest.exists());
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn config_publish_dir_resolution() {
+        let dir = tmp_dir("cfgdir");
+        let cfg_path = dir.join("herd.yaml");
+        let publish_target = dir.join("binaries");
+        std::fs::write(
+            &cfg_path,
+            format!("fleet:\n  publish_dir: {}\n", publish_target.display()),
+        )
+        .unwrap();
+
+        let result = publish_dir_from_config(&cfg_path).unwrap();
+        assert_eq!(result.as_deref(), Some(publish_target.to_str().unwrap()));
+
+        // FleetConfig::publish_dir_from selects config value when env is None.
+        let resolved = FleetConfig::publish_dir_from(None, Some(publish_target.to_str().unwrap()));
+        assert_eq!(resolved, publish_target);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/tasks/HERD-V1.2-SPRINT.md
+++ b/tasks/HERD-V1.2-SPRINT.md
@@ -2,7 +2,7 @@
 
 **Spec:** `docs/specs/v2-distributed-inference-spec.md`
 **Target:** v1.2 (foundation) — `herd agent` ships, single-node deployments only. No speculative, no pipeline.
-**Status:** PRs #1–#5.1, #6a, and #6b landed; #6c next (last reconciled with implementation: 2026-06-10)
+**Status:** PRs #1–#5.1, #6a, #6b, and #6c landed; #7 next (last reconciled with implementation: 2026-06-12)
 
 > This doc tracks the PR breakdown and acceptance checklist for the v1.2 milestone.
 > The architecture, data structures, and rationale live in the spec — this is the
@@ -22,7 +22,7 @@
 | #5.1 | Hard-exclude agent rows from poller + SQLite routing | Live-test fix: `get_pollable_nodes` and `get_routable_nodes` now filter `source != 'agent'` explicitly. Previously the health poller picked up agent rows (`enabled=1`), `update_health` flipped them 'online'→'healthy', and they entered the routable pool — decision 12 was implied by status convention, never enforced. Also closes the `update_node(enabled=true)` side door that sets `status='healthy'` on any row. | ✅ |
 | #6a | Gateway version authority | Reshaped scope (supersedes "heartbeat protocol hardening" — the old "deployments-assigned plumbing" line is folded into this response-channel work). `fleet:` config (`target_agent_version`, `publish_dir`, `download_url_base`); agents report `os`/`arch`; `BinaryStore` (sha256 cache over `{publish_dir}/{version}/{os}-{arch}/herd[.exe]`); heartbeat response gains `target_version` + `download_url`/`sha256` when a binary is published for the agent's platform; authed `GET /api/internal/nodes/binary/:version/:platform`. | ✅ |
 | #6b | Agent self-update | Agent acts on the heartbeat offer: download → verify sha256 (abort + keep running on mismatch) → self-replace → restart (Windows-safe swap via `self_replace`); URL source is presence-as-signal (decision 19, revised); respawn modes `self`/`supervised`; failed-offer memo (~5min suppression); `updating` registry state with eviction grace so the restart gap never looks like node death; `version_changed` beat persists the new `agent_version` and clears 'updating'. | ✅ |
-| #6c | `herd publish` helper | Thin promote step: copy a binary into the publish-dir layout for an os/arch, print its sha256 and a reminder to bump `fleet.target_agent_version` (config hot-reload picks it up). Docs for the manual drop-in flow. | ⬜ |
+| #6c | `herd publish` helper | Thin promote step: `herd publish [BINARY] --version <V> [--os --arch --publish-dir --config --force]` copies a binary into `{publish_dir}/{version}/{os}-{arch}/herd[.exe]` (the write side of `BinaryStore`), prints its sha256 (via `BinaryStore::sha256_of`, so it matches the gateway's advertised hash by construction) and a reminder to bump `fleet.target_agent_version`. Refuses to overwrite differing bytes without `--force`; identical bytes are idempotent. sha→stdout, narration→stderr. | ✅ |
 | #7 | `BackendPool` integration | Agent-registered nodes route identically to static backends; `NodeRegistry::find_for_model()`; conflict resolution (agent overrides static only on exact node-identity match). **Note (PR #5.1):** agents are now hard-excluded from `get_routable_nodes` by `source`; PR #7 must source agent routability from the in-memory registry's heartbeat freshness, not by falling through the SQLite pool path. | ⬜ |
 | #8 | Integration test + smoke | Gateway + 1 agent in same process; request routes through agent's (stub) llama-server end-to-end | ⬜ |
 
@@ -179,6 +179,20 @@ Locked decisions (extend the list above):
     `update_cleared` (true exactly when a normal beat disarms a prior `updating_since`),
     and the gateway persists on it — clearing the row back to 'online' independent of any
     version change. Verified by `normal_beat_with_same_version_clears_stuck_updating_row`.
+25. **`herd publish` is the write side of `BinaryStore`** (#6c). The promote subcommand
+    copies a binary into the exact layout the gateway serves and prints the sha256 via
+    `BinaryStore::sha256_of`, so the published hash matches the gateway's advertised hash
+    by construction (no second hashing implementation to drift). Design choices:
+    source defaults to `current_exe()` (publish the build you just made), positional
+    `[BINARY]` overrides for cross-publishing; `--version` is **required** — publishing
+    under the wrong version is the one silent mis-serve, so it is never defaulted from
+    `CARGO_PKG_VERSION`. os/arch default to host `std::env::consts`. publish-dir reuses
+    `FleetConfig::publish_dir_from` (`--publish-dir` > `HERD_AGENT_PUBLISH_DIR` > `--config`'s
+    `fleet.publish_dir` > `~/.herd/binaries`). Overwriting differing bytes is **refused
+    without `--force`** (a mid-flight sha change would break decision-18 verify); identical
+    bytes are idempotent (`Outcome::Unchanged`). sha256→stdout (scriptable), narration→stderr.
+    Thin promote only — no auto-bump of `target_agent_version` (a separate deliberate act,
+    decision 16), no list/prune/GC, no remote upload, no config `validate()`, no async.
 
 ---
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -3,83 +3,51 @@
 > Scratchpad for in-flight work. Milestone tracking lives in `ROADMAP.md`;
 > the v1.2 PR breakdown + acceptance checklist live in `tasks/HERD-V1.2-SPRINT.md`.
 
-**Last updated:** 2026-06-05
+**Last updated:** 2026-06-12
 
 ---
 
-## ✅ Verification complete (2026-06-05, post-toolchain-install)
+## In flight — v1.2 PR #6c: `herd publish` (branch `feat/v1.2-pr6c-publish`)
 
-PR #3 (`feat/v1.2-pr3-heartbeat-ingestion`) is now **compiler-verified**. Toolchain note:
-the machine had Rust (msvc) but no C/C++ build tools — installed VS 2022 Build Tools
-(VCTools + Windows SDK 10.0.26100) so linking and `ring` compile.
+Thin promote subcommand: copy a binary into `{publish_dir}/{version}/{os}-{arch}/herd[.exe]`,
+print sha256 + reminder to bump `fleet.target_agent_version`. Design by architect-pr6c (locked).
 
-Results:
-```
-cargo build                 # ✓ clean
-cargo test internal         # ✓ 8/8 heartbeat protocol tests pass
-cargo test                  # ✓ full suite green — 323 lib + 15 + 10 integration, 0 failures
-cargo fmt --check           # ✓ clean (applied fmt to src/api/internal.rs)
-cargo clippy --all-targets  # ✓ new code clean; one PRE-EXISTING warning in
-                            #   src/agent/store.rs:136 (sort_by → sort_by_key), unrelated to PR #3
-```
+**Decisions:** source = positional `[BINARY]`, default `current_exe()`; `--version` REQUIRED
+(no default — wrong version is the one silent mis-serve); os/arch default to host consts,
+overridable; publish-dir = `--publish-dir` > `HERD_AGENT_PUBLISH_DIR` env > `--config`'s
+`fleet.publish_dir` > `~/.herd/binaries` (reuse `FleetConfig::publish_dir_from`); overwrite
+refused on differing bytes without `--force`, identical bytes = idempotent; sha→stdout,
+narration→stderr; logic in new `src/publish.rs` (sync `pub fn run`), `PublishArgs` in `cli.rs`.
 
-**One real fix was needed** (the kind only a compiler catches): the `#[cfg(test)]`
-`AppState` builder in `src/server.rs` (reload-config test, ~L2246) was missing the new
-`node_registry` field — added `node_registry: Arc::new(NodeRegistry::new(Duration::from_secs(30)))`.
-The `tests/frontier_escalation.rs` builder already had it.
+### Build steps
+- [ ] 1. `cli.rs`: add `PublishArgs` struct + `Command::Publish(PublishArgs)` variant.
+- [ ] 2. `lib.rs`: `pub mod publish;` (keep alpha order).
+- [ ] 3. `src/publish.rs`: `run()` (arg resolution + stdout/stderr) wrapping a testable
+       `publish_inner(source, publish_dir, version, os, arch, force) -> Result<Outcome>`
+       returning `Written(sha)` | `Unchanged(sha)`. Validate version/os/arch up front via
+       `version_shaped`/`platform_shaped`; reuse `binary_path` + `BinaryStore::sha256_of`.
+- [ ] 4. `publish.rs`: `publish_dir_from_config(&Path) -> Result<Option<String>>` (read-only
+       `Config::from_file(...).fleet.publish_dir`, no `validate()`), called only when `--config` given.
+- [ ] 5. `main.rs`: dispatch `Some(Command::Publish(args)) => herd::publish::run(args)` (SYNC, no await).
+- [ ] 6. Tests: 11 unit (publish.rs, tempdir via `temp_dir()+process::id()` pattern — NO new dep) +
+       4 CLI-parse (cli.rs `cli_tests`). Key: returned sha == `BinaryStore` sha (by-construction
+       parity), refuse-overwrite, idempotent rehash, force-overwrite, malformed version/os/arch,
+       missing source, create-parent-dirs, config resolution, `--version` required.
+- [ ] 7. Docs: sprint-doc Decision 25 + flip #6c to ✅ in PR table; one README/fleet-docs line for
+       the manual drop-in flow. NOT the dashboard Agent Guide tab (CLI cmd, not HTTP endpoint).
 
-Spot-checks from the original review all held up:
-- `axum::body::Bytes` extractor is last in the `heartbeat` handler ✓
-- `#[serde(default)]` on `HeartbeatRequest::timestamp` deserializes correctly ✓
-- `constant_time_eq` is reachable as `pub(crate)` from `src/api/internal.rs` ✓
+### Verification gate (operator, before PR)
+- [ ] `cargo build` + `cargo test` (count grows from 468) + `cargo clippy --all-targets -- -D warnings` + `cargo fmt --check`
 
-Ready to commit (`feat(nodes): wire NodeRegistry onto AppState + heartbeat endpoint`),
-push, open PR #3.
+### Scope guard (OUT of #6c)
+No auto-bump of target version; no list/prune/GC; no remote upload (local disk only);
+no cross-compile/build invocation; no `latest` symlink; no full config `validate()`; no async.
 
----
-
-## In flight
-
-### v1.2 PR #3 — Gateway heartbeat ingestion ✅ (written, unverified)
-- [x] `NodeRegistry` on `AppState` (30s TTL)
-- [x] 10s stale-eviction background task in `server::run`
-- [x] `POST /api/internal/nodes/heartbeat` (`src/api/internal.rs`) + `HERD_AGENT_TOKEN` auth
-- [x] 8 heartbeat protocol unit tests
-- [x] Docs: sprint doc created, v2 spec reconciled
-- [x] **Compile + test verification** — green; fixed missing `node_registry` in test `AppState` builder
+### Done = green gate + reviewer CLEAN → commit + push → open PR vs `main`. Do NOT auto-merge.
 
 ---
 
-## Next — v1.2 PR #4: `herd agent` CLI + daemon
-
-The big structural one. Scope from `tasks/HERD-V1.2-SPRINT.md`:
-
-1. **CLI restructure** — `src/main.rs` is currently a flat `clap::Parser` (flags only).
-   Convert to subcommands: `serve` (default, today's behavior) + `agent`. Keep existing
-   flags (`--config`, `--port`, `--host`, `--backend`, `--update`) working under `serve`.
-   ⚠️ The v2 spec wrongly claims "cli.rs already dispatches subcommands" — it does not.
-   `src/cli.rs` is only `parse_backend_spec`. This restructure is real, unplanned-in-spec work.
-2. **`src/daemon/` module** (named `daemon`, not `agent`, to avoid colliding with the
-   existing agent-sessions `src/agent/`):
-   - `client.rs` — heartbeat client: POST capability snapshot to `--gateway` every 2s
-     (configurable), `HERD_AGENT_TOKEN` bearer. Reuse the `TestClock` pattern for timers.
-   - `capabilities.rs` — GPU/VRAM/model detection. Reuse herd-tune logic where possible.
-   - `lifecycle.rs` — spawn/supervise local `llama-server` (rpc-server deferred to v1.4).
-3. **Node ID** — hostname-derived default (`hostname-gpu`, e.g. `citadel-5090`), `--node-id` override.
-4. Tests: capability snapshot serialization round-trips against `AgentCapabilities`;
-   heartbeat client retries/backoff on gateway-down.
-
-## Then — remaining v1.2 PRs
-- **#5** — Dashboard Fleet tab projects `NodeRegistry` live state alongside SQLite operator nodes.
-- **#7** — `BackendPool` integration: agent nodes route like static backends; `NodeRegistry::find_for_model()`;
-  conflict resolution (agent overrides static only on exact `node_id` + address match); 503 when all gone.
-- **#8** — Integration test: gateway + 1 agent in-process, request routes through agent's stub llama-server.
-
----
-
-## Backlog / loose ends noticed during review
-- `tasks/HERD-V1.2-SPRINT.md` was missing entirely (referenced by ROADMAP + spec) — recreated 2026-06-05.
-- v1.1.1 and v1.1.2 are in `Cargo.toml`/commits but **not git-tagged** (tags stop at `v1.1.0`).
-  Consider `git tag v1.1.1 v1.1.2` retroactively, or tag at next release.
-- New endpoint not in `skills.md`/dashboard per CLAUDE.md rule — intentional: it's an internal
-  agent-protocol endpoint, not a client API. Dashboard surfacing is PR #5.
+## Backlog
+- #7 — `BackendPool` integration (agent nodes route via in-memory registry freshness, not SQLite pool).
+- #8 — Integration test: gateway + 1 agent in-process, request routes through agent's stub llama-server.
+- v1.1.1 / v1.1.2 not git-tagged (tags stop at v1.1.0) — tag retroactively or at next release.


### PR DESCRIPTION
## Summary

PR #6c of the v1.2 fleet-update stack — the operator-facing **promote** step that completes the loop (#6a gateway version authority, #6b agent self-update, both on `main`). `herd publish` is the **write side of the gateway's `BinaryStore`**: it drops a binary into the exact layout the gateway serves and prints the sha256 the gateway will advertise.

```
herd publish [BINARY] --version <V> [--os <OS>] [--arch <ARCH>] [--publish-dir <DIR>] [--config <FILE>] [--force]
```

Writes to `{publish_dir}/{version}/{os}-{arch}/herd[.exe]`. Operator flow: build → `herd publish --version <V>` → set `fleet.target_agent_version: <V>` (hot-reloaded) → agents self-update.

## Design (locked by architect, decision 25)

- **sha by construction.** Prints the sha256 via `BinaryStore::sha256_of` — the same function the gateway hashes with — so the published and advertised hashes can't drift (no second hashing implementation).
- **Source defaults to `current_exe()`** (publish the build you just made); a positional `[BINARY]` overrides for cross-publishing a binary built elsewhere. `--os`/`--arch` default to host `std::env::consts`.
- **`--version` is required** — never defaulted from `CARGO_PKG_VERSION`. Publishing under the wrong version is the one silent mis-serve (agents fetch bytes that don't match the version path), so the operator must name it.
- **publish-dir** reuses `FleetConfig::publish_dir_from`: `--publish-dir` > `HERD_AGENT_PUBLISH_DIR` > `--config`'s `fleet.publish_dir` (only when `--config` given) > `~/.herd/binaries`. No full `Config` load / `validate()` — reads one string.
- **Overwrite policy.** Differing bytes are **refused without `--force`** — silently changing the advertised sha mid-flight would break the agent's verify-before-swap (#6b decision 18). Identical bytes are idempotent (`Outcome::Unchanged`, exit 0).
- **Streams.** sha256 → **stdout** (alone, scriptable: `SHA=$(herd publish … --version 1.2.0)`); all narration → **stderr**. Sync — no HTTP, no async runtime.

## Testing

- **484 tests** passing (468 → 484; +16), `cargo clippy --all-targets -- -D warnings` clean, `cargo fmt --check` clean.
- Unit (`publish.rs`): expected layout, windows `.exe` suffix, **by-construction sha parity with `BinaryStore`**, idempotent rehash, refuse-overwrite-without-force, force-overwrite, malformed version/os/arch rejection, missing source, create-parent-dirs, `--config` resolution. CLI-parse (`cli.rs`): defaults, positional+overrides, `--version` required, `-c` short flag.
- **Functional smoke (operator-run):** published `"abc"` → stdout was exactly `ba7816bf…15ad` (known sha of "abc") with narration on stderr and the binary at `…/1.2.0/linux-x86_64/herd`; re-run reported idempotent "no change" (exit 0); differing bytes without `--force` refused with exit 1 and both shas named.

## Scope guard (explicitly out)

No auto-bump of `fleet.target_agent_version` (a separate deliberate cutover, decision 16); no `list`/`prune`/GC; no remote upload (local disk only — the gateway serves from local disk); no cross-compile/build invocation; no `latest` symlink; no async.

## Reviewer note (non-blocking, not actioned)

`publish::run` uses `binary_path(…).unwrap_or_default()` purely to format the success message; the inputs were already validated inside `publish_inner`, so the `None`/default branch is unreachable and never a panic. Left as-is rather than reshaping `Outcome` to carry the path for a cosmetic message on a thin PR.

Branches off `main` (`bdcfea4`). Reviewer pass returned CLEAN; operator independently re-ran build/test/clippy/fmt + the functional smoke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
