### PR TITLE
chore(ci): bump GitHub Actions off the deprecated Node 20 runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: dtolnay/rust-toolchain@stable
 
@@ -33,7 +33,7 @@ jobs:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
@@ -44,7 +44,7 @@ jobs:
     name: Format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt
@@ -54,7 +54,7 @@ jobs:
     name: Security Audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: cargo install cargo-audit --locked

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
             archive: tar.gz
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -59,7 +59,7 @@ jobs:
           Compress-Archive -Path "target/${{ matrix.target }}/release/herd.exe" -DestinationPath "herd-${{ github.ref_name }}-${{ matrix.target }}.zip"
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: herd-${{ matrix.target }}
           path: herd-${{ github.ref_name }}-${{ matrix.target }}.*
@@ -69,10 +69,10 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: artifacts
           merge-multiple: true
@@ -81,7 +81,7 @@ jobs:
         run: ls -la artifacts/
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           generate_release_notes: true
           files: artifacts/*


### PR DESCRIPTION
## What
The v1.2.0 release run annotated four JS actions as running on Node.js 20, which GitHub force-migrates to Node 24 starting **2026-06-16**. Bump them to the current majors (all on Node 24):

| Action | From | To | Where |
|--------|------|----|-------|
| `actions/checkout` | v4 | **v6** | ci.yml ×4, release.yml ×2 |
| `actions/upload-artifact` | v4 | **v7** | release.yml |
| `actions/download-artifact` | v4 | **v8** | release.yml |
| `softprops/action-gh-release` | v2 | **v3** | release.yml |

`dtolnay/rust-toolchain@stable` and `Swatinem/rust-cache@v2` were **not** flagged (already Node-24-safe) — left unchanged.

## Verified
Inputs these workflows depend on still exist in the target majors:
- upload-artifact@v7: `name`, `path`
- download-artifact@v8: `path`, `merge-multiple`
- action-gh-release@v3: `files`, `generate_release_notes`
- checkout@v6: bare usage, no inputs

CI on this PR exercises `checkout@v6` live across all 3 OS runners. The release.yml changes aren't PR-triggered (tag-only), but the artifact/gh-release inputs were verified against each action's `action.yml` at the target tag; they'll run on the next tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)