### PR TITLE
feat(router): Phase 4 Slice A — dims 19-20 (network_locality, power_cost)

### DIFF
--- a/docs/specs/smart-routing-scorer-spec.md
+++ b/docs/specs/smart-routing-scorer-spec.md
@@ -673,6 +673,23 @@ decision that can reshape scope, so it is flagged to the Director in open-questi
 Policy/affinity layer: session stickiness (agent sessions), locality tiers, power/cost
 weights, RPC-shard capability, GPU-class affinity, warm-model recency.
 
+Landing incrementally by data-source cost (Slice A → D):
+
+> **Slice A — dims 19 + 20 (config-only).** `Backend` gains `locality: Option<LocalityTier>`
+> (`local`/`lan`/`tailnet`/`wan`) and `power_cost: Option<f64>`. dim 19 maps the tier
+> (`local 1.0 / lan 0.8 / tailnet 0.6 / wan 0.4`); dim 20 = `clamp(1 - cost/COST_REF, 0, 1)`
+> with `COST_REF = 100`. Both present iff configured (absent → neutral, weight-dropped) and
+> stay **opt-in** (`w_zero` default — locality/cost are deployment value-judgments, not
+> universally-good defaults). No protocol field, no stateful plumbing.
+>
+> **Remaining:** dim 23 (`warm_model_recency`, stateful — per-(backend,model) last-served
+> time on `BackendState`); dim 18 (`session_stickiness`, architectural — needs a
+> session→backend ledger + a session key on the scoring path + routing agent turns through
+> the scorer); dim 22 (`gpu_class_affinity`, needs a model→preferred-class source). dim 21
+> (`rpc_shard_capability`) is **deferred to v1.3** — inert until a "request needs sharding"
+> signal exists (Q6 drops a uniform-0.5 dim every call), which depends on the llama.cpp RPC
+> tensor-sharding integration.
+
 ---
 
 ## Scoring Math

--- a/herd.yaml.example
+++ b/herd.yaml.example
@@ -73,6 +73,12 @@ routing:
   #     ttft_p50: 3.0                # prefer faster time-to-first-token (not yet measured)
   #     concurrency_saturation: 1.0  # prefer backends with free concurrency slots (agent telemetry)
   #     precise_vram_free: 2.0       # prefer more measured free VRAM (agent telemetry)
+  #     # History dims 14–17 (ewma_latency, recent_error_rate, recent_success_throughput,
+  #     # flap_stability) keep sensible non-zero defaults — omit to use them.
+  #     # Policy dims below are OPT-IN (default 0); turn on per fleet. They read the
+  #     # matching per-backend fields (locality / power_cost) shown in the backends block.
+  #     network_locality: 2.0        # prefer closer backends (needs per-backend `locality`)
+  #     power_cost: 1.0              # prefer cheaper/lower-power (needs per-backend `power_cost`)
 
   # === AUTO MODE ===
   # LLM-based request classification. When model is "auto" or omitted, Herd calls
@@ -179,6 +185,11 @@ backends:
                                  # Feeds the `scored` router's prompt_size_vs_capacity
                                  # dimension (prefers backends whose window fits the
                                  # prompt). Omit to leave that dimension neutral.
+    # locality: "local"          # Network tier vs the gateway: local | lan | tailnet | wan.
+                                 # Feeds the scored router's network_locality dim (opt-in;
+                                 # set the weight above). Omit to leave it neutral.
+    # power_cost: 10             # Relative cost/power weight (watts or $/1k-tok); lower =
+                                 # preferred. Feeds the power_cost dim (opt-in). Omit = neutral.
 
   - name: "minipc-4080"
     url: "http://100.81.153.82:11434"

--- a/src/api/admin.rs
+++ b/src/api/admin.rs
@@ -133,6 +133,8 @@ pub async fn add_backend(
         health_check_status: None,
         tags: req.tags,
         max_context_len: None,
+        locality: None,
+        power_cost: None,
     };
 
     state.pool.add(backend).await;

--- a/src/config.rs
+++ b/src/config.rs
@@ -461,6 +461,37 @@ impl std::fmt::Display for BackendType {
     }
 }
 
