### PR TITLE
feat(router): Phase 4 Slice B — dim 23 (warm_model_recency)

### DIFF
--- a/docs/specs/smart-routing-scorer-spec.md
+++ b/docs/specs/smart-routing-scorer-spec.md
@@ -682,10 +682,19 @@ Landing incrementally by data-source cost (Slice A → D):
 > stay **opt-in** (`w_zero` default — locality/cost are deployment value-judgments, not
 > universally-good defaults). No protocol field, no stateful plumbing.
 >
-> **Remaining:** dim 23 (`warm_model_recency`, stateful — per-(backend,model) last-served
-> time on `BackendState`); dim 18 (`session_stickiness`, architectural — needs a
-> session→backend ledger + a session key on the scoring path + routing agent turns through
-> the scorer); dim 22 (`gpu_class_affinity`, needs a model→preferred-class source). dim 21
+> **Slice B — dim 23 `warm_model_recency` (stateful).** `BackendState` gains
+> `last_served: BTreeMap<String, Instant>` (model → last-served wall-clock). Stamped by
+> `BackendPool::record_served` from BOTH the `ModelWarmer` (on warm success) and the proxy
+> post-request hooks (on a successful served request — this also covers llama-server nodes
+> the warmer skips). `compute_raw` takes a `now: Instant` captured once per routing call;
+> dim 23 = `clamp(1 - age_secs/WARM_REF, 0, 1)` (`WARM_REF = 300`), present iff a model is
+> requested, `0.5` when that model was never served on the backend (unknown, not a penalty).
+> Opt-in (`w_zero`). Time-based `age_secs` chosen over the spec's `turns_since` (no global
+> turn counter exists; time is the same `Instant` source the pool already uses).
+>
+> **Remaining:** dim 18 (`session_stickiness`, architectural — needs a session→backend
+> ledger + a session key on the scoring path + routing agent turns through the scorer);
+> dim 22 (`gpu_class_affinity`, needs a model→preferred-class source). dim 21
 > (`rpc_shard_capability`) is **deferred to v1.3** — inert until a "request needs sharding"
 > signal exists (Q6 drops a uniform-0.5 dim every call), which depends on the llama.cpp RPC
 > tensor-sharding integration.

--- a/herd.yaml.example
+++ b/herd.yaml.example
@@ -75,10 +75,11 @@ routing:
   #     precise_vram_free: 2.0       # prefer more measured free VRAM (agent telemetry)
   #     # History dims 14–17 (ewma_latency, recent_error_rate, recent_success_throughput,
   #     # flap_stability) keep sensible non-zero defaults — omit to use them.
-  #     # Policy dims below are OPT-IN (default 0); turn on per fleet. They read the
-  #     # matching per-backend fields (locality / power_cost) shown in the backends block.
+  #     # Policy/affinity dims below are OPT-IN (default 0); turn on per fleet.
   #     network_locality: 2.0        # prefer closer backends (needs per-backend `locality`)
   #     power_cost: 1.0              # prefer cheaper/lower-power (needs per-backend `power_cost`)
+  #     warm_model_recency: 2.0      # prefer backends that served this model recently
+  #                                  # (prompt/KV-cache warmth; tracked automatically)
 
   # === AUTO MODE ===
   # LLM-based request classification. When model is "auto" or omitted, Herd calls

--- a/src/api/openai.rs
+++ b/src/api/openai.rs
@@ -608,6 +608,12 @@ pub async fn chat_completions(
                 None, // tokens not extracted from streaming SSE
             )
             .await;
+        // Phase-4 dim 23: stamp warm-recency on a successful served request.
+        if log.status != "error" {
+            if let Some(m) = log.model.as_deref() {
+                state.pool.record_served(&log.backend, m).await;
+            }
+        }
         if let Err(e) = state.analytics.log_request(log).await {
             tracing::error!("Failed to log request: {}", e);
         }
@@ -677,6 +683,12 @@ pub async fn chat_completions(
                 tokens_out,
             )
             .await;
+        // Phase-4 dim 23: stamp warm-recency on a successful served request.
+        if log.status != "error" {
+            if let Some(m) = log.model.as_deref() {
+                state.pool.record_served(&log.backend, m).await;
+            }
+        }
         if let (Some(tin), Some(tout)) = (tokens_in, tokens_out) {
             state
                 .metrics

--- a/src/backend/pool.rs
+++ b/src/backend/pool.rs
@@ -1,5 +1,5 @@
 use crate::config::Backend;
-use std::collections::HashSet;
+use std::collections::{BTreeMap, HashSet};
 use std::sync::Arc;
 use std::time::Duration;
 use std::time::Instant;
@@ -27,6 +27,12 @@ pub struct BackendState {
     pub vram_free_mb: Option<u64>,
     /// Max concurrent requests the backend will accept. None — no source field yet (future phase).
     pub max_concurrent: Option<u32>,
+    /// Per-model last-served wall-clock instant (model name → when this backend
+    /// last successfully served or warmed it). Feeds the scored router's
+    /// `warm_model_recency` dimension (dim 23). Empty until the warmer or a
+    /// served request stamps it; a model absent from the map reads as "never
+    /// served here" (neutral 0.5), never a penalty.
+    pub last_served: BTreeMap<String, Instant>,
 }
 
 #[derive(Debug, Clone)]
@@ -87,6 +93,7 @@ impl BackendPool {
                 ttft_p50_ms: None,
                 vram_free_mb: None,
                 max_concurrent: None,
+                last_served: BTreeMap::new(),
             })
             .collect();
 
