### PR TITLE
feat(dashboard): fleet-aware infrastructure summary in the header stat

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,7 +388,7 @@ Herd is a **smart stateless proxy with a stateful routing cache**. It is not HA 
 - **Tokens per second** — Exponential moving average gauge
 - **Labeled latency** — Per-backend, per-model, per-status latency histograms (cardinality-capped at 200)
 - **Request analytics** — JSONL logging with auto-retention
-- **Interactive dashboard** — Real-time charts (Backends, Analytics, Sessions, Fleet, Models, Agent Guide, Settings)
+- **Interactive dashboard** — Real-time charts (Backends, Analytics, Sessions, Fleet, Models, Agent Guide, Settings), with a header infrastructure summary that distinguishes Fleet Nodes Online from live Router Backends Online
 - **GPU metrics** — Real-time VRAM, utilization, temperature via gpu-hot
 - **Latency tracking** — P50, P95, P99 percentiles
 - **Log rotation** — Size-based rotation with configurable retention
@@ -715,6 +715,8 @@ Wire these into Grafana, Datadog, or any Prometheus-compatible monitoring stack.
 
 Access the interactive dashboard at `http://your-herd:40114/dashboard`
 
+The header carries an at-a-glance **infrastructure summary**. When fleet nodes are registered (from `/api/nodes`) it reads **Fleet Nodes Online** (`online / total`) with a sub-line of active router-pool backends, enabled node count, and aggregate VRAM; with an empty fleet registry it falls back to **Router Backends Online** drawn from the live routing pool (`/status`). A node counts as online when its status is `healthy` or `online` (`degraded`/`offline` do not). The footer reports the running **Gateway** build version.
+
 **Tabs:**
 - **Backends** — Real-time node status with GPU metrics
 - **Analytics** — Request volume, top models, latency percentiles
@@ -726,7 +728,7 @@ Access the interactive dashboard at `http://your-herd:40114/dashboard`
 
 ### Request Logging
 