+/// Network locality tier for a backend, relative to the gateway. Feeds the
+/// scored router's `network_locality` dimension (dim 19): closer backends are
+/// preferred so the proxy hop adds the least latency. `None` on a `Backend` →
+/// that dimension is absent for it (neutral, weight-dropped).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum LocalityTier {
+    /// Same host as the gateway (loopback / unix socket).
+    #[serde(rename = "local")]
+    Local,
+    /// Same LAN segment.
+    #[serde(rename = "lan")]
+    Lan,
+    /// Reachable over a Tailscale / WireGuard tailnet.
+    #[serde(rename = "tailnet")]
+    Tailnet,
+    /// Public internet / WAN.
+    #[serde(rename = "wan")]
+    Wan,
+}
+
+impl std::fmt::Display for LocalityTier {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            LocalityTier::Local => write!(f, "local"),
+            LocalityTier::Lan => write!(f, "lan"),
+            LocalityTier::Tailnet => write!(f, "tailnet"),
+            LocalityTier::Wan => write!(f, "wan"),
+        }
+    }
+}
+
 fn default_strategy() -> RoutingStrategy {
     RoutingStrategy::ModelAware
 }
@@ -507,6 +538,19 @@ pub struct Backend {
     /// that dimension is absent for this backend (neutral, weight-dropped).
     #[serde(default)]
     pub max_context_len: Option<u32>,
+
+    /// Network locality tier relative to the gateway. Feeds the scored router's
+    /// `network_locality` dimension (dim 19); `None` (the default) → that
+    /// dimension is absent for this backend (neutral, weight-dropped).
+    #[serde(default)]
+    pub locality: Option<LocalityTier>,
+
+    /// Relative cost/power weight for this backend (e.g. watts, or $/1k tokens);
+    /// lower is cheaper. Feeds the scored router's `power_cost` dimension
+    /// (dim 20); `None` (the default) → that dimension is absent for this
+    /// backend (neutral, weight-dropped).
+    #[serde(default)]
+    pub power_cost: Option<f64>,
 }
 
 impl Backend {
@@ -534,6 +578,8 @@ impl Default for Backend {
             health_check_status: None,
             tags: Vec::new(),
             max_context_len: None,
+            locality: None,
+            power_cost: None,
         }
     }
 }

--- a/src/router/scored.rs
+++ b/src/router/scored.rs
@@ -4,7 +4,9 @@
 /// plus dims 10–13 (Phase 2 — live load & latency from agent telemetry; dim 11
 /// `ttft_p50` reads agent caps but the agent does not yet measure it). Dims 14–17
 /// (Phase 3) read per-(backend,model) EWMA history from `RoutingStats`.
-/// Dims 18–23 remain absent/neutral until Phase 4.
+/// Phase 4 (policy/affinity) is landing incrementally: dims 19 (`network_locality`)
+/// and 20 (`power_cost`) are active (config-only); dims 18, 21–23 remain
+/// absent/neutral until their slices.
 use crate::backend::{pool::filter_healthy, BackendPool};
 use crate::config::{BackendType, ModelGate, ScoredConfig, ScoredWeights};
 use crate::router::routing_stats::{BackendModelStats, RoutingStats, MIN_SAMPLES};
@@ -30,6 +32,10 @@ const QUEUE_REF: f64 = 8.0;
 /// Reference TTFT (ms) for dim 11 (`ttft_p50`); at/above this a backend
 /// normalizes to 0.0, instant first token to 1.0.
 const TTFT_REF: f64 = 2000.0;
+/// Reference cost/power weight for dim 20 (`power_cost`); a backend at/above
+/// this normalizes to 0.0 (most expensive), a zero-cost backend to 1.0. Same
+/// arbitrary unit the operator uses for `Backend.power_cost` (watts, $/1k tok…).
+const COST_REF: f64 = 100.0;
 /// Scale factor for quantizing scores to i64 comparison keys.
 const SCORE_SCALE: f64 = 1_000_000.0;
 