@@ -279,6 +286,23 @@ impl BackendPool {
         }
     }
 
+    /// Record that `name` just successfully served (or warmed) `model`, stamping
+    /// the wall-clock instant. Feeds the scored router's `warm_model_recency`
+    /// dimension. Called from the warmer (on warm success) and the proxy
+    /// post-request hooks (on a successful served request). No-op for an unknown
+    /// backend name or an empty model string.
+    pub async fn record_served(&self, name: &str, model: &str) {
+        if model.is_empty() {
+            return;
+        }
+        let mut backends = self.backends.write().await;
+        if let Some(backend) = backends.iter_mut().find(|b| b.config.name == name) {
+            backend
+                .last_served
+                .insert(model.to_string(), Instant::now());
+        }
+    }
+
     pub async fn set_vram(&self, name: &str, vram_mb: u64) {
         let mut backends = self.backends.write().await;
         if let Some(backend) = backends.iter_mut().find(|b| b.config.name == name) {
@@ -331,6 +355,7 @@ impl BackendPool {
             ttft_p50_ms: None,
             vram_free_mb: None,
             max_concurrent: None,
+            last_served: BTreeMap::new(),
         });
     }
 
@@ -398,6 +423,31 @@ mod tests {
         // Removing non-existent returns false
         let removed = pool.remove("gpu1").await;
         assert!(!removed);
+    }
+
+    #[tokio::test]
+    async fn record_served_stamps_last_served() {
+        let pool = BackendPool::new(vec![], 3, Duration::from_secs(60));
+        pool.add(make_backend("gpu1", 100)).await;
+
+        // Initially empty.
+        assert!(pool.get("gpu1").await.unwrap().last_served.is_empty());
+
+        // Stamps the model with a recent instant.
+        pool.record_served("gpu1", "llama3:8b").await;
+        let state = pool.get("gpu1").await.unwrap();
+        let t = state
+            .last_served
+            .get("llama3:8b")
+            .expect("model should be stamped");
+        assert!(t.elapsed() < Duration::from_secs(5), "stamp should be ~now");
+
+        // Empty model name is a no-op (no spurious "" key).
+        pool.record_served("gpu1", "").await;
+        assert!(!pool.get("gpu1").await.unwrap().last_served.contains_key(""));
+
+        // Unknown backend is a no-op (no panic).
+        pool.record_served("nope", "llama3:8b").await;
     }
 
     #[tokio::test]

--- a/src/backend/pool.rs
+++ b/src/backend/pool.rs
@@ -5,6 +5,12 @@ use std::time::Duration;
 use std::time::Instant;
 use tokio::sync::RwLock;
 
