### PR TITLE
docs: reconcile docs with the v1.2 fleet self-update stack (#6a/#6b/#6c)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,14 @@
 [![GitHub stars](https://img.shields.io/github/stars/swift-innovate/herd?style=social)](https://github.com/swift-innovate/herd/stargazers)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Rust](https://img.shields.io/badge/rust-1.70+-orange.svg)](https://www.rust-lang.org)
-[![Roadmap](https://img.shields.io/badge/roadmap-v1.1-blue)](ROADMAP.md)
+[![Roadmap](https://img.shields.io/badge/roadmap-v1.2-blue)](ROADMAP.md)
 
 **Intelligent LLM fleet router with GPU awareness, multi-backend support, and real-time observability.**
 
 Route your llama herd with intelligence — Herd sits in front of your inference nodes (Ollama, llama-server, or any self-hosted OpenAI-compatible backend) and routes requests based on model availability, GPU load, and node health. One binary. One endpoint. Your entire fleet, unified.
 
+> **v1.2 (main):** `herd agent` node daemon, gateway version authority + agent self-update, `herd publish` promote step, and the `fleet:` config block. See [What's New in v1.2](#whats-new-in-v12).
+>
 > **New in v1.1:** TLS termination, per-client rate limiting, budget caps, routing profiles, Ollama blob extraction, multi-node discovery, **Frontier Gateway** (cloud-model routing with per-provider rate limits and live USD cost tracking), and auto-mode → frontier escalation. See [What's New in v1.1](#whats-new-in-v11).
 >
 > **v1.0:** llama-server (llama.cpp) as a first-class backend. Benchmarked at **44–80% faster TTFT** and **~4x throughput** vs Ollama on identical hardware. Herd is now vendor-agnostic across NVIDIA, AMD, and Intel GPUs. See [Backend Types](#backend-types) and the [benchmark data](docs/LLAMA_CPP_BACKEND.md).
@@ -22,6 +24,71 @@ Running multiple agents + parallel tool calls? Herd stops the GPU wars.
 Point your agents at `http://your-herd:40114` — model homing + live VRAM routing keeps every request on the fastest available node.
 
 Benchmarked on RTX 5090 with 4 concurrent agent requests: **41 seconds average TTFT via Ollama → 8 seconds via llama-server through Herd.** That's the difference between agents waiting and agents working.
+
+## What's New in v1.2
+
+These features are available on `main`. The released binary version remains 1.1.2; the v1.2 label tracks the roadmap milestone.
+
+### `herd agent` — Node Daemon
+
+Run `herd agent --gateway <url>` on each inference node. The daemon heartbeats its version, capabilities, and backend URL to the gateway every ~2 seconds. No manual registration step required — the node appears in `GET /api/nodes` as soon as the first heartbeat arrives.
+
+Key flags:
+
+| Flag | Default | Env override |
+|------|---------|-------------|
+| `--gateway <url>` | (required) | — |
+| `--node-id <id>` | hostname-gpu | — |
+| `--heartbeat-secs <n>` | `2` | `HERD_HEARTBEAT_SECS` |
+| `--backend-url <url>` | `http://127.0.0.1:11434` | — |
+| `--advertise-url <url>` | same as `--backend-url` | — |
+| `--backend <type>` | auto-detected | — |
+| `--respawn-mode <self\|supervised>` | `self` | `HERD_RESPAWN_MODE` |
+
+Auth: set `HERD_AGENT_TOKEN` on both the gateway and the agent node.
+
+### Gateway Version Authority + Agent Self-Update
+
+The gateway advertises `fleet.target_agent_version` on every heartbeat response. An agent whose version is older downloads the binary from the gateway, verifies the sha256, self-replaces, and restarts. An update offer is only attached when a binary is actually published under `publish_dir` for the target version and the agent's platform — no offer, no download.
+
+Operator flow:
+
+```bash
+# 1. Build
+cargo build --release
+
+# 2. Publish — defaults to the running binary and host os/arch
+herd publish ./target/release/herd --version 1.2.0
+# Prints sha256 to stdout; refuses to overwrite differing bytes without --force
+
+# 3. Set the target version in herd.yaml (hot-reloaded — no restart needed)
+#    fleet:
+#      target_agent_version: "1.2.0"
+# Agents pick it up on their next heartbeat.
+```
+
+### `herd publish` — Promote a Binary
+
+```
+herd publish [BINARY] --version <V> [--os <os>] [--arch <arch>]
+             [--publish-dir <dir>] [--config <file>] [--force]
+```
+
+`BINARY` defaults to the running binary (`current_exe()`). Writes `{publish_dir}/{version}/{os}-{arch}/herd[.exe]` and prints the sha256. `--force` is required to overwrite a file whose bytes differ from the source.
+
+### `fleet:` Config Block
+
+```yaml
+fleet:
+  target_agent_version: "1.2.0"          # version agents self-update to; env HERD_TARGET_AGENT_VERSION wins; defaults to gateway's own version
+  publish_dir: "~/.herd/binaries"        # where published agent binaries live; env HERD_AGENT_PUBLISH_DIR wins; default ~/.herd/binaries
+  download_url_base: "https://cdn.example.com/herd"  # OPTIONAL: external download source; unset = gateway serves binaries itself
+  respawn_mode: "self"                   # fleet-wide restart intent: self | supervised
+```
+
+All fields are optional with sensible defaults — an empty `fleet:` block or omitting it entirely is valid.
+
+---
 
 ## What's New in v1.1
 
@@ -295,7 +362,7 @@ Herd is a **smart stateless proxy with a stateful routing cache**. It is not HA 
 - **Blackwell detection** — Identifies RTX 5000-series GPUs requiring CUDA 13.x
 - **llama-server provisioning** — herd-tune downloads the correct llama-server binary per GPU vendor
 - **SQLite node registry** — Persistent fleet state with health polling
-- **Agent self-update** — The gateway is the fleet's version authority: agents (`herd agent`) heartbeat their version and self-update to the published target. Promote a build with `herd publish [BINARY] --version <V>` (defaults to the running binary and host os/arch), then set `fleet.target_agent_version: <V>` in `herd.yaml` (hot-reloaded). `publish` prints the sha256 the gateway will advertise and refuses to overwrite differing bytes without `--force`.
+- **Agent self-update** — The gateway is the fleet's version authority: agents (`herd agent`) heartbeat their version and self-update to the published target. Promote a build with `herd publish [BINARY] --version <V>` (defaults to the running binary and host os/arch), then set `fleet.target_agent_version: <V>` in the `fleet:` config block (hot-reloaded). `publish` prints the sha256 the gateway will advertise and refuses to overwrite differing bytes without `--force`. See [`fleet:` config block](#fleet-config-block) for all options.
 - **HuggingFace model search** — Search GGUF models with VRAM compatibility per-node
 - **Model download** — Pull models to Ollama nodes via API (llama-server download in roadmap)
 - **Ollama blob extraction** — Extract raw GGUF from Ollama blob storage for llama-server reuse
@@ -344,6 +411,25 @@ herd --port 40114 \
   --backend node-b=http://node-b:11434:80 \
   --backend node-c=http://node-c:11434:50
 ```
+
+### Running a fleet agent
+
+On each inference node, run the `herd agent` daemon alongside the backend. It self-registers with the gateway and keeps the node's health record live:
+
+```bash
+# Minimal — auto-detects backend type and node ID
+HERD_AGENT_TOKEN=your-token herd agent --gateway http://herd-host:40114
+
+# Explicit flags
+HERD_AGENT_TOKEN=your-token herd agent \
+  --gateway http://herd-host:40114 \
+  --node-id my-gpu-node \
+  --backend-url http://127.0.0.1:8090 \
+  --backend llama-server \
+  --heartbeat-secs 2
+```
+
+The node appears in `GET /api/nodes` as soon as the first heartbeat arrives. The gateway will offer a binary update if `fleet.target_agent_version` is set and a matching binary is published — the agent downloads, verifies, and self-replaces automatically.
 
 ## Using Herd with any LLM client
 
@@ -482,6 +568,12 @@ observability:
 agent:
   enabled: false             # Agent sessions, tool calling, permissions
 
+fleet:
+  target_agent_version: "1.2.0"    # version to push to all agents; defaults to gateway's own version
+  publish_dir: "~/.herd/binaries"  # where herd publish writes binaries
+  # download_url_base: "https://cdn.example.com/herd"  # omit to serve binaries from the gateway
+  respawn_mode: "self"             # self | supervised
+
 routing:
   auto:
     enabled: false           # Auto Mode: off by default
@@ -587,6 +679,8 @@ Request IDs are included in JSONL analytics logs for correlation across systems.
 | `GET /api/ollama/models` | List extractable Ollama models |
 | `POST /api/ollama/extract` | Extract GGUF from Ollama blob storage |
 | `GET /api/frontier/costs` | Per-provider monthly spend and token totals |
+| `POST /api/internal/nodes/heartbeat` | Agent capability + version heartbeat — `herd agent` protocol only (`HERD_AGENT_TOKEN` bearer) |
+| `GET /api/internal/nodes/binary/{version}/{os}-{arch}` | Serve published agent binary for self-update — `herd agent` protocol only (`HERD_AGENT_TOKEN` bearer) |
 
 ## Telemetry & Prometheus Metrics
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Herd Roadmap
 
-**Updated:** April 17, 2026
+**Updated:** June 12, 2026
 
 ## Vision
 
@@ -131,16 +131,16 @@ No cloud dependency. No API keys exposed. Full local control.
 
 Three-phase delivery introduces self-registering node agents and deployment-aware routing:
 
-- **v1.2** — Agent/Gateway foundation. `herd agent` subcommand, `NodeRegistry`, single-node deployments. Sprint plan: `tasks/HERD-V1.2-SPRINT.md`. *Status: PRs #1–#5.1 of 8 landed — `Deployment` module, `NodeRegistry` with TTL eviction, gateway heartbeat endpoint (`HERD_AGENT_TOKEN` auth), the node-side `herd agent` daemon (GPU/VRAM detection, local backend probe, 2s heartbeat with backoff), and agent node persistence (migration v5 `source`/`agent_version`, write-through on transitions, soft-evict + reaper, Fleet tab reads unified SQLite store). PR #6 (three stacked PRs) makes the gateway the fleet version authority: heartbeat responses advertise `target_agent_version` + a sha256-verified download offer served from a publish dir (#6a, landed), agents act on the offer — download from their own `--gateway` address (or the explicit `download_url` external override), verify sha256 before swap, self-replace, restart per respawn mode (`self`/`supervised`) — with an `updating` registry state + eviction grace so the restart gap never reads as node death (#6b, landed). Still to come: a `herd publish` promote helper (#6c). Remaining after that: `BackendPool` routing integration, end-to-end test.*
+- **v1.2** — Agent/Gateway foundation. `herd agent` subcommand, `NodeRegistry`, single-node deployments. Sprint plan: `tasks/HERD-V1.2-SPRINT.md`. *Status: PRs #1–#6c landed (fleet foundation: `Deployment` module, `NodeRegistry` with TTL eviction, gateway heartbeat endpoint (`HERD_AGENT_TOKEN` auth), `herd agent` daemon (GPU/VRAM detection, local backend probe, 2s heartbeat with backoff), agent node persistence (migration v5 `source`/`agent_version`, write-through on transitions, soft-evict + reaper, Fleet tab reads unified SQLite store), gateway version authority with sha256-verified download offers (#6a), agent self-update with verify-before-swap and eviction grace (#6b), and `herd publish` promote helper (#6c — `herd publish [BINARY] --version <V> [--os --arch --publish-dir --config --force]`, copies binary into `{publish_dir}/{version}/{os}-{arch}/herd[.exe]`, prints sha256, refuses overwrite of differing bytes without `--force`)). Remaining: `BackendPool` routing integration (#7) and end-to-end integration test (#8).*
 - **v1.3** — Speculative decoding deployments. Draft/verifier pairs across nodes via llama.cpp's `--model-draft` for 2-3x throughput on daily-driver models.
 - **v1.4** — Pipeline parallel deployments. llama.cpp RPC integration to serve models that don't fit on any single GPU (Qwen2.5-72B-class).
 
-Other v1.2.0+ items still on the list:
+The following items were originally listed alongside v1.2 but are **not part of the v1.2 foundation scope** — they target v1.3 and later:
 
-- Multi-node discovery (mDNS — full implementation)
-- Plugin system for custom routing strategies
-- Distributed health consensus
-- Multi-model consensus routing
+- Multi-node discovery (mDNS — full implementation) *(v1.3+)*
+- Plugin system for custom routing strategies *(v1.3+)*
+- Distributed health consensus *(v1.4+)*
+- Multi-model consensus routing *(v1.4+)*
 
 ## Get Involved
 

--- a/docs/LLAMA_CPP_BACKEND.md
+++ b/docs/LLAMA_CPP_BACKEND.md
@@ -79,6 +79,25 @@ Herd doesn't care about GPU vendor — it talks OpenAI-compatible HTTP to each n
 
 **Fleet mode** (new): One Herd instance is the host. Each additional node runs llama-server with the appropriate GPU backend. herd-tune detects hardware, downloads the correct llama-server binary, and registers with the host.
 
+### Fleet Architecture (v1.2): the `herd agent` daemon
+
+v1.2 adds a lightweight node daemon — `herd agent` — that can run alongside any node backend (Ollama or llama-server). This is an evolution of fleet mode, not a replacement for the static herd-tune enrollment flow: both coexist and the gateway routes to all of them identically.
+
+**How it works:** A node starts `herd agent --gateway <gateway-url>`. The daemon registers with the gateway on startup and sends periodic heartbeats. The gateway is the fleet version authority: it holds a `fleet:` config block specifying `target_agent_version`, `publish_dir`, `download_url_base`, and `respawn_mode`. On each heartbeat response the gateway can include an update offer when the agent's reported version is behind target.
+
+**Self-update flow:** On receiving an update offer the agent downloads the new binary from `{download_url_base}/{version}/{os}-{arch}/herd[.exe]`, verifies the sha256 digest, atomically replaces itself, then restarts via the configured respawn mode (`self` — re-exec in place, or `supervised` — signal the parent supervisor and exit). A `herd publish [BINARY] --version <V>` command promotes a built binary into the publish directory.
+
+**What this adds to the fleet picture:**
+
+```
+[Herd Gateway]  --HTTP/OpenAI-->  [llama-server node 1]  <-- herd agent (heartbeat + self-update)
+                --HTTP/OpenAI-->  [llama-server node 2]  <-- herd agent
+                --HTTP/OpenAI-->  [Ollama node 3]         <-- herd agent (or static, both work)
+                --HTTP/OpenAI-->  [llama-server node 4]  <-- herd-tune enrolled (static)
+```
+
+Nodes without a running agent daemon still work — heartbeat-enrolled nodes and statically registered nodes coexist in the same registry and are routed identically.
+
 ### Node Setup (herd-tune changes)
 
 herd-tune currently assumes Ollama. For llama-server backends, herd-tune needs to:
@@ -153,4 +172,4 @@ Prefix caching (available in llama-server) is directly relevant to VALOR operati
 - [x] Add `herd search` API endpoint (inspired by Fox's model search UX) -- available at `GET /api/models/search`
 - [ ] Test ROCm backend on an AMD node (minipc candidate if swapped to AMD GPU)
 - [ ] Fix streaming token counter in benchmark harness for complete throughput data
-- [ ] Investigate llama.cpp RPC for tensor-parallel sharding across fleet nodes (v2.0+)
+- [ ] Investigate llama.cpp RPC for tensor-parallel sharding across fleet nodes (v1.4+)

--- a/docs/specs/v2-distributed-inference-spec.md
+++ b/docs/specs/v2-distributed-inference-spec.md
@@ -1,8 +1,8 @@
 # Herd v2 — Distributed Inference Spec
 
-**Status:** v1.2 in progress (PRs #1–#3 landed of 8; see `tasks/HERD-V1.2-SPRINT.md`)
+**Status:** v1.2 in progress (PRs #1–#6c landed of 8; #7 BackendPool integration and #8 integration test pending; see `tasks/HERD-V1.2-SPRINT.md`)
 **Author:** Tom Swift (Director) + Gage
-**Date:** 2026-04-17 (last reconciled with implementation: 2026-06-05)
+**Date:** 2026-04-17 (last reconciled with implementation: 2026-06-12)
 **Targets:** v1.2 (foundation) → v1.3 (speculative) → v1.4 (pipeline)
 **Supersedes:** N/A — extends `ROADMAP.md` v1.2.0+ "llama.cpp RPC integration for tensor-parallel sharding"
 
@@ -375,23 +375,25 @@ src/
 
 ## Open Questions for Tom
 
-These should be decided before v1.2 implementation lands. PR descriptions should reference whichever ones the PR touches.
+**All questions below are resolved and locked for v1.2.** See `tasks/HERD-V1.2-SPRINT.md` → "Decisions (locked for v1.2)" for the full record, including the fleet-authority decisions added during the PR #6 series (questions 15–25 in that doc).
 
-1. **Module naming.** `src/daemon/` proposed to avoid colliding with existing `src/agent/` (sessions). Alternative: `src/node_agent/`. Preference?
+For reference, the original questions and their outcomes:
 
-2. **Auth mechanism.** Shared bearer token in `HERD_AGENT_TOKEN` env var for v1.2 (simple, fine on Tailscale). Document mTLS as future hardening. OK with that, or want mTLS day one?
+1. **Module naming.** RESOLVED: `src/daemon/` — avoids collision with existing `src/agent/` (sessions). User-facing CLI term remains `herd agent`.
 
-3. **Node ID assignment.** Recommend: human-readable, hostname-derived (`hostname-gpu` like `citadel-5090`), with `--node-id` override. Sound right?
+2. **Auth mechanism.** RESOLVED: Shared bearer token via `HERD_AGENT_TOKEN` env var. Unset = warn+allow; set = required. mTLS documented as future hardening.
 
-4. **Heartbeat cadence.** 2s default. Configurable per-agent via flag or env. Reasonable?
+3. **Node ID assignment.** RESOLVED: Human-readable, hostname-derived (`hostname-gpu` format, e.g. `citadel-5090`), with `--node-id` override flag.
 
-5. **Deployment manifest source.** Option A: top-level `deployments:` section in `herd.yaml`. Option B: separate `deployments.yaml`. Option C: admin API only, persisted to SQLite. Recommend A for consistency with existing config patterns. This is deferred beyond v1.2; v1.2 ships single-node only and does not add new deployment config.
+4. **Heartbeat cadence.** RESOLVED: 2s default, configurable per-agent via flag or env. 30s TTL on the gateway.
 
-6. **Conflict resolution.** A node is both statically configured *and* registers as an agent. Decided for v1.2: agent registration overrides only on exact logical-node identity match (`node_id` + advertised inference address). Otherwise both remain and a duplication warning is logged.
+5. **Deployment manifest source.** RESOLVED: Deferred beyond v1.2. v1.2 ships single-node only and adds no new deployment config. When it lands, top-level `deployments:` in `herd.yaml` (Option A) is the target.
 
-7. **Gateway address discovery.** Require explicit `--gateway <url>` on the agent. Document `herd.starbase` (Tailscale DNS) as the recommended value but don't auto-discover. Agreed?
+6. **Conflict resolution.** RESOLVED: Agent registration overrides a static backend only on exact logical-node identity match (`node_id` + advertised inference address). Otherwise both remain and the gateway logs a duplication warning.
 
-8. **Speculative decoding model pairing.** Configured per-deployment in the manifest, or auto-suggested by Herd based on model family? Recommend: manual for v1.3, auto-suggestion is a v1.5 nice-to-have.
+7. **Gateway address discovery.** RESOLVED: Explicit `--gateway <url>` required on the agent. No auto-discovery; `herd.starbase` (Tailscale DNS) documented as the recommended value.
+
+8. **Speculative decoding model pairing.** RESOLVED: Manual per-deployment config for v1.3. Auto-suggestion is a v1.5 nice-to-have.
 
 ---
 

--- a/herd.yaml.example
+++ b/herd.yaml.example
@@ -334,3 +334,29 @@ observability:
 #     rate_limit: 100
 #     monthly_budget: 50.00
 #     priority: 20
+
+# === FLEET MANAGEMENT ===
+# Agent self-update: herd agent daemons running on each node heartbeat the gateway
+# every ~2s and self-update when the gateway advertises a newer published binary.
+# All fields optional — defaults work out of the box (gateway serves its own version).
+#
+# Operator promote workflow:
+#   1. cargo build --release
+#   2. herd publish ./target/release/herd --version 1.2.0
+#      (prints the sha256 the gateway will advertise)
+#   3. Set fleet.target_agent_version: "1.2.0" in herd.yaml (supports hot-reload —
+#      POST /admin/reload or wait for the 30s file-watcher cycle; no restart needed)
+#   4. Agents self-update on their next heartbeat (~2s); old binary is evicted after
+#      the grace period
+
+# fleet:
+#   target_agent_version: "1.2.0"          # version agents self-update to;
+#                                           # env HERD_TARGET_AGENT_VERSION wins;
+#                                           # defaults to the gateway's own version
+#   publish_dir: "~/.herd/binaries"        # where published agent binaries live;
+#                                           # env HERD_AGENT_PUBLISH_DIR wins;
+#                                           # default: ~/.herd/binaries
+#   download_url_base: "https://cdn.example.com/herd"
+#                                           # OPTIONAL external download source;
+#                                           # unset = gateway serves binaries itself
+#   respawn_mode: "self"                   # fleet-wide restart intent: self | supervised

--- a/skills.md
+++ b/skills.md
@@ -387,6 +387,51 @@ clients like Open WebUI from accidentally evicting models.
 **Hot models warmer:** Backends can declare `hot_models` — Herd pings each one
 every 4 minutes with `keep_alive: "-1"` to pre-load on startup and recover from OOM.
 
+## Fleet Self-Update (agent heartbeat protocol)
+
+`herd agent` is a daemon that runs on each node alongside the backend (Ollama, llama-server, etc.).
+It does two things:
+
+1. **Heartbeat** — calls `POST /api/internal/nodes/heartbeat` every ~2 seconds. The gateway
+   responds with the current `target_version`, and when a newer published binary is available for
+   the agent's platform, also returns `download_url` and `sha256`.
+2. **Self-update** — when the heartbeat response advertises a version newer than the running binary,
+   the agent downloads, verifies (sha256), and hot-swaps itself. The old process gets a grace period
+   to drain in-flight work before eviction.
+
+**Auth:** Both internal endpoints require `Authorization: Bearer <HERD_AGENT_TOKEN>`. This token
+is never shared with client chat agents.
+
+### Promoting a new agent binary
+
+```bash
+# 1. Build
+cargo build --release
+
+# 2. Publish — prints the sha256 the gateway will advertise
+herd publish ./target/release/herd --version 1.2.0
+
+# 3. Point the fleet at the new version (hot-reload — no gateway restart needed)
+#    Edit herd.yaml:
+#      fleet:
+#        target_agent_version: "1.2.0"
+#    Then: POST /admin/reload  (or wait up to 30s for the file-watcher)
+
+# 4. Agents self-update on their next heartbeat (~2s)
+```
+
+### `fleet:` config knobs (all optional)
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `target_agent_version` | gateway's own version | Version agents self-update to. Env `HERD_TARGET_AGENT_VERSION` wins. |
+| `publish_dir` | `~/.herd/binaries` | Directory where `herd publish` drops binaries. Env `HERD_AGENT_PUBLISH_DIR` wins. |
+| `download_url_base` | _(unset)_ | External CDN base URL for binary downloads. Unset = gateway serves binaries itself. |
+| `respawn_mode` | `self` | Fleet-wide restart intent: `self` (agent re-execs itself) or `supervised` (hands off to the process supervisor). |
+
+An empty or absent `fleet:` block is valid — agents will not self-update unless binaries are
+actually published.
+
 ## Quick Reference
 
 | Action | Method | Endpoint | Notes |
@@ -492,4 +537,10 @@ circuit_breaker:
   failure_threshold: 3
   timeout: 120s
   recovery_time: 60s
+
+fleet:                    # agent self-update (all optional)
+  target_agent_version: "1.2.0"
+  publish_dir: "~/.herd/binaries"
+  # download_url_base: "https://cdn.example.com/herd"
+  # respawn_mode: "self"
 ```


### PR DESCRIPTION
## Summary

Documentation-only PR: reconcile the docs with the **v1.2 fleet self-update stack** (PRs #6a gateway version authority, #6b agent self-update, #6c `herd publish`), all now on `main`. No code changes.

A read-only doc survey found the fleet features fully implemented but undocumented; four areas were updated and cross-checked against the source by a reviewer pass.

## Changes

- **README.md** — new **"What's New in v1.2"** section (`herd agent` daemon, gateway version authority + agent self-update, `herd publish`); the `fleet:` block added to the config YAML example; a **"Running a fleet agent"** quick-start; the two internal `/api/internal/nodes/...` endpoints added to the endpoint table; roadmap badge `v1.1` → `v1.2`.
- **ROADMAP.md** — #6c marked shipped; v1.2 status now reads "#1–#6c landed, #7/#8 pending"; mDNS / plugins / health-consensus / multi-model-consensus rescoped to **v1.3+/v1.4+** (they were never part of the v1.2 foundation).
- **docs/specs/v2-distributed-inference-spec.md** — status line current; the "Open Questions for Tom" section annotated **RESOLVED** with a pointer to the locked sprint decisions.
- **docs/LLAMA_CPP_BACKEND.md** — new **"Fleet Architecture (v1.2): the `herd agent` daemon"** subsection (explicitly coexisting with static/herd-tune nodes); RPC/tensor-parallel item corrected `v2.0` → `v1.4`.
- **herd.yaml.example** — commented `=== FLEET MANAGEMENT ===` block (fields + promote workflow); stays commented, no behavior change.
- **skills.md** — **"Fleet Self-Update (agent heartbeat protocol)"** operator section; `fleet:` added to the config reference.

## Version framing

`Cargo.toml` stays **1.1.2** — deliberately not bumped. `agent_version` derives from it and drives the fleet self-update protocol (an agent self-updates when the gateway advertises a *newer* version), and v1.2 items #7/#8 are still pending. So v1.2 features are documented as **available on `main`**, with `1.2.0` used only as an example target-version value — no doc claims a tagged 1.2.0 release.

## Verification

Reviewer-verified against the source: every `fleet:` field (`target_agent_version`, `publish_dir`, `download_url_base`, `respawn_mode`), `herd agent`/`herd publish` flag, internal endpoint, default, and env var matches the implementation; no invented fields; markdown tables/fences and the commented YAML sample are intact. Release binary (`target/release/herd.exe`) builds clean and `herd publish --help` is present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