@@ -63,7 +69,7 @@ pub enum Dimension {
     RecentErrorRate = 14,
     RecentSuccessThroughput = 15,
     FlapStability = 16,
-    // Phase 4 — always absent in Phase 1
+    // Phase 4 — dims 19/20 active (config-only); 18, 21–23 absent until their slices
     SessionStickiness = 17,
     NetworkLocality = 18,
     PowerCost = 19,
@@ -431,8 +437,33 @@ fn compute_raw(
             1.0 - (s.health_transitions as f64 / FLAP_REF).clamp(0.0, 1.0);
     }
 
-    // ── Dims 18–23: Phase 4 — absent until that phase ────────────────────────
-    // Their sources are None/absent → present0 stays false → neutral, weight-dropped.
+    // ── Dim 19: network_locality — Phase 4 (config-only) ─────────────────────
+    // Closer backends are preferred (less proxy-hop latency). Present iff the
+    // operator configured a tier; absent → neutral 0.5, weight-dropped.
+    if let Some(tier) = b.config.locality {
+        present0[Dimension::NetworkLocality.idx()] = true;
+        norms[Dimension::NetworkLocality.idx()] = match tier {
+            crate::config::LocalityTier::Local => 1.0,
+            crate::config::LocalityTier::Lan => 0.8,
+            crate::config::LocalityTier::Tailnet => 0.6,
+            crate::config::LocalityTier::Wan => 0.4,
+        };
+    }
+
+    // ── Dim 20: power_cost — Phase 4 (config-only) ───────────────────────────
+    // Cheaper/lower-power backends preferred. n = clamp(1 - cost/COST_REF, 0, 1):
+    // a zero-cost backend → 1.0, one at/above COST_REF → 0.0. Present iff the
+    // operator configured a cost AND COST_REF > 0 (guard div-by-zero).
+    if let Some(cost) = b.config.power_cost {
+        if COST_REF > 0.0 {
+            present0[Dimension::PowerCost.idx()] = true;
+            norms[Dimension::PowerCost.idx()] = (1.0 - cost / COST_REF).clamp(0.0, 1.0);
+        }
+    }
+
+    // ── Dims 18, 21–23: Phase 4 — absent until their slices ──────────────────
+    // session_stickiness (18), rpc_shard_capability (21), gpu_class_affinity (22),
+    // warm_model_recency (23): sources None/absent → present0 stays false.
 
     CandidateRaw { norms, present0 }
 }
@@ -1686,6 +1717,132 @@ mod tests {
             raw.present0[dim10],
             "dim 10 still present without max_concurrent"
         );