+/// Per-backend cap on the `last_served` map (dim 23 warm-recency). A real
+/// backend hosts at most a few dozen distinct models, so this never triggers in
+/// normal operation; it bounds growth if a relaxed-gate fleet is fed arbitrary
+/// model strings. Mirrors `RoutingStats`' size-cap-with-LRU-eviction approach.
+const MAX_LAST_SERVED: usize = 256;
+
 #[derive(Debug, Clone)]
 pub struct BackendState {
     pub config: Backend,
@@ -297,6 +303,20 @@ impl BackendPool {
         }
         let mut backends = self.backends.write().await;
         if let Some(backend) = backends.iter_mut().find(|b| b.config.name == name) {
+            // Bound the map: at capacity, evict the least-recently-served entry
+            // before inserting a NEW model (re-stamping an existing one is free).
+            if backend.last_served.len() >= MAX_LAST_SERVED
+                && !backend.last_served.contains_key(model)
+            {
+                if let Some(oldest) = backend
+                    .last_served
+                    .iter()
+                    .min_by_key(|(_, t)| **t)
+                    .map(|(k, _)| k.clone())
+                {
+                    backend.last_served.remove(&oldest);
+                }
+            }
             backend
                 .last_served
                 .insert(model.to_string(), Instant::now());
@@ -448,6 +468,41 @@ mod tests {
 
         // Unknown backend is a no-op (no panic).
         pool.record_served("nope", "llama3:8b").await;
+    }
+
+    #[tokio::test]
+    async fn record_served_bounds_map_with_lru_eviction() {
+        let pool = BackendPool::new(vec![], 3, Duration::from_secs(60));
+        pool.add(make_backend("gpu1", 100)).await;
+
+        // The first model served is the oldest; it must be the eviction victim.
+        pool.record_served("gpu1", "oldest").await;
+        // Guarantee a strictly-older instant so the LRU victim is unambiguous
+        // (avoids a same-tick tie with the next insert).
+        tokio::time::sleep(Duration::from_millis(5)).await;
+        // Fill to capacity with distinct models (oldest is now entry 0 of CAP+1).
+        for i in 0..super::MAX_LAST_SERVED {
+            pool.record_served("gpu1", &format!("m{i}")).await;
+        }
+
+        let state = pool.get("gpu1").await.unwrap();
+        assert_eq!(
+            state.last_served.len(),
+            super::MAX_LAST_SERVED,
+            "map must be capped at MAX_LAST_SERVED"
+        );
+        assert!(
+            !state.last_served.contains_key("oldest"),
+            "least-recently-served entry must be evicted"
+        );
+
+        // Re-stamping an EXISTING model must not evict (no net growth).
+        pool.record_served("gpu1", "m0").await;
+        assert_eq!(
+            pool.get("gpu1").await.unwrap().last_served.len(),
+            super::MAX_LAST_SERVED,
+            "re-stamping an existing model does not grow or evict"
+        );
     }
 
     #[tokio::test]

--- a/src/backend/warmer.rs
+++ b/src/backend/warmer.rs
@@ -54,12 +54,15 @@ impl ModelWarmer {
                     let model = model.clone();
                     let name = name.clone();
                     let permit = semaphore.clone();
+                    let pool = pool.clone();
                     tokio::spawn(async move {
                         let _permit = permit.acquire().await.expect("semaphore closed");
                         if let Err(e) = client.post(&url).json(&payload).send().await {
                             tracing::warn!("Warmer failed for {} on {}: {}", model, name, e);
                         } else {
                             tracing::debug!("Warmed {} on {}", model, name);
+                            // Stamp warm-recency (dim 23) on success.
+                            pool.record_served(&name, &model).await;
                         }
                     });
                 }

--- a/src/router/scored.rs
+++ b/src/router/scored.rs
@@ -4,8 +4,9 @@
 /// plus dims 10–13 (Phase 2 — live load & latency from agent telemetry; dim 11
 /// `ttft_p50` reads agent caps but the agent does not yet measure it). Dims 14–17
 /// (Phase 3) read per-(backend,model) EWMA history from `RoutingStats`.
-/// Phase 4 (policy/affinity) is landing incrementally: dims 19 (`network_locality`)
-/// and 20 (`power_cost`) are active (config-only); dims 18, 21–23 remain
+/// Phase 4 (policy/affinity) is landing incrementally: dims 19 (`network_locality`),
+/// 20 (`power_cost`, config-only) and 23 (`warm_model_recency`, from per-(backend,
+/// model) last-served time on `BackendState`) are active; dims 18, 21, 22 remain
 /// absent/neutral until their slices.
 use crate::backend::{pool::filter_healthy, BackendPool};
 use crate::config::{BackendType, ModelGate, ScoredConfig, ScoredWeights};
@@ -15,6 +16,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 use std::collections::{BTreeMap, HashSet};
 use std::sync::Arc;
+use std::time::Instant;
 use tracing::debug;
 
 // ── Normalization constants ──────────────────────────────────────────────────
@@ -36,6 +38,10 @@ const TTFT_REF: f64 = 2000.0;
 /// this normalizes to 0.0 (most expensive), a zero-cost backend to 1.0. Same
 /// arbitrary unit the operator uses for `Backend.power_cost` (watts, $/1k tok…).
 const COST_REF: f64 = 100.0;
+/// Reference age (seconds) for dim 23 (`warm_model_recency`); a model served
+/// just now normalizes to 1.0, one served `WARM_REF`+ seconds ago to 0.0.
+/// ~5 min ≈ Ollama's default keep-alive window before a model is evicted.
+const WARM_REF: f64 = 300.0;
 /// Scale factor for quantizing scores to i64 comparison keys.
 const SCORE_SCALE: f64 = 1_000_000.0;
 
@@ -238,6 +244,7 @@ fn compute_raw(
     pmax: u32,
     prompt_tokens: Option<u32>,
     stats: Option<&BackendModelStats>,
+    now: Instant,
 ) -> CandidateRaw {
     let mut norms = [0.0f64; DIM_COUNT];
     let mut present0 = [false; DIM_COUNT];
@@ -461,9 +468,28 @@ fn compute_raw(
         }
     }
 
-    // ── Dims 18, 21–23: Phase 4 — absent until their slices ──────────────────
-    // session_stickiness (18), rpc_shard_capability (21), gpu_class_affinity (22),
-    // warm_model_recency (23): sources None/absent → present0 stays false.
+    // ── Dim 23: warm_model_recency — Phase 4 (stateful) ──────────────────────
+    // How recently THIS backend last served the requested model (prompt/KV-cache
+    // warmth). Present iff a model is requested. Served just now → 1.0, ≥WARM_REF
+    // seconds ago → 0.0; a model never served here reads neutral 0.5 (unknown, not
+    // a penalty). When no model is requested the dimension is absent. `now` is
+    // captured once per routing call so every candidate is aged against the same
+    // instant (fair + deterministic within the call).
+    if let Some(m) = model {
+        let dim = Dimension::WarmModelRecency.idx();
+        present0[dim] = true;
+        norms[dim] = match b.last_served.get(m) {
+            Some(&t) => {
+                let age = now.saturating_duration_since(t).as_secs_f64();
+                (1.0 - age / WARM_REF).clamp(0.0, 1.0)
+            }
+            None => 0.5,
+        };
+    }
+
+    // ── Dims 18, 21, 22: Phase 4 — absent until their slices ─────────────────
+    // session_stickiness (18), rpc_shard_capability (21), gpu_class_affinity (22):
+    // sources None/absent → present0 stays false.
 
     CandidateRaw { norms, present0 }
 }
@@ -554,6 +580,10 @@ impl Router for ScoredRouter {
             (lo.min(b.config.priority), hi.max(b.config.priority))
         });
 
