### PR TITLE
feat(agent): report context window so dim 3 covers agent nodes

### DIFF
--- a/src/api/internal.rs
+++ b/src/api/internal.rs
@@ -501,6 +501,7 @@ mod tests {
             queue_depth: Some(0),
             ttft_p50_ms: Some(42),
             max_concurrent: None,
+            context_len: None,
             rpc_capable: false,
             rpc_port: None,
             agent_version: version.to_string(),

--- a/src/daemon/capabilities.rs
+++ b/src/daemon/capabilities.rs
@@ -217,6 +217,7 @@ impl SnapshotBuilder {
         &self.node_id
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn snapshot(
         &self,
         backend: BackendType,
@@ -225,6 +226,7 @@ impl SnapshotBuilder {
         models_loaded: Vec<String>,
         queue_depth: Option<u32>,
         max_concurrent: Option<u32>,
+        context_len: Option<u32>,
     ) -> AgentCapabilities {
         AgentCapabilities {
             node_id: self.node_id.clone(),
@@ -240,6 +242,9 @@ impl SnapshotBuilder {
             queue_depth,
             ttft_p50_ms: None, // deferred — needs --metrics + p50 windowing
             max_concurrent,
+            // Context-window size from llama-server /props; None for Ollama
+            // and openai-compat (dim 3 absent → neutral, never penalized).
+            context_len,
             rpc_capable: false, // v1.4 (pipeline parallel)
             rpc_port: None,
             agent_version: AGENT_VERSION.to_string(),
@@ -358,6 +363,7 @@ mod tests {
             vec!["qwen3-32b".into()],
             Some(2),
             Some(4),
+            Some(32_768),
         );
         assert_eq!(caps.vram_free_mb, 32607);
         assert_eq!(caps.vram_total_mb, 32607);
@@ -366,6 +372,7 @@ mod tests {
         assert_eq!(caps.agent_version, AGENT_VERSION);
         assert_eq!(caps.queue_depth, Some(2));
         assert_eq!(caps.max_concurrent, Some(4));
+        assert_eq!(caps.context_len, Some(32_768));
         assert!(!caps.rpc_capable);
         assert_eq!(caps.os.as_deref(), Some(std::env::consts::OS));
         assert_eq!(caps.arch.as_deref(), Some(std::env::consts::ARCH));
@@ -381,12 +388,14 @@ mod tests {
             vec![],
             None,
             None,
+            None,
         );
         assert_eq!(caps.vram_total_mb, 0);
         assert_eq!(caps.vram_free_mb, 0);
         assert!(caps.gpu_model.is_none());
-        // Ollama can't report load → honest None, not a fake 0.
+        // Ollama can't report load or context window → honest None, not a fake 0.
         assert_eq!(caps.queue_depth, None);
         assert_eq!(caps.max_concurrent, None);
+        assert_eq!(caps.context_len, None);
     }
 }

--- a/src/daemon/client.rs
+++ b/src/daemon/client.rs
@@ -463,6 +463,7 @@ mod tests {
             queue_depth: Some(0),
             ttft_p50_ms: None,
             max_concurrent: None,
+            context_len: None,
             rpc_capable: false,
             rpc_port: None,
             agent_version: "1.2.0".to_string(),

--- a/src/daemon/lifecycle.rs
+++ b/src/daemon/lifecycle.rs
@@ -46,6 +46,11 @@ pub struct ProbeOutcome {
     /// Concurrency limit the backend launched with (llama-server `/props`
     /// `total_slots`). `None` when unavailable.
     pub max_concurrent: Option<u32>,
+    /// Context-window size reported by llama-server `/props`
+    /// `default_generation_settings.n_ctx`. `None` for Ollama,
+    /// openai-compat, or any probe failure — best-effort, never affects
+    /// reachability.
+    pub context_len: Option<u32>,
 }
 
 /// Ollama `/api/ps` response (currently loaded models).
@@ -76,11 +81,23 @@ struct OpenAIModel {
     id: String,
 }
 
-/// llama-server `/props` (subset): `total_slots` is the `--parallel` limit.
+/// `default_generation_settings` block inside a llama-server `/props` response.
+/// Only the fields Herd reads are listed; the server may send many more.
+#[derive(Debug, Deserialize, Default)]
+struct LlamaGenSettings {
+    /// The context-window size the server was launched with.
+    #[serde(default)]
+    n_ctx: Option<u32>,
+}
+
+/// llama-server `/props` (subset): `total_slots` is the `--parallel` limit;
+/// `default_generation_settings.n_ctx` is the served context-window size.
 #[derive(Debug, Deserialize)]
 struct LlamaProps {
     #[serde(default)]
     total_slots: Option<u32>,
+    #[serde(default)]
+    default_generation_settings: LlamaGenSettings,
 }
 
 /// llama-server `/slots` entry (subset): `is_processing` marks a busy slot.
@@ -113,6 +130,16 @@ pub fn parse_openai_models(body: &str) -> Option<Vec<String>> {
 /// Parse a llama-server `/props` body into its `total_slots` (concurrency limit).
 pub fn parse_llama_total_slots(body: &str) -> Option<u32> {
     serde_json::from_str::<LlamaProps>(body).ok()?.total_slots
+}
+
+/// Parse a llama-server `/props` body into the served context-window size
+/// (`default_generation_settings.n_ctx`). Returns `None` when the field is
+/// absent or the body is malformed — caller treats absence as neutral.
+pub fn parse_llama_ctx_len(body: &str) -> Option<u32> {
+    serde_json::from_str::<LlamaProps>(body)
+        .ok()?
+        .default_generation_settings
+        .n_ctx
 }
 
 /// Parse a llama-server `/slots` body into the count of busy slots. `[]` →
@@ -163,36 +190,43 @@ impl LocalProbe {
         parse_openai_models(&body)
     }
 
-    /// Best-effort llama-server load probe: `max_concurrent` from `/props`
-    /// (`total_slots`) and `queue_depth` from `/slots` (busy count). Each is
+    /// Best-effort llama-server load probe: `max_concurrent` and `context_len`
+    /// from `/props`, `queue_depth` from `/slots` (busy count). Each is
     /// independent — a missing or disabled endpoint yields `None` for just that
     /// value and never affects reachability.
-    async fn probe_llama_load(&self) -> (Option<u32>, Option<u32>) {
-        let max_concurrent = self
-            .get_body("/props")
-            .await
-            .and_then(|b| parse_llama_total_slots(&b));
+    ///
+    /// Returns `(queue_depth, max_concurrent, context_len)`.
+    async fn probe_llama_load(&self) -> (Option<u32>, Option<u32>, Option<u32>) {
+        let props_body = self.get_body("/props").await;
+        let max_concurrent = props_body.as_deref().and_then(parse_llama_total_slots);
+        let context_len = props_body.as_deref().and_then(parse_llama_ctx_len);
         let queue_depth = self
             .get_body("/slots")
             .await
             .and_then(|b| parse_llama_busy_slots(&b));
-        (queue_depth, max_concurrent)
+        (queue_depth, max_concurrent, context_len)
     }
 
     pub async fn probe(&self) -> ProbeOutcome {
         match self.override_backend {
             Some(BackendType::Ollama) => {
-                // Ollama exposes no slot/concurrency telemetry → load stays None.
-                self.outcome(BackendType::Ollama, self.probe_ollama().await, None, None)
+                // Ollama exposes no slot/concurrency/context telemetry → all stay None.
+                self.outcome(
+                    BackendType::Ollama,
+                    self.probe_ollama().await,
+                    None,
+                    None,
+                    None,
+                )
             }
             Some(backend @ (BackendType::LlamaServer | BackendType::OpenAICompat)) => {
                 let models = self.probe_openai().await;
-                let (queue_depth, max_concurrent) = if models.is_some() {
+                let (queue_depth, max_concurrent, context_len) = if models.is_some() {
                     self.probe_llama_load().await
                 } else {
-                    (None, None)
+                    (None, None, None)
                 };
-                self.outcome(backend, models, queue_depth, max_concurrent)
+                self.outcome(backend, models, queue_depth, max_concurrent, context_len)
             }
             None => {
                 if let Some(models) = self.probe_ollama().await {
@@ -202,19 +236,21 @@ impl LocalProbe {
                         reachable: true,
                         queue_depth: None,
                         max_concurrent: None,
+                        context_len: None,
                     };
                 }
                 let models = self.probe_openai().await;
-                let (queue_depth, max_concurrent) = if models.is_some() {
+                let (queue_depth, max_concurrent, context_len) = if models.is_some() {
                     self.probe_llama_load().await
                 } else {
-                    (None, None)
+                    (None, None, None)
                 };
                 self.outcome(
                     BackendType::LlamaServer,
                     models,
                     queue_depth,
                     max_concurrent,
+                    context_len,
                 )
             }
         }
@@ -226,6 +262,7 @@ impl LocalProbe {
         models: Option<Vec<String>>,
         queue_depth: Option<u32>,
         max_concurrent: Option<u32>,
+        context_len: Option<u32>,
     ) -> ProbeOutcome {
         match models {
             Some(models_loaded) => ProbeOutcome {
@@ -234,6 +271,7 @@ impl LocalProbe {
                 reachable: true,
                 queue_depth,
                 max_concurrent,
+                context_len,
             },
             None => ProbeOutcome {
                 backend,
@@ -241,6 +279,7 @@ impl LocalProbe {
                 reachable: false,
                 queue_depth: None,
                 max_concurrent: None,
+                context_len: None,
             },
         }
     }
@@ -309,9 +348,10 @@ mod tests {
         assert!(!outcome.reachable);
         assert!(outcome.models_loaded.is_empty());
         assert_eq!(outcome.backend, BackendType::LlamaServer);
-        // Unmeasured load must be None, never a fake 0.
+        // Unmeasured load and context_len must be None, never a fake 0.
         assert_eq!(outcome.queue_depth, None);
         assert_eq!(outcome.max_concurrent, None);
+        assert_eq!(outcome.context_len, None);
     }
 
     #[test]
@@ -353,5 +393,50 @@ mod tests {
             None
         );
         assert_eq!(parse_llama_busy_slots("not json"), None);
+    }
+
+    #[test]
+    fn parses_ctx_len_from_props() {
+        // Full /props body with default_generation_settings.n_ctx present.
+        let body = r#"{
+            "total_slots": 4,
+            "model_path": "qwen3-32b.gguf",
+            "default_generation_settings": {
+                "n_ctx": 32768,
+                "temperature": 0.8
+            }
+        }"#;
+        assert_eq!(parse_llama_ctx_len(body), Some(32768));
+    }
+
+    #[test]
+    fn ctx_len_absent_when_field_missing() {
+        // /props without default_generation_settings → None (old server).
+        let body = r#"{"total_slots":4,"model_path":"m.gguf","is_sleeping":false}"#;
+        assert_eq!(parse_llama_ctx_len(body), None);
+    }
+
+    #[test]
+    fn ctx_len_absent_when_n_ctx_missing_from_settings() {
+        // default_generation_settings present but n_ctx absent.
+        let body = r#"{"total_slots":2,"default_generation_settings":{"temperature":0.7}}"#;
+        assert_eq!(parse_llama_ctx_len(body), None);
+    }
+
+    #[test]
+    fn ctx_len_absent_on_malformed_body() {
+        assert_eq!(parse_llama_ctx_len("not json"), None);
+        assert_eq!(parse_llama_ctx_len(""), None);
+    }
+
+    #[test]
+    fn props_body_populates_both_slots_and_ctx_len() {
+        // Both total_slots and n_ctx coexist; each parser is independent.
+        let body = r#"{
+            "total_slots": 8,
+            "default_generation_settings": { "n_ctx": 131072 }
+        }"#;
+        assert_eq!(parse_llama_total_slots(body), Some(8));
+        assert_eq!(parse_llama_ctx_len(body), Some(131_072));
     }
 }

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -152,6 +152,7 @@ pub async fn run(args: AgentArgs) -> anyhow::Result<()> {
             local.models_loaded,
             local.queue_depth,
             local.max_concurrent,
+            local.context_len,
         );
 
         let outcome = heartbeat.send(&caps, false).await;

--- a/src/nodes/db.rs
+++ b/src/nodes/db.rs
@@ -1095,6 +1095,7 @@ mod tests {
             queue_depth: Some(3),
             ttft_p50_ms: Some(42),
             max_concurrent: Some(8),
+            context_len: None,
             rpc_capable: false,
             rpc_port: None,
             agent_version: "1.2.0".to_string(),

--- a/src/nodes/health.rs
+++ b/src/nodes/health.rs
@@ -364,6 +364,7 @@ mod tests {
             queue_depth: Some(0),
             ttft_p50_ms: None,
             max_concurrent: None,
+            context_len: None,
             rpc_capable: false,
             rpc_port: None,
             agent_version: "1.2.0".to_string(),

--- a/src/nodes/pool_sync.rs
+++ b/src/nodes/pool_sync.rs
@@ -68,12 +68,17 @@ impl AgentPoolSync {
                 backend: caps.backend,
                 priority: 50, // house default for agent nodes
                 tags: Vec::new(),
+                max_context_len: caps.context_len,
                 ..Default::default()
             };
 
             if let Some(mut st) = pool.get(&name).await {
                 // Update existing entry — refresh config, models, health, VRAM, and live telemetry.
                 st.config = backend;
+                // Propagate the reported context-window size so dim 3 remains
+                // current across backend restarts (e.g. a model reload that
+                // changes --ctx-size).
+                st.config.max_context_len = caps.context_len;
                 st.models = caps.models_loaded.clone();
                 st.healthy = true; // fresh ⇒ alive
                 if caps.vram_total_mb > 0 {
@@ -130,6 +135,7 @@ mod tests {
             queue_depth: Some(3),
             ttft_p50_ms: Some(42),
             max_concurrent: Some(8),
+            context_len: None,
             rpc_capable: false,
             rpc_port: None,
             agent_version: "1.2.0".to_string(),
@@ -456,6 +462,87 @@ mod tests {
         assert_eq!(
             enrolled_entry.max_concurrent, None,
             "enrolled max_concurrent must be None"
+        );
+    }
+
+    /// Test 8: An agent with context_len set propagates it to
+    /// BackendState.config.max_context_len via the add branch.
+    #[tokio::test]
+    async fn agent_add_propagates_context_len_to_max_context_len() {
+        let reg = NodeRegistry::new(Duration::from_secs(30));
+        let pool = Arc::new(BackendPool::new(vec![], 3, Duration::from_secs(30)));
+
+        let mut caps = sample_caps("ctx-node");
+        caps.context_len = Some(32_768);
+        reg.heartbeat(caps).await.unwrap();
+        AgentPoolSync::reconcile(&reg, &pool).await;
+
+        let entry = pool.get("agent:ctx-node").await.unwrap();
+        assert_eq!(
+            entry.config.max_context_len,
+            Some(32_768),
+            "max_context_len must be populated from context_len on add"
+        );
+    }
+
+    /// Test 9: An existing agent entry has max_context_len refreshed via the
+    /// update branch when a new context_len arrives (e.g. after backend restart
+    /// with a different --ctx-size).
+    #[tokio::test]
+    async fn agent_update_refreshes_max_context_len() {
+        let reg = NodeRegistry::new(Duration::from_secs(30));
+        let pool = Arc::new(BackendPool::new(vec![], 3, Duration::from_secs(30)));
+
+        // First beat: no context_len yet.
+        let caps1 = sample_caps("ctx-update");
+        reg.heartbeat(caps1).await.unwrap();
+        AgentPoolSync::reconcile(&reg, &pool).await;
+
+        let entry = pool.get("agent:ctx-update").await.unwrap();
+        assert_eq!(
+            entry.config.max_context_len, None,
+            "max_context_len must be None before any context_len reported"
+        );
+
+        // Second beat: context_len now available.
+        let mut caps2 = sample_caps("ctx-update");
+        caps2.context_len = Some(65_536);
+        reg.heartbeat(caps2).await.unwrap();
+        AgentPoolSync::reconcile(&reg, &pool).await;
+
+        let entry = pool.get("agent:ctx-update").await.unwrap();
+        assert_eq!(
+            entry.config.max_context_len,
+            Some(65_536),
+            "max_context_len must be refreshed on update branch"
+        );
+    }
+
+    /// Test 10: A static or enrolled entry leaves max_context_len unaffected by
+    /// reconcile (it is agent-only; static entries keep their config as-is).
+    #[tokio::test]
+    async fn static_entry_max_context_len_unchanged_by_reconcile() {
+        let reg = NodeRegistry::new(Duration::from_secs(30));
+        let pool = Arc::new(BackendPool::new(vec![], 3, Duration::from_secs(30)));
+
+        pool.add(Backend {
+            name: "static-ctx".to_string(),
+            url: "http://static:8080".to_string(),
+            priority: 100,
+            max_context_len: Some(4096),
+            ..Default::default()
+        })
+        .await;
+
+        // Reconcile with a live agent — static entry must be untouched.
+        reg.heartbeat(sample_caps("other")).await.unwrap();
+        AgentPoolSync::reconcile(&reg, &pool).await;
+
+        let entry = pool.get("static-ctx").await.unwrap();
+        assert_eq!(
+            entry.config.max_context_len,
+            Some(4096),
+            "static max_context_len must not be altered by agent reconcile"
         );
     }
 }

--- a/src/nodes/registry.rs
+++ b/src/nodes/registry.rs
@@ -32,6 +32,13 @@ pub struct AgentCapabilities {
     /// unavailable. `#[serde(default)]` keeps pre-Slice-2 agents wire-compatible.
     #[serde(default)]
     pub max_concurrent: Option<u32>,
+    /// Served context-window size from llama-server `/props`
+    /// `default_generation_settings.n_ctx`. `None` for Ollama, openai-compat,
+    /// or when the probe could not read the field.
+    /// `#[serde(default)]` → older agents that don't send this field
+    /// deserialize to `None` (wire-compatible).
+    #[serde(default)]
+    pub context_len: Option<u32>,
     #[serde(default)]
     pub rpc_capable: bool,
     #[serde(default)]
@@ -343,6 +350,7 @@ mod tests {
             queue_depth: Some(0),
             ttft_p50_ms: Some(42),
             max_concurrent: Some(4),
+            context_len: None,
             rpc_capable: false,
             rpc_port: None,
             agent_version: "1.2.0".to_string(),

--- a/tests/agent_daemon.rs
+++ b/tests/agent_daemon.rs
@@ -74,6 +74,7 @@ fn test_snapshot(node_id: &str) -> herd::nodes::AgentCapabilities {
         vec!["qwen3-32b.gguf".into()],
         Some(1),
         Some(4),
+        None,
     )
 }
 

--- a/tests/fleet_routing.rs
+++ b/tests/fleet_routing.rs
@@ -257,6 +257,7 @@ fn caps(node_id: &str, address: &str, models: &[&str]) -> AgentCapabilities {
         queue_depth: Some(0),
         ttft_p50_ms: Some(42),
         max_concurrent: None,
+        context_len: None,
         rpc_capable: false,
         rpc_port: None,
         agent_version: "1.2.0".to_string(),


### PR DESCRIPTION
## Summary

- The `herd agent` daemon now parses `default_generation_settings.n_ctx` from llama-server `/props` (the same single HTTP fetch already used for `total_slots`) and carries it through the telemetry chain to `BackendState.config.max_context_len`.
- This makes the scored router's `prompt_size_vs_capacity` dimension (dim 3) **present** for agent (fleet) nodes — previously it was always absent-neutral because only static `[[backends]]` could set `max_context_len`.
- Reuses the Slice 2 (PR #24) pattern: best-effort probe, any failure → `None`, never affects reachability.

## Changes

| File | What changed |
|------|--------------|
| `src/daemon/lifecycle.rs` | `LlamaGenSettings` serde struct; `LlamaProps.default_generation_settings`; `parse_llama_ctx_len` pure fn; `context_len` in `ProbeOutcome`; `probe_llama_load` returns 3-tuple (no extra HTTP call); 5 new unit tests |
| `src/nodes/registry.rs` | `context_len: Option<u32>` on `AgentCapabilities` with `#[serde(default)]` (wire-compat) |
| `src/daemon/capabilities.rs` | `context_len` param threaded through `SnapshotBuilder::snapshot`; `#[allow(clippy::too_many_arguments)]` |
| `src/daemon/mod.rs` | Pass `local.context_len` to `snapshot()` |
| `src/nodes/pool_sync.rs` | Set `Backend.max_context_len = caps.context_len` on add; refresh `st.config.max_context_len` on update; 3 new tests |
| 6 other files | `AgentCapabilities` struct literal fixes (compile-enforced by the new field) |

## Test plan

- [x] `parse_llama_ctx_len` with full `/props` body (`n_ctx: 32768`) → `Some(32768)`
- [x] `parse_llama_ctx_len` with `/props` missing `default_generation_settings` → `None`
- [x] `parse_llama_ctx_len` with `default_generation_settings` but no `n_ctx` → `None`
- [x] `parse_llama_ctx_len` malformed body → `None`
- [x] Both `total_slots` and `ctx_len` parse correctly from the same body (single fetch reuse)
- [x] `pool_sync` add branch: `caps.context_len = Some(N)` → `entry.config.max_context_len == Some(N)`
- [x] `pool_sync` update branch: second beat with new `context_len` refreshes `max_context_len`
- [x] Static entry `max_context_len` unchanged by agent reconcile
- [x] `cargo build` — clean
- [x] `cargo test` — **526 lib** (baseline 518, +8 new), 32 integration; 0 failures
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)