+    }
+
+    // ── Phase 4 Slice A: network_locality (dim 19) & power_cost (dim 20) ──────
+
+    /// dim 19 — exact tier map (local 1.0 / lan 0.8 / tailnet 0.6 / wan 0.4),
+    /// present iff the operator configured a locality; absent (neutral, never a
+    /// penalty) when None. Tested directly on `compute_raw`.
+    #[test]
+    fn network_locality_tier_map_in_compute_raw() {
+        use crate::config::LocalityTier;
+        let dim = Dimension::NetworkLocality.idx();
+        for (tier, expected) in [
+            (LocalityTier::Local, 1.0_f64),
+            (LocalityTier::Lan, 0.8),
+            (LocalityTier::Tailnet, 0.6),
+            (LocalityTier::Wan, 0.4),
+        ] {
+            let mut s = make_state("n", 50, true);
+            s.config.locality = Some(tier);
+            let raw = compute_raw(&s, None, None, false, None, 50, 50, None, None);
+            assert!(raw.present0[dim], "dim 19 present when locality configured");
+            assert!(
+                (raw.norms[dim] - expected).abs() < 1e-9,
+                "tier {tier} → {expected}"
+            );
+        }
+        // Unconfigured → absent (neutral, weight-dropped), never a penalty.
+        let s = make_state("n", 50, true);
+        let raw = compute_raw(&s, None, None, false, None, 50, 50, None, None);
+        assert!(!raw.present0[dim], "dim 19 absent when locality is None");
+    }
+
+    /// dim 20 — n = clamp(1 - cost/COST_REF, 0, 1): zero-cost → 1.0, COST_REF/2 →
+    /// 0.5, ≥COST_REF → 0.0 (clamped). Present iff `power_cost` configured;
+    /// absent (neutral) when None. Tested directly on `compute_raw`.
+    #[test]
+    fn power_cost_formula_and_absence_in_compute_raw() {
+        let dim = Dimension::PowerCost.idx();
+        let with_cost = |c: f64| {
+            let mut s = make_state("b", 50, true);
+            s.config.power_cost = Some(c);
+            s
+        };
+
+        let raw = compute_raw(&with_cost(0.0), None, None, false, None, 50, 50, None, None);
+        assert!(raw.present0[dim], "dim 20 present when cost configured");
+        assert!((raw.norms[dim] - 1.0).abs() < 1e-9, "zero cost → 1.0");
+
+        let raw = compute_raw(
+            &with_cost(COST_REF / 2.0),
+            None,
+            None,
+            false,
+            None,
+            50,
+            50,
+            None,
+            None,
+        );
+        assert!((raw.norms[dim] - 0.5).abs() < 1e-9, "half COST_REF → 0.5");
+
+        // Above COST_REF clamps to 0.0 (never negative).
+        let raw = compute_raw(
+            &with_cost(COST_REF * 2.0),
+            None,
+            None,
+            false,
+            None,
+            50,
+            50,
+            None,
+            None,
+        );
+        assert!((raw.norms[dim]).abs() < 1e-9, "≥COST_REF clamps to 0.0");
+
+        // Unconfigured → absent (neutral, weight-dropped).
+        let s = make_state("b", 50, true);
+        let raw = compute_raw(&s, None, None, false, None, 50, 50, None, None);
+        assert!(!raw.present0[dim], "dim 20 absent when power_cost is None");
+    }
+
+    /// dim 19 end-to-end — the closer backend wins. Anti-trivial: the WAN node is
+    /// named "alpha" (would win the name tie-break) and the local node "zeta"; a
+    /// "zeta" win proves dim 19 decided, not the tie-break. Weight opt-in (default
+    /// is `w_zero`), so the test sets it explicitly.
+    #[tokio::test]
+    async fn network_locality_closer_backend_wins() {
+        use crate::config::LocalityTier;
+        let mut far = make_state("alpha", 50, true);
+        let mut near = make_state("zeta", 50, true);
+        far.models = vec!["m".to_string()];
+        near.models = vec!["m".to_string()];
+        far.config.locality = Some(LocalityTier::Wan);
+        near.config.locality = Some(LocalityTier::Local);
+
+        let mut cfg = ScoredConfig::default();
+        cfg.weights.network_locality = 100.0;
+        let pool = pool_from_states(vec![far, near]);
+        let router = make_router(pool, &cfg);
+        let result = router
+            .route_scored(Some("m"), None, &HashSet::new(), &RouteContext::default())
+            .await
+            .unwrap();
+        assert_eq!(result.name, "zeta", "closer (local) backend must win");
+    }
+
+    /// dim 20 end-to-end — the cheaper backend wins. Anti-trivial: the expensive
+    /// node is "alpha", the cheap node "zeta"; a "zeta" win proves dim 20 decided.
+    #[tokio::test]
+    async fn power_cost_cheaper_backend_wins() {
+        let mut pricey = make_state("alpha", 50, true);
+        let mut cheap = make_state("zeta", 50, true);
+        pricey.models = vec!["m".to_string()];
+        cheap.models = vec!["m".to_string()];
+        pricey.config.power_cost = Some(90.0);
+        cheap.config.power_cost = Some(10.0);
+
+        let mut cfg = ScoredConfig::default();
+        cfg.weights.power_cost = 100.0;
+        let pool = pool_from_states(vec![pricey, cheap]);
+        let router = make_router(pool, &cfg);
+        let result = router
+            .route_scored(Some("m"), None, &HashSet::new(), &RouteContext::default())
+            .await
+            .unwrap();
+        assert_eq!(result.name, "zeta", "cheaper backend must win");
     }
 
     // ── Phase 2: prompt_size_vs_capacity (dim 3) ─────────────────────────────

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -4,62 +4,147 @@
 > the v1.2 PR breakdown + acceptance checklist live in `tasks/HERD-V1.2-SPRINT.md`.
 > Full scorer design: `docs/specs/smart-routing-scorer-spec.md`.
 
-**Last updated:** 2026-06-19
+**Last updated:** 2026-06-25
 
 ---
 
-## ACTIVE — Scorer Phase 2: prompt_size_vs_capacity (dim 3)
+## ACTIVE — Scorer Phase 4: Locality, cost & capability (dims 18–23)
 