+        // Dim 23 (warm_model_recency) ages every candidate against ONE instant,
+        // captured here so the comparison is fair and deterministic within the call.
+        let now = Instant::now();
+
         // Per-candidate raw norms + present₀ flags.
         let raws: Vec<CandidateRaw> = candidates
             .iter()
@@ -575,6 +605,7 @@ impl Router for ScoredRouter {
                     pmax,
                     ctx.prompt_tokens,
                     candidate_stats,
+                    now,
                 )
             })
             .collect();
@@ -823,6 +854,7 @@ mod tests {
             ttft_p50_ms: None,
             vram_free_mb: None,
             max_concurrent: None,
+            last_served: std::collections::BTreeMap::new(),
         }
     }
 
@@ -1623,7 +1655,18 @@ mod tests {
         agent.gpu_metrics = Some(gm.clone());
         agent.vram_total_mb = Some(8000);
         agent.vram_free_mb = Some(4000);
-        let raw_a = compute_raw(&agent, None, None, false, None, 50, 50, None, None);
+        let raw_a = compute_raw(
+            &agent,
+            None,
+            None,
+            false,
+            None,
+            50,
+            50,
+            None,
+            None,
+            Instant::now(),
+        );
         assert!(
             raw_a.present0[Dimension::PreciseVramFree.idx()],
             "agent dim 13 must be present"
@@ -1636,7 +1679,18 @@ mod tests {
         // Static node: gpu_metrics only, no agent telemetry.
         let mut stat = make_state("static", 50, true);
         stat.gpu_metrics = Some(gm);
-        let raw_s = compute_raw(&stat, None, None, false, None, 50, 50, None, None);
+        let raw_s = compute_raw(
+            &stat,
+            None,
+            None,
+            false,
+            None,
+            50,
+            50,
+            None,
+            None,
+            Instant::now(),
+        );
         assert!(
             !raw_s.present0[Dimension::PreciseVramFree.idx()],
             "static dim 13 must be absent"
@@ -1688,7 +1742,18 @@ mod tests {
         let mut ok = make_state("ok", 50, true);
         ok.queue_depth = Some(3);
         ok.max_concurrent = Some(8);
-        let raw = compute_raw(&ok, None, None, false, None, 50, 50, None, None);
+        let raw = compute_raw(
+            &ok,
+            None,
+            None,
+            false,
+            None,
+            50,
+            50,
+            None,
+            None,
+            Instant::now(),
+        );
         assert!(
             raw.present0[dim12],
             "dim 12 present when both known and max>0"
@@ -1702,7 +1767,18 @@ mod tests {
         let mut zero_cap = make_state("zerocap", 50, true);
         zero_cap.queue_depth = Some(3);
         zero_cap.max_concurrent = Some(0);
-        let raw = compute_raw(&zero_cap, None, None, false, None, 50, 50, None, None);
+        let raw = compute_raw(
+            &zero_cap,
+            None,
+            None,
+            false,
+            None,
+            50,
+            50,
+            None,
+            None,
+            Instant::now(),
+        );
         assert!(
             !raw.present0[dim12],
             "Some(0) capacity → dim 12 absent (guard)"
@@ -1711,7 +1787,18 @@ mod tests {
         // Missing max_concurrent → dim 12 absent (dim 10 unaffected).
         let mut no_cap = make_state("nocap", 50, true);
         no_cap.queue_depth = Some(3);
-        let raw = compute_raw(&no_cap, None, None, false, None, 50, 50, None, None);
+        let raw = compute_raw(
+            &no_cap,
+            None,
+            None,
+            false,
+            None,
+            50,
+            50,
+            None,
+            None,
+            Instant::now(),
+        );
         assert!(!raw.present0[dim12], "no max_concurrent → dim 12 absent");
         assert!(
             raw.present0[dim10],
@@ -1736,7 +1823,18 @@ mod tests {
         ] {
             let mut s = make_state("n", 50, true);
             s.config.locality = Some(tier);
-            let raw = compute_raw(&s, None, None, false, None, 50, 50, None, None);
+            let raw = compute_raw(
+                &s,
+                None,
+                None,
+                false,
+                None,
+                50,
+                50,
+                None,
+                None,
+                Instant::now(),
+            );
             assert!(raw.present0[dim], "dim 19 present when locality configured");
             assert!(
                 (raw.norms[dim] - expected).abs() < 1e-9,
@@ -1745,7 +1843,18 @@ mod tests {
         }
         // Unconfigured → absent (neutral, weight-dropped), never a penalty.
         let s = make_state("n", 50, true);
-        let raw = compute_raw(&s, None, None, false, None, 50, 50, None, None);
+        let raw = compute_raw(
+            &s,
+            None,
+            None,
+            false,
+            None,
+            50,
+            50,
+            None,
+            None,
+            Instant::now(),
+        );
         assert!(!raw.present0[dim], "dim 19 absent when locality is None");
     }
 
@@ -1761,7 +1870,18 @@ mod tests {
             s
         };
 
-        let raw = compute_raw(&with_cost(0.0), None, None, false, None, 50, 50, None, None);
+        let raw = compute_raw(
+            &with_cost(0.0),
+            None,
+            None,
+            false,
+            None,
+            50,
+            50,
+            None,
+            None,
+            Instant::now(),
+        );
         assert!(raw.present0[dim], "dim 20 present when cost configured");
         assert!((raw.norms[dim] - 1.0).abs() < 1e-9, "zero cost → 1.0");
 
@@ -1775,6 +1895,7 @@ mod tests {
             50,
             None,
             None,
+            Instant::now(),
         );
         assert!((raw.norms[dim] - 0.5).abs() < 1e-9, "half COST_REF → 0.5");
 
@@ -1789,12 +1910,24 @@ mod tests {
             50,
             None,
             None,
+            Instant::now(),
         );
         assert!((raw.norms[dim]).abs() < 1e-9, "≥COST_REF clamps to 0.0");
 
         // Unconfigured → absent (neutral, weight-dropped).
         let s = make_state("b", 50, true);
-        let raw = compute_raw(&s, None, None, false, None, 50, 50, None, None);
+        let raw = compute_raw(
+            &s,
+            None,
+            None,
+            false,
+            None,
+            50,
+            50,
+            None,
+            None,
+            Instant::now(),
+        );
         assert!(!raw.present0[dim], "dim 20 absent when power_cost is None");
     }
 
@@ -1843,6 +1976,158 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(result.name, "zeta", "cheaper backend must win");
+    }
+
+    // ── Phase 4 Slice B: warm_model_recency (dim 23) ─────────────────────────
+
+    /// dim 23 — recency norm from per-model last-served time. Served now → 1.0,
+    /// half WARM_REF ago → 0.5, ≥WARM_REF ago → 0.0 (clamped); a model never
+    /// served here reads neutral 0.5 (unknown, not a penalty); absent entirely
+    /// when no model is requested. Direct on `compute_raw` with a fixed `now` so
+    /// ages are deterministic.
+    #[test]
+    fn warm_model_recency_formula_and_absence_in_compute_raw() {
+        let dim = Dimension::WarmModelRecency.idx();
+        let now = Instant::now();
+        let served_ago = |secs: u64| {
+            let mut s = make_state("w", 50, true);
+            s.last_served
+                .insert("m".to_string(), now - Duration::from_secs(secs));
+            s
+        };
+
+        // Served just now → 1.0
+        let raw = compute_raw(
+            &served_ago(0),
+            Some("m"),
+            None,
+            false,
+            None,
+            50,
+            50,
+            None,
+            None,
+            now,
+        );
+        assert!(
+            raw.present0[dim],
+            "dim 23 present when a model is requested"
+        );
+        assert!((raw.norms[dim] - 1.0).abs() < 1e-9, "served now → 1.0");
+
+        // Half WARM_REF ago → 0.5
+        let raw = compute_raw(
+            &served_ago((WARM_REF / 2.0) as u64),
+            Some("m"),
+            None,
+            false,
+            None,
+            50,
+            50,
+            None,
+            None,
+            now,
+        );
+        assert!((raw.norms[dim] - 0.5).abs() < 1e-9, "half WARM_REF → 0.5");
+
+        // ≥WARM_REF ago → clamps to 0.0
+        let raw = compute_raw(
+            &served_ago(WARM_REF as u64 * 2),
+            Some("m"),
+            None,
+            false,
+            None,
+            50,
+            50,
+            None,
+            None,
+            now,
+        );
+        assert!((raw.norms[dim]).abs() < 1e-9, "≥WARM_REF → 0.0");
+
+        // Model requested but never served here → neutral 0.5 (unknown).
+        let never = make_state("w", 50, true);
+        let raw = compute_raw(
+            &never,
+            Some("m"),
+            None,
+            false,
+            None,
+            50,
+            50,
+            None,
+            None,
+            now,
+        );
+        assert!(
+            raw.present0[dim],
+            "present with a requested model even if never served"
+        );
+        assert!((raw.norms[dim] - 0.5).abs() < 1e-9, "never served → 0.5");
+
+        // A DIFFERENT model is warm, but the requested one isn't → still 0.5.
+        let mut other = make_state("w", 50, true);
+        other.last_served.insert("other".to_string(), now);
+        let raw = compute_raw(
+            &other,
+            Some("m"),
+            None,
+            false,
+            None,
+            50,
+            50,
+            None,
+            None,
+            now,
+        );
+        assert!(
+            (raw.norms[dim] - 0.5).abs() < 1e-9,
+            "a different warm model leaves the requested one at 0.5"
+        );
+
+        // No model requested → dim 23 absent (neutral, weight-dropped).
+        let raw = compute_raw(
+            &served_ago(0),
+            None,
+            None,
+            false,
+            None,
+            50,
+            50,
+            None,
+            None,
+            now,
+        );
+        assert!(
+            !raw.present0[dim],
+            "dim 23 absent when no model is requested"
+        );
+    }
+
+    /// dim 23 end-to-end — the backend that served the model more recently wins.
+    /// Anti-trivial: the stale node is "alpha", the freshly-served node "zeta"; a
+    /// "zeta" win proves dim 23 decided. Weight opt-in, set explicitly.
+    #[tokio::test]
+    async fn warm_model_recency_recent_backend_wins() {
+        let now = Instant::now();
+        let mut stale = make_state("alpha", 50, true);
+        let mut warm = make_state("zeta", 50, true);
+        stale.models = vec!["m".to_string()];
+        warm.models = vec!["m".to_string()];
+        stale
+            .last_served
+            .insert("m".to_string(), now - Duration::from_secs(280));
+        warm.last_served.insert("m".to_string(), now);
+
+        let mut cfg = ScoredConfig::default();
+        cfg.weights.warm_model_recency = 100.0;
+        let pool = pool_from_states(vec![stale, warm]);
+        let router = make_router(pool, &cfg);
+        let result = router
+            .route_scored(Some("m"), None, &HashSet::new(), &RouteContext::default())
+            .await
+            .unwrap();
+        assert_eq!(result.name, "zeta", "more recently served backend must win");
     }
 
     // ── Phase 2: prompt_size_vs_capacity (dim 3) ─────────────────────────────
@@ -1895,6 +2180,7 @@ mod tests {
             50,
             Some(500),
             None,
+            Instant::now(),
         );
         assert!(raw.present0[dim3]);
         assert!((raw.norms[dim3] - 1.0).abs() < 1e-9, "≤50% window → 1.0");
@@ -1910,6 +2196,7 @@ mod tests {
             50,
             Some(750),
             None,
+            Instant::now(),
         );
         assert!((raw.norms[dim3] - 0.5).abs() < 1e-9, "75% window → 0.5");
 
@@ -1924,6 +2211,7 @@ mod tests {
             50,
             Some(1000),
             None,
+            Instant::now(),
         );
         assert!((raw.norms[dim3]).abs() < 1e-9, "≥100% window → 0.0");
 
@@ -1938,12 +2226,24 @@ mod tests {
             50,
             None,
             None,
+            Instant::now(),
         );
         assert!(!raw.present0[dim3], "no prompt_tokens → dim 3 absent");
 
         // No max_context_len → absent even with a prompt size.
         let no_window = make_state("nw", 50, true);
-        let raw = compute_raw(&no_window, None, None, false, None, 50, 50, Some(500), None);
+        let raw = compute_raw(
+            &no_window,
+            None,
+            None,
+            false,
+            None,
+            50,
+            50,
+            Some(500),
+            None,
+            Instant::now(),
+        );
         assert!(!raw.present0[dim3], "no max_context_len → dim 3 absent");
     }
 
@@ -1974,7 +2274,18 @@ mod tests {
 
         // Warm stats: all four dims should be present.
         let st = warm_stats(1000.0, 50.0, 0, 0);
-        let raw = compute_raw(&s, None, None, false, None, 50, 50, None, Some(&st));
+        let raw = compute_raw(
+            &s,
+            None,
+            None,
+            false,
+            None,
+            50,
+            50,
+            None,
+            Some(&st),
+            Instant::now(),
+        );
         assert!(
             raw.present0[Dimension::EwmaLatency.idx()],
             "dim 14 must be present with warm stats"
@@ -1993,7 +2304,18 @@ mod tests {
         );
 
         // Cold (None): all four dims absent.
-        let raw_cold = compute_raw(&s, None, None, false, None, 50, 50, None, None);
+        let raw_cold = compute_raw(
+            &s,
+            None,
+            None,
+            false,
+            None,
+            50,
+            50,
+            None,
+            None,
+            Instant::now(),
+        );
         assert!(
             !raw_cold.present0[Dimension::EwmaLatency.idx()],
             "dim 14 absent without stats"
@@ -2014,7 +2336,18 @@ mod tests {
         // Under-sampled (samples < MIN_SAMPLES): treated as cold → absent.
         let mut under = st.clone();
         under.samples = MIN_SAMPLES - 1;
-        let raw_under = compute_raw(&s, None, None, false, None, 50, 50, None, Some(&under));
+        let raw_under = compute_raw(
+            &s,
+            None,
+            None,
+            false,
+            None,
+            50,
+            50,
+            None,
+            Some(&under),
+            Instant::now(),
+        );
         assert!(
             !raw_under.present0[Dimension::EwmaLatency.idx()],
             "dim 14 absent when under-sampled"
@@ -2030,13 +2363,35 @@ mod tests {
 
         // Half the reference latency → 0.5 norm.
         let st = warm_stats(LAT_REF / 2.0, 0.0, 0, 0);
-        let raw = compute_raw(&s, None, None, false, None, 50, 50, None, Some(&st));
+        let raw = compute_raw(
+            &s,
+            None,
+            None,
+            false,
+            None,
+            50,
+            50,
+            None,
+            Some(&st),
+            Instant::now(),
+        );
         let n14 = raw.norms[Dimension::EwmaLatency.idx()];
         assert!((n14 - 0.5).abs() < 1e-9, "LAT_REF/2 → 0.5, got {}", n14);
 
         // Near-zero latency → ~1.0.
         let st_fast = warm_stats(1.0, 0.0, 0, 0);
-        let raw_fast = compute_raw(&s, None, None, false, None, 50, 50, None, Some(&st_fast));
+        let raw_fast = compute_raw(
+            &s,
+            None,
+            None,
+            false,
+            None,
+            50,
+            50,
+            None,
+            Some(&st_fast),
+            Instant::now(),
+        );
         assert!(
             raw_fast.norms[Dimension::EwmaLatency.idx()] > 0.99,
             "1ms latency → near 1.0"
@@ -2044,7 +2399,18 @@ mod tests {
 
         // Latency at or above LAT_REF → 0.0.
         let st_slow = warm_stats(LAT_REF, 0.0, 0, 0);
-        let raw_slow = compute_raw(&s, None, None, false, None, 50, 50, None, Some(&st_slow));
+        let raw_slow = compute_raw(
+            &s,
+            None,
+            None,
+            false,
+            None,
+            50,
+            50,
+            None,
+            Some(&st_slow),
+            Instant::now(),
+        );
         assert!(
             raw_slow.norms[Dimension::EwmaLatency.idx()] <= 0.0,
             "LAT_REF ms → 0.0"
@@ -2058,7 +2424,18 @@ mod tests {
 
         // All successes (err_window = 0) → error_rate = 0 → n = 1.0.
         let st_clean = warm_stats(100.0, 0.0, 0b0000_0000, 0);
-        let raw_clean = compute_raw(&s, None, None, false, None, 50, 50, None, Some(&st_clean));
+        let raw_clean = compute_raw(
+            &s,
+            None,
+            None,
+            false,
+            None,
+            50,
+            50,
+            None,
+            Some(&st_clean),
+            Instant::now(),
+        );
         assert!(
             (raw_clean.norms[Dimension::RecentErrorRate.idx()] - 1.0).abs() < 1e-9,
             "all success → dim 15 = 1.0"
@@ -2068,7 +2445,18 @@ mod tests {
         // 0xAAAAAAAA = 0b10101010... (16 of 32 bits set)
         let mut half = warm_stats(100.0, 0.0, 0xAAAA_AAAA, 0);
         half.samples = 32; // exactly 32 observations so denominator is 32.
-        let raw_half = compute_raw(&s, None, None, false, None, 50, 50, None, Some(&half));
+        let raw_half = compute_raw(
+            &s,
+            None,
+            None,
+            false,
+            None,
+            50,
+            50,
+            None,
+            Some(&half),
+            Instant::now(),
+        );
         assert!(
             (raw_half.norms[Dimension::RecentErrorRate.idx()] - 0.5).abs() < 1e-9,
             "50% errors → dim 15 = 0.5, got {}",
@@ -2084,7 +2472,18 @@ mod tests {
 
         // Half TPS_REF → 0.5.
         let st = warm_stats(100.0, TPS_REF / 2.0, 0, 0);
-        let raw = compute_raw(&s, None, None, false, None, 50, 50, None, Some(&st));
+        let raw = compute_raw(
+            &s,
+            None,
+            None,
+            false,
+            None,
+            50,
+            50,
+            None,
+            Some(&st),
+            Instant::now(),
+        );
         assert!(
             (raw.norms[Dimension::RecentSuccessThroughput.idx()] - 0.5).abs() < 1e-9,
             "TPS_REF/2 → 0.5"
@@ -2092,7 +2491,18 @@ mod tests {
 
         // At or above TPS_REF → 1.0.
         let st_max = warm_stats(100.0, TPS_REF, 0, 0);
-        let raw_max = compute_raw(&s, None, None, false, None, 50, 50, None, Some(&st_max));
+        let raw_max = compute_raw(
+            &s,
+            None,
+            None,
+            false,
+            None,
+            50,
+            50,
+            None,
+            Some(&st_max),
+            Instant::now(),
+        );
         assert!(
             (raw_max.norms[Dimension::RecentSuccessThroughput.idx()] - 1.0).abs() < 1e-9,
             "TPS_REF → 1.0"
@@ -2107,7 +2517,18 @@ mod tests {
 
         // 0 transitions → 1.0.
         let st_stable = warm_stats(100.0, 0.0, 0, 0);
-        let raw_stable = compute_raw(&s, None, None, false, None, 50, 50, None, Some(&st_stable));
+        let raw_stable = compute_raw(
+            &s,
+            None,
+            None,
+            false,
+            None,
+            50,
+            50,
+            None,
+            Some(&st_stable),
+            Instant::now(),
+        );
         assert!(
             (raw_stable.norms[Dimension::FlapStability.idx()] - 1.0).abs() < 1e-9,
             "0 transitions → 1.0"
@@ -2115,7 +2536,18 @@ mod tests {
 
         // FLAP_REF transitions → 0.0.
         let st_flappy = warm_stats(100.0, 0.0, 0, FLAP_REF as u32);
-        let raw_flappy = compute_raw(&s, None, None, false, None, 50, 50, None, Some(&st_flappy));
+        let raw_flappy = compute_raw(
+            &s,
+            None,
+            None,
+            false,
+            None,
+            50,
+            50,
+            None,
+            Some(&st_flappy),
+            Instant::now(),
+        );
         assert!(
             raw_flappy.norms[Dimension::FlapStability.idx()] <= 0.0,
             "FLAP_REF transitions → 0.0"

--- a/src/server.rs
+++ b/src/server.rs
@@ -1626,6 +1626,13 @@ async fn proxy_handler(
                 )
                 .await;
 
+            // Phase-4 dim 23: stamp warm-recency on a successful served request.
+            if log.status != "error" {
+                if let Some(m) = self.model_name.as_deref() {
+                    self.state.pool.record_served(&log.backend, m).await;
+                }
+            }
+
             if let (Some(tin), Some(tout)) = (usage.tokens_in, usage.tokens_out) {
                 self.state
                     .metrics

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -107,7 +107,18 @@ Still open (resolve at each slice's architect pass, not blocking Slice A):
       2 anti-trivial e2e). Build ✓, clippy `-D warnings` ✓, fmt ✓, **lib 540→544**. Docs:
       herd.yaml example (weights + per-backend fields), spec Slice-A note. No lib unwrap.
       **Awaiting: commit + push + PR (user confirm).**
-- [ ] SLICE B (dim 23) — warm-recency, resolve Q-B1/B2 first.
+- [x] SLICE B (dim 23 `warm_model_recency`) — built on the locked decisions:
+      Q-B1 = `last_served: BTreeMap<String, Instant>` on `BackendState` (read from existing
+      pool snapshot, no new lock); Q-B2 = time-based `n = clamp(1 - age_secs/WARM_REF, 0, 1)`,
+      `WARM_REF=300`, `0.5` when requested model never served here, absent when no model
+      requested; Q-B3 = stamp on BOTH `ModelWarmer` success AND every successful served
+      request via new `BackendPool::record_served` (3 hooks: openai.rs streaming+non-streaming,
+      server.rs proxy; serve-path writer also covers llama-server nodes the warmer skips).
+      `compute_raw` gained a `now: Instant` arg (captured once per call → fair + deterministic;
+      dim 23 stays weight-0 opt-in so default determinism tests unaffected). 3 tests (dim-23
+      formula/absence direct, e2e recent-backend-wins, pool `record_served`). Build ✓, clippy
+      `-D warnings` ✓, fmt ✓, **lib 544→547**, no lib unwrap. Docs: herd.yaml.example weight +
+      spec Slice-B note. **Awaiting: commit (user said local-only for the branch).**
 - [ ] SLICE C (dim 18) — session stickiness, resolve Q-C1 first.
 - [ ] SLICE D (dim 22) — gpu-class affinity, blocked on Q-D1.
 


### PR DESCRIPTION
Scores backends by how recently they served the requested model (prompt/KV-cache warmth). Stateful but additive and opt-in.

- `BackendState.last_served: BTreeMap<String, Instant>` + `BackendPool::record_served` (LRU-bounded at `MAX_LAST_SERVED=256`).
- Stamped on **both** `ModelWarmer` success and every successful served request (3 post-request hooks). The serve-path writer also covers llama-server nodes the warmer skips.
- dim 23 `clamp(1 - age_secs/WARM_REF, 0, 1)`, `WARM_REF=300`; `compute_raw` gains `now: Instant` captured once/call (fair + deterministic). `0.5` when never served here; absent when no model requested.
- 4 tests incl. LRU cap. lib → **548**.

**Base:** Slice A branch (stacked). Includes the `last_served` LRU hardening commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)