-All proxied requests are logged to `~/.herd/requests.jsonl`:
+All proxied requests are logged to `{HERD_DATA_DIR}/requests.jsonl` (default `~/.herd/requests.jsonl`; see [Running in Docker](#running-in-docker) for the container data dir):
 
 ```json
 {"timestamp":1709395200,"model":"qwen2.5-coder:32b","backend":"fast-node","duration_ms":234,"status":"success","path":"/api/generate","request_id":"550e8400-...","tier":"heavy","classified_by":"keyword"}

--- a/dashboard.html
+++ b/dashboard.html
@@ -692,7 +692,8 @@
             </div>
             <div class="stat-card">
                 <div class="stat-value" id="stat-backends">--</div>
-                <div class="stat-label">Online Backends</div>
+                <div class="stat-label" id="stat-backends-label">Fleet Nodes Online</div>
+                <div class="stat-sub" id="stat-backends-sub"></div>
             </div>
         </div>
 
@@ -1293,7 +1294,7 @@ Content-Type: application/json
         <div class="footer">
             <span id="last-update">Updating...</span>
             <span class="footer-refresh" id="refresh-countdown">Refreshing in 5s</span>
-            <span id="version-info">Herd</span>
+            <span id="version-info">Gateway v--</span>
         </div>
     </div>
 
@@ -1352,6 +1353,7 @@ Content-Type: application/json
         let countdownInterval = null;
         let fleetNodes = [];
         let fleetRefreshInterval = null;
+        let lastRouterSummary = { totalBackends: 0, healthyBackends: 0 };
 
         // -- Tab System --
         function switchTab(name) {
@@ -1403,6 +1405,64 @@ Content-Type: application/json
             if (seconds < 3600) return `${Math.floor(seconds / 60)}m ago`;
             if (seconds < 86400) return `${Math.floor(seconds / 3600)}h ago`;
             return `${Math.floor(seconds / 86400)}d ago`;
+        }
+
+        function isFleetNodeOnline(status) {
+            return status === 'healthy' || status === 'online';
+        }
+
+        function summarizeFleetNodes(nodes) {
+            return nodes.reduce((summary, node) => {
+                summary.total++;
+                if (node.enabled !== false) summary.enabled++;
+                if (isFleetNodeOnline(node.status)) summary.online++;
+                if (node.status === 'degraded') summary.degraded++;
+                if (node.source === 'agent') summary.agent++;
+                else summary.enrolled++;
+                summary.totalVramMb += Number(node.vram_mb || 0);
+                return summary;
+            }, {
+                total: 0,
+                enabled: 0,
+                online: 0,
+                degraded: 0,
+                agent: 0,
+                enrolled: 0,
+                totalVramMb: 0,
+            });
+        }
+
+        function updateInfrastructureSummary() {
+            const summary = summarizeFleetNodes(fleetNodes);
+            const labelEl = document.getElementById('stat-backends-label');
+            const valueEl = document.getElementById('stat-backends');
+            const subEl = document.getElementById('stat-backends-sub');
+            if (!labelEl || !valueEl || !subEl) return;
+
+            if (summary.total > 0) {
+                const totalVramGb = summary.totalVramMb > 0
+                    ? `${(summary.totalVramMb / 1024).toFixed(summary.totalVramMb >= 16 * 1024 ? 0 : 1)} GB VRAM`
+                    : 'no VRAM reported';
+                valueEl.textContent = `${summary.online}/${summary.total}`;
+                labelEl.textContent = 'Fleet Nodes Online';
+                const parts = [
+                    `${summary.agent} agent / ${summary.enrolled} enrolled`,
+                    `${summary.enabled} enabled`,
+                ];
+                if (summary.degraded > 0) parts.push(`${summary.degraded} degraded`);
+                parts.push(
+                    `${lastRouterSummary.healthyBackends}/${lastRouterSummary.totalBackends} router backends active`
+                );
+                parts.push(totalVramGb);
+                subEl.textContent = parts.join(' · ');
+                return;
+            }
+
+            valueEl.textContent = `${lastRouterSummary.healthyBackends}/${lastRouterSummary.totalBackends}`;
+            labelEl.textContent = 'Router Backends Online';
+            subEl.textContent = lastRouterSummary.totalBackends > 0
+                ? 'Fleet registry empty; showing live router pool only'
+                : 'No fleet nodes or backends registered yet';
         }
 
         function gpuClass(pct) {
@@ -1966,7 +2026,7 @@ Content-Type: application/json
                     badge.style.display = 'inline-block';
                     badge.onclick = () => window.open(data.download_url, '_blank');
                 }
-                document.getElementById('version-info').textContent = `Herd v${data.current}`;
+                document.getElementById('version-info').textContent = `Gateway v${data.current}`;
             } catch (e) {
                 console.error('Update check failed:', e);
             }
@@ -1976,9 +2036,10 @@ Content-Type: application/json
         async function refresh() {
             const conn = document.getElementById('conn-indicator');
             try {
-                const [statusRes, gpuRes] = await Promise.all([
+                const [statusRes, gpuRes, nodesRes] = await Promise.all([
                     fetch('/status'),
                     fetch('/gpu').catch(() => null),
+                    fetch('/api/nodes').catch(() => null),
                 ]);
                 const data = await statusRes.json();
                 const healthy = data.healthy_backends || [];
@@ -1986,6 +2047,10 @@ Content-Type: application/json
                 const all = [...healthy, ...unhealthy];
                 const timeout = data.idle_timeout_minutes || 30;
                 const healthyCount = healthy.length;
+                lastRouterSummary = {
+                    totalBackends: all.length,
+                    healthyBackends: healthyCount,
+                };
 
                 // GPU map
                 let gpuMap = {};
@@ -2000,6 +2065,12 @@ Content-Type: application/json
                 }
                 for (const b of all) { if (!b.gpu && gpuMap[b.name]) b.gpu = gpuMap[b.name]; }
 
+                if (nodesRes && nodesRes.ok) {
+                    const nodesData = await nodesRes.json();
+                    fleetNodes = nodesData.nodes || [];
+                    renderFleetTable();
+                }
+
                 // Update UI
                 document.getElementById('strategy').textContent = data.routing_strategy || '--';
                 document.getElementById('idle-timeout').textContent = timeout;
@@ -2007,7 +2078,7 @@ Content-Type: application/json
                     ? all.map(b => renderCard(b, timeout)).join('')
                     : '<div class="empty-state" style="grid-column:1/-1;"><div class="empty-state-title">No backends configured</div><div class="empty-state-text">Click "+ Add Node" to add an Ollama backend</div></div>';
                 document.getElementById('backends-count').textContent = all.length;
-                document.getElementById('stat-backends').textContent = `${healthyCount}/${all.length}`;
+                updateInfrastructureSummary();
 
                 conn.classList.remove('error');
                 refreshCountdown = 5;
@@ -2170,6 +2241,7 @@ Content-Type: application/json
                 const data = await resp.json();
                 fleetNodes = data.nodes || [];
                 renderFleetTable();
+                updateInfrastructureSummary();
             } catch (e) {
                 console.error('Failed to fetch fleet nodes:', e);
             }

--- a/dashboard.html
+++ b/dashboard.html
@@ -2068,7 +2068,12 @@ Content-Type: application/json
                 if (nodesRes && nodesRes.ok) {
                     const nodesData = await nodesRes.json();
                     fleetNodes = nodesData.nodes || [];
-                    renderFleetTable();
+                    // Keep fleetNodes fresh every cycle (the infrastructure summary
+                    // below reads it), but only re-render the table when its tab is
+                    // visible — skip the wasted DOM work while the Fleet tab is hidden.
+                    if (document.getElementById('tab-fleet')?.classList.contains('active')) {
+                        renderFleetTable();
+                    }
                 }
 
                 // Update UI


### PR DESCRIPTION
## Summary

Reworks the dashboard's top **"Online Backends"** stat card into an at-a-glance **infrastructure summary** that distinguishes the persistent fleet registry from the live router pool, and rebrands the version label to **Gateway v…**.

### Dashboard (`dashboard.html`)
- **Fleet Nodes Online (`online/total`)** when fleet nodes are registered (`GET /api/nodes`), with a sub-line:
  `N agent / M enrolled · E enabled[ · D degraded] · X/Y router backends active · Z GB VRAM`.
  A node counts as online when its status is `healthy` or `online` (`degraded`/`offline` do not). `degraded` is shown only when > 0.
- Falls back to **Router Backends Online** from the live routing pool (`/status`) when the fleet registry is empty.
- `refresh()` now also fetches `/api/nodes` and renders the fleet table each cycle.
- Footer/version label: `Herd` → `Gateway v{version}`.

### Docs (`README.md`)
- Documented the header infrastructure summary in the **Analytics & Dashboard** section and the features bullet.
- Corrected the request-log path: `~/.herd/requests.jsonl` → `{HERD_DATA_DIR}/requests.jsonl` (default `~/.herd`), now that gateway stores root under `HERD_DATA_DIR` (#18).

### Notes
- Field access verified against the serialized `Node` struct (`src/nodes/types.rs`): `vram_mb`, `status`, `enabled`, `source` — exact names, no renames.
- No new endpoints (consumes existing `/api/nodes` + `/status`), so `skills.md` is unchanged.
- HTML/JS-only + docs; no Rust touched, no test impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)