-Branch `feat/v1.2-scorer-pr-e-dim3` off `main` (post-#24). The deferred dim-3 feature.
+Phase 4 is the **final 6 dims** (spec dims 18–23 = `Dimension` enum slots 17–22, all already
+declared, weight-zeroed via `w_zero()`, and `present0=false`). The scorer engine does NOT
+change — each dim needs a **data source + a `compute_raw` branch + a weight default**. Plan
+only; no code yet (Director decision 2026-06-25).
 
-**Scope decision (Director, 2026-06-19):** picked over ttft (dim 11), which isn't cleanly
-reachable for an observe-only agent (no per-request timings; `/metrics` has no quantiles).
-dim-3 is self-contained, no approximation, no new protocol field.
+### Seam audit (verified against current `main`, post-PR #28)
 
-- New `Backend.max_context_len: Option<u32>` config field (`#[serde(default)]`); static
-  backends only — agent nodes stay None (a later slice could report `/props` `n_ctx`).
-- `api/openai.rs::estimate_prompt_tokens(body)` — ~4 chars/token over chat `messages`
-  content (string or multimodal text) or a `prompt` string; None when unrecognized/empty.
-- BOTH proxy sites (`openai.rs` chat, `server.rs` generic) switch `route_excluding` →
-  `route_scored(&RouteContext{prompt_tokens, ..})`. No-op for the 4 legacy routers (ctx-blind).
-- `scored.rs` dim 3: present iff `prompt_tokens.is_some()` AND `max_context_len Some(>0)`;
-  `n = clamp((1 - prompt/window)/0.5, 0, 1)`. `compute_raw` gains a `prompt_tokens` arg.
+The plumbing is locked in and proven by Phases 1–3:
+- `Dimension` enum + `ALL_DIMS` + `weights_array` carry all 23 dims (`scored.rs:46–195`).
+- `compute_raw(b, model, tags, relaxed, prefer_type, pmin, pmax, prompt_tokens, stats)`
+  sets `present0[i]` per candidate; dims 18–23 currently force `false` (`scored.rs:~434`).
+- Injected state pattern: `ScoredRouter` holds an `Arc`, snapshots **once per call** off the
+  scoring path (`routing_stats.snapshot_all()` at `scored.rs:519`; pool snapshot at `:466`).
+  This is the template for any new stateful source.
+- `ScoredWeights` already has all 6 Phase-4 fields, each `#[serde(default = "w_zero")]`
+  (`config.rs:283–293`). `RouteContext` (`router/mod.rs:21–26`) carries `prompt_tokens` +
+  `requested_ctx_len` and is the seam for any new request-side signal.
+
+Per-dim source reality (the part the spec assumed but didn't verify):
+
+| dim | name | source today | verdict |
+|----|------|--------------|---------|
+| 18 | `session_stickiness` | **none on scoring path** — proxy never reads a session id; agent `executor.rs:160` uses legacy `route()` not `route_scored()` and never writes the chosen backend back to `Session` (no `last_backend` field) | **architectural** |
+| 19 | `network_locality` | net-new `Backend` config field (tier) | **config-only ✅** |
+| 20 | `power_cost` | net-new `Backend` config field (cost weight) | **config-only ✅** |
+| 21 | `rpc_shard_capability` | `AgentCapabilities.rpc_capable` exists, but "**request needs sharding**" signal does NOT — dim is always `0.5` → Q6-dropped every call | **policy-blocked → defer** |
+| 22 | `gpu_class_affinity` | hardware side exists (`gpu_model`/`gpu_vendor` in `NodeRegistration`/SQLite; `gpu_model` in `AgentCapabilities`) but **no model→preferred-class mapping** and `BackendState` carries no class string on the scoring path | **needs design** |
+| 23 | `warm_model_recency` | `ModelWarmer` records **no timestamps** (just logs); `BackendState` has `last_check`/`last_request` `Instant`s but no per-model warm time | **stateful, self-contained ✅** |
+
+### Recommended slice order (cheapest/lowest-risk first)
+
+**Slice A (PR #29) — dims 19 + 20, config-only.** The clean dim-3-shaped slice: no protocol
+field, no stateful plumbing, no agent change.
+- `Backend` gains `locality: Option<LocalityTier>` (enum: `local`/`lan`/`tailnet`/`wan`,
+  `#[serde(default)]`) and `power_cost: Option<f64>` (e.g. watts or $/1k-tok).
+- `compute_raw` dim 19: tier map `local 1.0 / lan 0.8 / tailnet 0.6 / wan 0.4`, present iff
+  `locality.is_some()`. dim 20: `clamp(1 - cost/COST_REF, 0, 1)`, present iff
+  `power_cost.is_some() && COST_REF > 0`.
+- **Weight default decision (open):** keep `w_zero()` (opt-in policy) — locality/cost are
+  deployment value-judgments, not universally-good defaults. Document, don't flip.
+- Tests: presence gating, tier map exactness, cost clamp, Q6-drop when all candidates same tier.
+
+**Slice B (PR #30) — dim 23 `warm_model_recency`, one stateful source.**
+- Add per-(backend, model) last-served time. Two options (Q-B1): (a) `BTreeMap<String,Instant>`
+  on `BackendState` — reuses the pool snapshot already taken at `:466`, no new lock; (b) a
+  separate `ModelWarmStore` `Arc` like `RoutingStats`. **Recommend (a)** — no extra snapshot,
+  warm-state is backend-local.
+- Writers: `ModelWarmer` on successful warm **and** the serve path (a model loaded by serving
+  is warm too, not just `hot_models`) — record `Instant::now()` keyed by served model.
+- Norm: `clamp(1 - age_secs/WARM_REF, 0, 1)`; `0.5` when model never seen (spec: neutral).
+  Open (Q-B2): spec says `turns_since/WARM_REF` (turn count) — recommend **time-based**
+  (`age_secs`) since there's no global turn counter; `WARM_REF` ~ a few minutes.
+
+**Slice C (PR #31) — dim 18 `session_stickiness`, architectural.** Largest blast radius; do
+after A/B prove the Phase-4 wiring.
+- Needs three things that don't exist: (1) a session→backend ledger (extend `Session` with
+  `last_backend: Option<String>`, or a side map), (2) a session key on the scoring path
+  (`RouteContext.session_id` + proxy/agent extraction), (3) route agent turns through
+  `route_scored()` and write the chosen backend back post-request (piggyback the existing
+  post-request hooks at `openai.rs:601/670`, `server.rs:1618`).
+- Open (Q-C1): does this apply to plain `/v1/chat/completions` (no session) at all, or only
+  agent sessions? If agent-only, the proxy path stays untouched and scope shrinks a lot.
+
+**Defer — dim 21 `rpc_shard_capability` → backlog / v1.3.** Inert until a "request needs
+sharding" signal exists, which itself depends on the roadmap llama.cpp RPC tensor-sharding
+integration. Building it now adds a field that Q6 drops on every call. Park with rationale.
+
+**Needs-design — dim 22 `gpu_class_affinity` (PR #32, after a decision).** Blocked on Q-D1:
+where does "model M's preferred GPU class" come from? Options: a config `model_gpu_class` map,
+a request tag, or inferred from model size. Also needs the candidate's GPU class on the scoring
+path (`BackendState` doesn't carry `gpu_model` today — would thread it from `AgentCapabilities`
+via pool_sync, the dim-12 pattern). Decide source before building.
+
+### Director decisions (locked 2026-06-25)
+
+- **Reach:** *all dims except the blocked 21.* Build order **A (19+20) → B (23) → C (18) →
+  D (22)**. dim 21 deferred to v1.3 (RPC integration). Target: **22/23 dims live.**
+- **Q-A1 (weights):** *all Phase-4 dims stay opt-in `w_zero()`* — incl. dim 23. Operators
+  turn on what fits their fleet; no non-zero defaults this milestone.
+
+Still open (resolve at each slice's architect pass, not blocking Slice A):
+- **Q-B1:** warm-time on `BackendState` (recommended) vs separate store. *(Slice B)*
+- **Q-B2:** time-based recency (recommended) vs spec's turn-count. *(Slice B)*
+- **Q-C1:** dim 18 agent-sessions-only (smaller) vs all proxy traffic. *(Slice C)*
+- **Q-D1:** source of "model→preferred GPU class" for dim 22. *(blocks Slice D)*
 
 ### Status
-- [x] ARCHITECT — spec dim-3 formula confirmed; `RouteContext.prompt_tokens` seam already
-  existed (route_scored), so wiring is threading one value + the config field + the proxy switch.
-- [x] BUILDER — config field, estimator, both proxy switches, dim 3, tests.
-- [x] OPERATOR gates — build ✓, clippy `-D warnings` ✓, fmt ✓; lib 512→**518** (+6). No lib unwrap.
-- [x] REVIEWER independent hunt list — **CLEAN, all 8 items PASS** (legacy-router safety,
-  div-by-zero/presence guard, formula, estimator honesty, wire-compat, determinism, no lib
-  unwrap, anti-trivial tests).
-- [x] LEAD docs (ROADMAP, spec dim-3 source-gap closed) + commit + PR.
-- [ ] INDEPENDENT outside review before merge
+- [x] SEAM AUDIT — 3 parallel explores (scorer plumbing / session model / warmer+capability),
+      cross-checked against spec dims 18–23 formulas. Findings above.
+- [x] DIRECTOR — reach + weights locked (above). Build order A→B→C→D, 21 deferred.
+- [x] SLICE A (dims 19+20) — branch `feat/v1.2-scorer-phase4-slice-a-dims-19-20`.
+      `LocalityTier` enum + `Backend.locality`/`Backend.power_cost` (both serde-default,
+      wire-compat); `COST_REF=100`; dim 19 tier map + dim 20 `clamp(1-cost/COST_REF)` in
+      `compute_raw`; both opt-in (`w_zero`). 4 tests (2 direct `compute_raw` formula/absence,
+      2 anti-trivial e2e). Build ✓, clippy `-D warnings` ✓, fmt ✓, **lib 540→544**. Docs:
+      herd.yaml example (weights + per-backend fields), spec Slice-A note. No lib unwrap.
+      **Awaiting: commit + push + PR (user confirm).**
+- [ ] SLICE B (dim 23) — warm-recency, resolve Q-B1/B2 first.
+- [ ] SLICE C (dim 18) — session stickiness, resolve Q-C1 first.
+- [ ] SLICE D (dim 22) — gpu-class affinity, blocked on Q-D1.
 
 ---
 
 ## DONE — audit log (collapsed; full detail in git history + ROADMAP)
 
+- **Scorer Phase 3 — history/EWMA dims 14–17** (PR #28, `2026-06-24`, merged `95123a6`) —
+  new `src/router/routing_stats.rs`: per-(backend,model) request-count EWMA (`alpha=0.2`),
+  32-bit rolling error ring, LRU eviction at 20k entries. `ScoredRouter` holds
+  `Arc<RoutingStats>`, `snapshot_all()` once per call; dims 14–17 absent for cold/
+  under-sampled backends (`< MIN_SAMPLES=5`). Phase-3 weights flipped off 0:
+  `error_rate=3`/`latency=3`/`throughput=2`/`flap_stability=1`. Post-request hooks in
+  `server.rs`/`openai.rs` call `routing_stats.update()`. 14 new tests; lib 526→540.
+
+- **dim-3 agent ctx source** (commit `147bb3f`) — agent reports llama-server `/props` `n_ctx`
+  so dim 3 (`prompt_size_vs_capacity`) covers agent nodes, not just static `max_context_len`.
+
+- **Scorer Phase 2 — prompt_size_vs_capacity (dim 3)** (PR #25, `2026-06-19`) — `Backend.
+  max_context_len: Option<u32>` (static backends); `estimate_prompt_tokens` ~4 chars/token over
+  chat messages; both proxy sites switched `route_excluding` → `route_scored(RouteContext)`;
+  dim 3 `n = clamp((1 - prompt/window)/0.5, 0, 1)`, present iff both sides known. lib 512→518.
+
 - **Scorer Phase 2 Slice 2 — measure real load + dim 12** (PR #24, `2026-06-19`, merged
-  `53f86b7`) — the `herd agent` daemon now MEASURES load: probes llama-server `/props`
-  (`total_slots`→`max_concurrent`) + `/slots` (busy count→`queue_depth`), best-effort
-  (failure/disabled/non-llama → None, never flips reachable). `AgentCapabilities.queue_depth`
-  → `Option<u32>` (honest unmeasured, no fake idle) + new `max_concurrent` (both serde-default
-  wire-compat). dim 12 `concurrency_saturation` = `1-queue_depth/max_concurrent`, guard `max>0`,
-  COEXISTS with dim 10 (no supersession), weight 1.0. lib 504→512. Endpoints verified vs
-  ggml-org docs. Independent review CLEAN. **Still deferred:** agent ttft (dim 11) — `/metrics`
-  has no quantiles, observe-only agent can't get a true p50.
+  `53f86b7`) — `herd agent` probes llama-server `/props` (`total_slots`→`max_concurrent`) +
+  `/slots` (busy→`queue_depth`), best-effort. `AgentCapabilities.queue_depth` → `Option<u32>`
+  (honest unmeasured) + new `max_concurrent` (both serde-default). dim 12
+  `concurrency_saturation = 1-queue_depth/max_concurrent`, guard `max>0`, coexists with dim 10,
+  weight 1.0. lib 504→512. **Deferred:** agent ttft (dim 11) — `/metrics` has no quantiles.
 
 - **Scorer Phase 2 Slice 1 — live-load dims 10/11/13** (PR #23, `2026-06-19`, merged
-  `90b5251`) — `queue_depth`/`ttft_p50`/`precise_vram_free` read agent telemetry already
-  at the pool boundary (`vram_total_mb` was already a `BackendState` field + populated by
-  `pool_sync`, so Slice 1 was pure `scored.rs` + `config.rs`). `is_some()` presence
-  predicate (`Some(0)` scored, not absent); dim 13 supersedes dim 5 per-candidate (no
-  VRAM double-count); latency-aware balanced weights (`ttft_p50=3`/`queue_depth=2`/
-  `precise_vram_free=2`). `QUEUE_REF=8`/`TTFT_REF=2000`. lib 499→504. Independent
-  fresh-context review CLEAN; all CI green. **Test gotcha:** the Q6 call-uniform pre-pass
-  drops any dim present on only ONE candidate — live-dim tests need ≥2 reporters, and
-  per-candidate supersession is tested directly on `compute_raw`.
+  `90b5251`) — read agent telemetry at the pool boundary. `is_some()` presence (`Some(0)`
+  scored, not absent); dim 13 supersedes dim 5 per-candidate (no VRAM double-count); weights
+  `ttft_p50=3`/`queue_depth=2`/`precise_vram_free=2`. `QUEUE_REF=8`/`TTFT_REF=2000`. lib
+  499→504. **Test gotcha:** the Q6 call-uniform pre-pass drops any dim present on only ONE
+  candidate — live-dim tests need ≥2 reporters; supersession tested directly on `compute_raw`.
+
 - **Scorer Phase 1 hardening** (PR #21, `2026-06-15`) — dim-6 temp sentinel guard,
   per-candidate alloc drop, VRAM-comment fix. lib 499.
 - **Scorer Phase 1 — `ScoredRouter`** (PR #19) — GATE→SCORE→SELECT over dims 1–9,
@@ -78,15 +163,15 @@ dim-3 is self-contained, no approximation, no new protocol field.
 ---
 
 ## Backlog
-- **Agent ttft measurement (dim 11)** — the agent reports `ttft_p50_ms: None` today; dim 11
-  reads the field but is never fed. A TRUE p50 isn't reachable for an observe-only agent
-  (`/metrics` is counters/gauges, no quantiles; per-request `timings.prompt_ms` only on
-  completion responses the agent doesn't see). Realistic option: interval-MEAN TTFT from
-  `/metrics` counter deltas (needs `--metrics` + daemon delta-state), reported as an
-  approximation. Deferred pending a decision on whether the mean approximation is wanted.
-- **dim-3 agent ctx source** — extend dim 3 to agent nodes by reporting llama-server
-  `/props` `default_generation_settings.n_ctx` → `max_context_len` (Slice E does config-only).
-- **Scorer Phase 3** — per-(backend,model) `RoutingStats` (EWMA latency, error-rate).
-  Open-question Q1: in-memory (recommended) vs SQLite persistence — decide before building.
-- **Scorer Phase 4** — locality/cost/capability (dims 18–23).
-- v1.3 milestone — speculative decoding, full mDNS discovery, routing-strategy plugins.
+- **dim 21 `rpc_shard_capability`** — deferred from Phase 4: inert until a "request needs
+  sharding" signal exists, which depends on llama.cpp RPC tensor-sharding integration (v1.3
+  roadmap). Building now = a Q6-dropped no-op field. Revisit with the RPC work.
+- **Agent ttft measurement (dim 11)** — agent reports `ttft_p50_ms: None`; a TRUE p50 isn't
+  reachable for an observe-only agent (`/metrics` counters/gauges, no quantiles; per-request
+  `timings.prompt_ms` only on completion responses the agent doesn't see). Realistic option:
+  interval-MEAN TTFT from `/metrics` counter deltas (needs `--metrics` + daemon delta-state),
+  reported as an approximation. Deferred pending a decision on the mean approximation.
+- **Scorer Phase 4 leftovers** — dim 18 (session stickiness) and dim 22 (gpu-class affinity)
+  may land or defer per Director decisions Q-C1/Q-D1 above.
+- v1.3 milestone — speculative decoding, full mDNS discovery, routing-strategy plugins,
+  llama.cpp RPC tensor-parallel sharding.


### PR DESCRIPTION
First slice of scorer **Phase 4** (policy/affinity). Both dims are config-only, opt-in, and additive — un-configured backends stay neutral/weight-dropped, so scorer behavior is byte-identical until an operator opts in.

- `LocalityTier` enum (`local`/`lan`/`tailnet`/`wan`) + `Backend.locality` + `Backend.power_cost`, both `#[serde(default)]` (wire-compatible).
- dim 19 tier map (`local 1.0 / lan 0.8 / tailnet 0.6 / wan 0.4`); dim 20 `clamp(1 - cost/COST_REF, 0, 1)`, `COST_REF=100`. Present iff configured; weights stay `w_zero` (opt-in).
- 4 tests (2 direct `compute_raw`, 2 anti-trivial e2e). lib **540 → 544**. clippy `-D warnings` + fmt clean, no lib unwrap.

**Base:** `main`. First of 4 stacked Phase-4 PRs (A→B→C→D).

🤖 Generated with [Claude Code](https://claude.com/claude-code)