### PR TITLE
feat(router): Phase 4 Slice C — dim 18 (session_stickiness)

### DIFF
--- a/docs/specs/smart-routing-scorer-spec.md
+++ b/docs/specs/smart-routing-scorer-spec.md
@@ -692,12 +692,18 @@ Landing incrementally by data-source cost (Slice A → D):
 > Opt-in (`w_zero`). Time-based `age_secs` chosen over the spec's `turns_since` (no global
 > turn counter exists; time is the same `Instant` source the pool already uses).
 >
-> **Remaining:** dim 18 (`session_stickiness`, architectural — needs a session→backend
-> ledger + a session key on the scoring path + routing agent turns through the scorer);
-> dim 22 (`gpu_class_affinity`, needs a model→preferred-class source). dim 21
-> (`rpc_shard_capability`) is **deferred to v1.3** — inert until a "request needs sharding"
-> signal exists (Q6 drops a uniform-0.5 dim every call), which depends on the llama.cpp RPC
-> tensor-sharding integration.
+> **Slice C — dim 18 `session_stickiness` (affinity).** New `SessionAffinity` store
+> (`session_id → backend`, LRU-bounded at 50k like `RoutingStats`), injected into
+> `ScoredRouter` and written on the post-request hooks. `RouteContext` gains `session_id`,
+> sourced from the **`X-Herd-Session`** request header in both proxy paths (all traffic, not
+> just agent sessions — Q-C1). `compute_raw` takes `sticky_backend: Option<&str>` (resolved
+> once per call); dim 18 present iff a prior backend is known for the session → the matching
+> candidate scores `1.0`, others `0.5`; unknown/new session → absent. Opt-in (`w_zero`).
+>
+> **Remaining:** dim 22 (`gpu_class_affinity`, Slice D — preferred class inferred from model
+> size, Q-D1). dim 21 (`rpc_shard_capability`) is **deferred to v1.3** — inert until a
+> "request needs sharding" signal exists (Q6 drops a uniform-0.5 dim every call), which
+> depends on the llama.cpp RPC tensor-sharding integration.
 
 ---
 

--- a/herd.yaml.example
+++ b/herd.yaml.example
@@ -80,6 +80,8 @@ routing:
   #     power_cost: 1.0              # prefer cheaper/lower-power (needs per-backend `power_cost`)
   #     warm_model_recency: 2.0      # prefer backends that served this model recently
   #                                  # (prompt/KV-cache warmth; tracked automatically)
+  #     session_stickiness: 3.0      # keep a conversation on its last backend
+  #                                  # (needs the X-Herd-Session request header)
 
   # === AUTO MODE ===
   # LLM-based request classification. When model is "auto" or omitted, Herd calls

--- a/skills.md
+++ b/skills.md
@@ -239,6 +239,20 @@ this header, Herd only considers backends matching **all** specified tags.
 
 **Use case:** Route coding tasks to high-VRAM GPUs, research to slower but larger-context nodes.
 
+### X-Herd-Session (Conversation Stickiness)
+
+Keep a multi-turn conversation on the same backend for prompt/KV-cache warmth:
+
+```
+X-Herd-Session: my-conversation-id
+```
+
+- Only the `scored` routing strategy uses it, via the `session_stickiness` dimension
+  (opt-in — set a non-zero `session_stickiness` weight in `routing.scored.weights`).
+- Send a stable, opaque id (any string) per conversation; Herd records which backend
+  served the last turn and prefers it next time. Omit it for stateless requests.
+- Session ids are bounded internally (LRU) and never persisted to disk.
+
 ### X-Request-Id (Correlation)
 
 ```

--- a/src/api/openai.rs
+++ b/src/api/openai.rs
@@ -387,11 +387,19 @@ pub async fn chat_completions(
 
     let forward_body = rewrite_request_model(&body_bytes, model_name.as_deref());
 
+    // Session id (X-Herd-Session) for the scored router's dim 18 stickiness.
+    let session_id: Option<String> = headers
+        .get("x-herd-session")
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.to_string())
+        .filter(|s| !s.is_empty());
+
     // Estimate prompt size once (pre-routing) for the scored router's dim 3.
     // Ignored by the other routing strategies (their route_scored is ctx-blind).
     let route_ctx = crate::router::RouteContext {
         prompt_tokens: estimate_prompt_tokens(&body_bytes),
         requested_ctx_len: None,
+        session_id: session_id.clone(),
     };
 
     for _ in 0..=state.retry_count() {
@@ -613,6 +621,10 @@ pub async fn chat_completions(
             if let Some(m) = log.model.as_deref() {
                 state.pool.record_served(&log.backend, m).await;
             }
+            // Phase-4 dim 18: record this session's backend for next-turn stickiness.
+            if let Some(sid) = session_id.as_deref() {
+                state.session_affinity.record(sid, &log.backend).await;
+            }
         }
         if let Err(e) = state.analytics.log_request(log).await {
             tracing::error!("Failed to log request: {}", e);
@@ -687,6 +699,10 @@ pub async fn chat_completions(
         if log.status != "error" {
             if let Some(m) = log.model.as_deref() {
                 state.pool.record_served(&log.backend, m).await;
+            }
+            // Phase-4 dim 18: record this session's backend for next-turn stickiness.
+            if let Some(sid) = session_id.as_deref() {
+                state.session_affinity.record(sid, &log.backend).await;
             }
         }
         if let (Some(tin), Some(tout)) = (tokens_in, tokens_out) {

--- a/src/router/mod.rs
+++ b/src/router/mod.rs
@@ -4,11 +4,13 @@ pub mod model_aware;
 pub mod priority;
 pub mod routing_stats;
 pub mod scored;
+pub mod session_affinity;
 pub mod weighted_round_robin;
 
 use crate::backend::BackendPool;
 use crate::config::{RoutingConfig, RoutingStrategy};
 use crate::router::routing_stats::RoutingStats;
+use crate::router::session_affinity::SessionAffinity;
 use anyhow::Result;
 use async_trait::async_trait;
 use std::collections::HashSet;
@@ -23,6 +25,10 @@ pub struct RouteContext {
     pub prompt_tokens: Option<u32>,
     /// Requested context-window length, if the request carried one (e.g. num_ctx).
     pub requested_ctx_len: Option<u32>,
+    /// Caller session id (`X-Herd-Session` header), if present. Feeds dim 18
+    /// (`session_stickiness`): the scorer prefers the backend that served this
+    /// session's last turn. `None` → that dimension is absent (neutral).
+    pub session_id: Option<String>,
 }
 
 #[async_trait]
@@ -109,13 +115,15 @@ impl Router for RouterEnum {
 ///
 /// `routing` is passed so the Scored arm can read `routing.scored`; legacy arms
 /// ignore it — no behaviour change for Priority/ModelAware/LeastBusy/WRR.
-/// `routing_stats` is the shared Phase-3 EWMA history store; it is only wired
-/// into the `Scored` arm. Legacy routers ignore it.
+/// `routing_stats` is the shared Phase-3 EWMA history store and `session_affinity`
+/// the Phase-4 session→backend store; both are only wired into the `Scored` arm.
+/// Legacy routers ignore them.
 pub fn create_router(
     strategy: RoutingStrategy,
     pool: BackendPool,
     routing: &RoutingConfig,
     routing_stats: Arc<RoutingStats>,
+    session_affinity: Arc<SessionAffinity>,
 ) -> RouterEnum {
     match strategy {
         RoutingStrategy::Priority => RouterEnum::Priority(priority::PriorityRouter::new(pool)),
@@ -130,6 +138,7 @@ pub fn create_router(
             pool,
             &routing.scored,
             routing_stats,
+            session_affinity,
         )),
     }
 }

--- a/src/router/scored.rs
+++ b/src/router/scored.rs
@@ -4,13 +4,14 @@
 /// plus dims 10–13 (Phase 2 — live load & latency from agent telemetry; dim 11
 /// `ttft_p50` reads agent caps but the agent does not yet measure it). Dims 14–17
 /// (Phase 3) read per-(backend,model) EWMA history from `RoutingStats`.
-/// Phase 4 (policy/affinity) is landing incrementally: dims 19 (`network_locality`),
-/// 20 (`power_cost`, config-only) and 23 (`warm_model_recency`, from per-(backend,
-/// model) last-served time on `BackendState`) are active; dims 18, 21, 22 remain
-/// absent/neutral until their slices.
+/// Phase 4 (policy/affinity) is landing incrementally: dims 18 (`session_stickiness`,
+/// from the `SessionAffinity` store), 19 (`network_locality`), 20 (`power_cost`,
+/// config-only) and 23 (`warm_model_recency`, from per-(backend,model) last-served
+/// time on `BackendState`) are active; dims 21, 22 remain absent until their slices.
 use crate::backend::{pool::filter_healthy, BackendPool};
 use crate::config::{BackendType, ModelGate, ScoredConfig, ScoredWeights};
 use crate::router::routing_stats::{BackendModelStats, RoutingStats, MIN_SAMPLES};
+use crate::router::session_affinity::SessionAffinity;
 use crate::router::{RouteContext, RoutedBackend, Router};
 use anyhow::Result;
 use async_trait::async_trait;
@@ -75,7 +76,7 @@ pub enum Dimension {
     RecentErrorRate = 14,
     RecentSuccessThroughput = 15,
     FlapStability = 16,
-    // Phase 4 — dims 19/20 active (config-only); 18, 21–23 absent until their slices
+    // Phase 4 — dims 18/19/20/23 active; 21, 22 absent until their slices
     SessionStickiness = 17,
     NetworkLocality = 18,
     PowerCost = 19,
@@ -161,10 +162,18 @@ pub struct ScoredRouter {
     /// Shared Phase-3 EWMA history store. One read-lock snapshot is taken per
     /// routing call; no lock is held across the score/select steps.
     routing_stats: Arc<RoutingStats>,
+    /// Shared Phase-4 session→backend affinity store (dim 18). Read once per
+    /// routing call, only when the request carries a session id.
+    session_affinity: Arc<SessionAffinity>,
 }
 
 impl ScoredRouter {
-    pub fn new(pool: BackendPool, config: &ScoredConfig, routing_stats: Arc<RoutingStats>) -> Self {
+    pub fn new(
+        pool: BackendPool,
+        config: &ScoredConfig,
+        routing_stats: Arc<RoutingStats>,
+        session_affinity: Arc<SessionAffinity>,
+    ) -> Self {
         let w = &config.weights;
         let weights = weights_array(w);
         Self {
@@ -173,6 +182,7 @@ impl ScoredRouter {
             model_gate: config.model_gate,
             prefer_backend_type: config.prefer_backend_type,
             routing_stats,
+            session_affinity,
         }
     }
 }
@@ -245,6 +255,7 @@ fn compute_raw(
     prompt_tokens: Option<u32>,
     stats: Option<&BackendModelStats>,
     now: Instant,
+    sticky_backend: Option<&str>,
 ) -> CandidateRaw {
     let mut norms = [0.0f64; DIM_COUNT];
     let mut present0 = [false; DIM_COUNT];
@@ -487,9 +498,21 @@ fn compute_raw(
         };
     }
 
-    // ── Dims 18, 21, 22: Phase 4 — absent until their slices ─────────────────
-    // session_stickiness (18), rpc_shard_capability (21), gpu_class_affinity (22):
-    // sources None/absent → present0 stays false.
+    // ── Dim 18: session_stickiness — Phase 4 (affinity) ──────────────────────
+    // Prefer the backend that served this session's last turn (prompt/KV-cache
+    // warmth). Present iff a prior backend is known for the session (the request
+    // carried a session id AND it has history): the matching candidate scores
+    // 1.0, all others 0.5. A new/unknown session → `sticky_backend` is None → dim
+    // absent (a brand-new session would make every candidate uniform-0.5 anyway).
+    if let Some(last) = sticky_backend {
+        let dim = Dimension::SessionStickiness.idx();
+        present0[dim] = true;
+        norms[dim] = if last == b.config.name { 1.0 } else { 0.5 };
+    }
+
+    // ── Dims 21, 22: Phase 4 — absent until their slices ─────────────────────
+    // rpc_shard_capability (21), gpu_class_affinity (22): sources None/absent →
+    // present0 stays false.
 
     CandidateRaw { norms, present0 }
 }
@@ -584,6 +607,15 @@ impl Router for ScoredRouter {
         // captured here so the comparison is fair and deterministic within the call.
         let now = Instant::now();
 
+        // Dim 18 (session_stickiness): resolve the session's last backend ONCE,
+        // only when the request carries a session id. Same value for every
+        // candidate; the matching one scores 1.0. None → dim absent.
+        let sticky_backend: Option<String> = match ctx.session_id.as_deref() {
+            Some(sid) => self.session_affinity.get(sid).await,
+            None => None,
+        };
+        let sticky_backend = sticky_backend.as_deref();
+
         // Per-candidate raw norms + present₀ flags.
         let raws: Vec<CandidateRaw> = candidates
             .iter()
@@ -606,6 +638,7 @@ impl Router for ScoredRouter {
                     ctx.prompt_tokens,
                     candidate_stats,
                     now,
+                    sticky_backend,
                 )
             })
             .collect();
@@ -875,7 +908,12 @@ mod tests {
     /// Build a `ScoredRouter` with an empty (cold-start) `RoutingStats`.
     /// Existing tests that don't exercise Phase-3 dims use this helper.
     fn make_router(pool: BackendPool, cfg: &ScoredConfig) -> ScoredRouter {
-        ScoredRouter::new(pool, cfg, Arc::new(RoutingStats::new()))
+        ScoredRouter::new(
+            pool,
+            cfg,
+            Arc::new(RoutingStats::new()),
+            Arc::new(SessionAffinity::new()),
+        )
     }
 
     // ── Test 1 & determinism: same pool + request → same result every time ──
@@ -1666,6 +1704,7 @@ mod tests {
             None,
             None,
             Instant::now(),
+            None,
         );
         assert!(
             raw_a.present0[Dimension::PreciseVramFree.idx()],
@@ -1690,6 +1729,7 @@ mod tests {
             None,
             None,
             Instant::now(),
+            None,
         );
         assert!(
             !raw_s.present0[Dimension::PreciseVramFree.idx()],
@@ -1753,6 +1793,7 @@ mod tests {
             None,
             None,
             Instant::now(),
+            None,
         );
         assert!(
             raw.present0[dim12],
@@ -1778,6 +1819,7 @@ mod tests {
             None,
             None,
             Instant::now(),
+            None,
         );
         assert!(
             !raw.present0[dim12],
@@ -1798,6 +1840,7 @@ mod tests {
             None,
             None,
             Instant::now(),
+            None,
         );
         assert!(!raw.present0[dim12], "no max_concurrent → dim 12 absent");
         assert!(
@@ -1834,6 +1877,7 @@ mod tests {
                 None,
                 None,
                 Instant::now(),
+                None,
             );
             assert!(raw.present0[dim], "dim 19 present when locality configured");
             assert!(
@@ -1854,6 +1898,7 @@ mod tests {
             None,
             None,
             Instant::now(),
+            None,
         );
         assert!(!raw.present0[dim], "dim 19 absent when locality is None");
     }
@@ -1881,6 +1926,7 @@ mod tests {
             None,
             None,
             Instant::now(),
+            None,
         );
         assert!(raw.present0[dim], "dim 20 present when cost configured");
         assert!((raw.norms[dim] - 1.0).abs() < 1e-9, "zero cost → 1.0");
@@ -1896,6 +1942,7 @@ mod tests {
             None,
             None,
             Instant::now(),
+            None,
         );
         assert!((raw.norms[dim] - 0.5).abs() < 1e-9, "half COST_REF → 0.5");
 
@@ -1911,6 +1958,7 @@ mod tests {
             None,
             None,
             Instant::now(),
+            None,
         );
         assert!((raw.norms[dim]).abs() < 1e-9, "≥COST_REF clamps to 0.0");
 
@@ -1927,6 +1975,7 @@ mod tests {
             None,
             None,
             Instant::now(),
+            None,
         );
         assert!(!raw.present0[dim], "dim 20 absent when power_cost is None");
     }
@@ -2008,6 +2057,7 @@ mod tests {
             None,
             None,
             now,
+            None,
         );
         assert!(
             raw.present0[dim],
@@ -2027,6 +2077,7 @@ mod tests {
             None,
             None,
             now,
+            None,
         );
         assert!((raw.norms[dim] - 0.5).abs() < 1e-9, "half WARM_REF → 0.5");
 
@@ -2042,6 +2093,7 @@ mod tests {
             None,
             None,
             now,
+            None,
         );
         assert!((raw.norms[dim]).abs() < 1e-9, "≥WARM_REF → 0.0");
 
@@ -2058,6 +2110,7 @@ mod tests {
             None,
             None,
             now,
+            None,
         );
         assert!(
             raw.present0[dim],
@@ -2079,6 +2132,7 @@ mod tests {
             None,
             None,
             now,
+            None,
         );
         assert!(
             (raw.norms[dim] - 0.5).abs() < 1e-9,
@@ -2097,6 +2151,7 @@ mod tests {
             None,
             None,
             now,
+            None,
         );
         assert!(
             !raw.present0[dim],
@@ -2130,6 +2185,92 @@ mod tests {
         assert_eq!(result.name, "zeta", "more recently served backend must win");
     }
 
+    // ── Phase 4 Slice C: session_stickiness (dim 18) ─────────────────────────
+
+    /// dim 18 — present iff a prior backend is known for the session. The matching
+    /// candidate scores 1.0, all others 0.5; an unknown session (None sticky) →
+    /// absent (neutral). Tested directly on `compute_raw`.
+    #[test]
+    fn session_stickiness_norm_and_absence_in_compute_raw() {
+        let dim = Dimension::SessionStickiness.idx();
+        let now = Instant::now();
+        let b = make_state("beta", 50, true);
+
+        // Sticky to THIS backend → 1.0.
+        let raw = compute_raw(
+            &b,
+            None,
+            None,
+            false,
+            None,
+            50,
+            50,
+            None,
+            None,
+            now,
+            Some("beta"),
+        );
+        assert!(raw.present0[dim], "present when a sticky backend is known");
+        assert!(
+            (raw.norms[dim] - 1.0).abs() < 1e-9,
+            "matching backend → 1.0"
+        );
+
+        // Sticky to ANOTHER backend → 0.5.
+        let raw = compute_raw(
+            &b,
+            None,
+            None,
+            false,
+            None,
+            50,
+            50,
+            None,
+            None,
+            now,
+            Some("other"),
+        );
+        assert!(raw.present0[dim]);
+        assert!(
+            (raw.norms[dim] - 0.5).abs() < 1e-9,
+            "non-matching backend → 0.5"
+        );
+
+        // No sticky backend (new/unknown session) → absent.
+        let raw = compute_raw(&b, None, None, false, None, 50, 50, None, None, now, None);
+        assert!(!raw.present0[dim], "absent when no sticky backend is known");
+    }
+
+    /// dim 18 end-to-end — the session's last backend wins. Anti-trivial: the
+    /// sticky backend is "zeta" (loses the name tie-break to "alpha"); a "zeta"
+    /// win proves dim 18 decided. Affinity store pre-seeded; weight opt-in.
+    #[tokio::test]
+    async fn session_stickiness_sticky_backend_wins() {
+        let mut a = make_state("alpha", 50, true);
+        let mut z = make_state("zeta", 50, true);
+        a.models = vec!["m".to_string()];
+        z.models = vec!["m".to_string()];
+
+        let affinity = Arc::new(SessionAffinity::new());
+        affinity.record("sess-1", "zeta").await;
+
+        let mut cfg = ScoredConfig::default();
+        cfg.weights.session_stickiness = 100.0;
+        let pool = pool_from_states(vec![a, z]);
+        let router = ScoredRouter::new(pool, &cfg, Arc::new(RoutingStats::new()), affinity);
+
+        let ctx = RouteContext {
+            prompt_tokens: None,
+            requested_ctx_len: None,
+            session_id: Some("sess-1".to_string()),
+        };
+        let result = router
+            .route_scored(Some("m"), None, &HashSet::new(), &ctx)
+            .await
+            .unwrap();
+        assert_eq!(result.name, "zeta", "session's last backend must win");
+    }
+
     // ── Phase 2: prompt_size_vs_capacity (dim 3) ─────────────────────────────
 
     /// dim 3 — given the same prompt, the backend with the LARGER context window
@@ -2149,6 +2290,7 @@ mod tests {
         let ctx = RouteContext {
             prompt_tokens: Some(4000),
             requested_ctx_len: None,
+            session_id: None,
         };
         let result = router
             .route_scored(Some("m"), None, &HashSet::new(), &ctx)
@@ -2181,6 +2323,7 @@ mod tests {
             Some(500),
             None,
             Instant::now(),
+            None,
         );
         assert!(raw.present0[dim3]);
         assert!((raw.norms[dim3] - 1.0).abs() < 1e-9, "≤50% window → 1.0");
@@ -2197,6 +2340,7 @@ mod tests {
             Some(750),
             None,
             Instant::now(),
+            None,
         );
         assert!((raw.norms[dim3] - 0.5).abs() < 1e-9, "75% window → 0.5");
 
@@ -2212,6 +2356,7 @@ mod tests {
             Some(1000),
             None,
             Instant::now(),
+            None,
         );
         assert!((raw.norms[dim3]).abs() < 1e-9, "≥100% window → 0.0");
 
@@ -2227,6 +2372,7 @@ mod tests {
             None,
             None,
             Instant::now(),
+            None,
         );
         assert!(!raw.present0[dim3], "no prompt_tokens → dim 3 absent");
 
@@ -2243,6 +2389,7 @@ mod tests {
             Some(500),
             None,
             Instant::now(),
+            None,
         );
         assert!(!raw.present0[dim3], "no max_context_len → dim 3 absent");
     }
@@ -2285,6 +2432,7 @@ mod tests {
             None,
             Some(&st),
             Instant::now(),
+            None,
         );
         assert!(
             raw.present0[Dimension::EwmaLatency.idx()],
@@ -2315,6 +2463,7 @@ mod tests {
             None,
             None,
             Instant::now(),
+            None,
         );
         assert!(
             !raw_cold.present0[Dimension::EwmaLatency.idx()],
@@ -2347,6 +2496,7 @@ mod tests {
             None,
             Some(&under),
             Instant::now(),
+            None,
         );
         assert!(
             !raw_under.present0[Dimension::EwmaLatency.idx()],
@@ -2374,6 +2524,7 @@ mod tests {
             None,
             Some(&st),
             Instant::now(),
+            None,
         );
         let n14 = raw.norms[Dimension::EwmaLatency.idx()];
         assert!((n14 - 0.5).abs() < 1e-9, "LAT_REF/2 → 0.5, got {}", n14);
@@ -2391,6 +2542,7 @@ mod tests {
             None,
             Some(&st_fast),
             Instant::now(),
+            None,
         );
         assert!(
             raw_fast.norms[Dimension::EwmaLatency.idx()] > 0.99,
@@ -2410,6 +2562,7 @@ mod tests {
             None,
             Some(&st_slow),
             Instant::now(),
+            None,
         );
         assert!(
             raw_slow.norms[Dimension::EwmaLatency.idx()] <= 0.0,
@@ -2435,6 +2588,7 @@ mod tests {
             None,
             Some(&st_clean),
             Instant::now(),
+            None,
         );
         assert!(
             (raw_clean.norms[Dimension::RecentErrorRate.idx()] - 1.0).abs() < 1e-9,
@@ -2456,6 +2610,7 @@ mod tests {
             None,
             Some(&half),
             Instant::now(),
+            None,
         );
         assert!(
             (raw_half.norms[Dimension::RecentErrorRate.idx()] - 0.5).abs() < 1e-9,
@@ -2483,6 +2638,7 @@ mod tests {
             None,
             Some(&st),
             Instant::now(),
+            None,
         );
         assert!(
             (raw.norms[Dimension::RecentSuccessThroughput.idx()] - 0.5).abs() < 1e-9,
@@ -2502,6 +2658,7 @@ mod tests {
             None,
             Some(&st_max),
             Instant::now(),
+            None,
         );
         assert!(
             (raw_max.norms[Dimension::RecentSuccessThroughput.idx()] - 1.0).abs() < 1e-9,
@@ -2528,6 +2685,7 @@ mod tests {
             None,
             Some(&st_stable),
             Instant::now(),
+            None,
         );
         assert!(
             (raw_stable.norms[Dimension::FlapStability.idx()] - 1.0).abs() < 1e-9,
@@ -2547,6 +2705,7 @@ mod tests {
             None,
             Some(&st_flappy),
             Instant::now(),
+            None,
         );
         assert!(
             raw_flappy.norms[Dimension::FlapStability.idx()] <= 0.0,
@@ -2597,7 +2756,12 @@ mod tests {
             rs.update("zeta", "m", 500, false, None).await;
         }
 
-        let router = ScoredRouter::new(pool, &cfg, Arc::clone(&rs));
+        let router = ScoredRouter::new(
+            pool,
+            &cfg,
+            Arc::clone(&rs),
+            Arc::new(SessionAffinity::new()),
+        );
         let result = router
             .route_scored(Some("m"), None, &HashSet::new(), &RouteContext::default())
             .await
@@ -2648,7 +2812,12 @@ mod tests {
             rs.update("zzz-warm", "m", 2000, false, None).await;
         }
 
-        let router = ScoredRouter::new(pool, &cfg, Arc::clone(&rs));
+        let router = ScoredRouter::new(
+            pool,
+            &cfg,
+            Arc::clone(&rs),
+            Arc::new(SessionAffinity::new()),
+        );
         let result = router
             .route_scored(Some("m"), None, &HashSet::new(), &RouteContext::default())
             .await
@@ -2699,7 +2868,12 @@ mod tests {
         };
 
         let pool = pool_from_states(vec![n1, n2]);
-        let router = ScoredRouter::new(pool, &cfg, Arc::clone(&rs));
+        let router = ScoredRouter::new(
+            pool,
+            &cfg,
+            Arc::clone(&rs),
+            Arc::new(SessionAffinity::new()),
+        );
 
         let r1 = router
             .route_scored(Some("m"), None, &HashSet::new(), &RouteContext::default())

--- a/src/router/session_affinity.rs
+++ b/src/router/session_affinity.rs
@@ -1,0 +1,158 @@
+/// Session→backend affinity store for Phase-4 scoring dim 18 (`session_stickiness`).
+///
+/// Records which backend served a session's most recent turn so the scorer can
+/// prefer it on the next turn (prompt / KV-cache warmth). Writes happen
+/// **off-path** (post-request hook); reads happen **on-path** inside
+/// `ScoredRouter::route_scored` — one lookup per request, only when the request
+/// carries a session id (the `X-Herd-Session` header).
+use std::collections::BTreeMap;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+/// Soft ceiling on tracked sessions. Session ids come from an untrusted client
+/// header, so the map is bounded: at the ceiling the least-recently-used entry
+/// is evicted before inserting a new one — never a silent drop of the new write.
+/// An evicted session simply loses its affinity hint (dim 18 goes neutral).
+pub const MAX_SESSIONS_TRACKED: usize = 50_000;
+
+/// Shared, in-memory session→backend affinity map.
+///
+/// `BTreeMap` for deterministic iteration/eviction (house rule). Keyed by the
+/// owned session-id string.
+#[derive(Clone, Debug, Default)]
+pub struct SessionAffinity {
+    inner: Arc<RwLock<Inner>>,
+}
+
+#[derive(Debug, Default)]
+struct Inner {
+    map: BTreeMap<String, Entry>,
+    /// Global monotonic tick, bumped once per `record()`. Each entry records the
+    /// tick at its last write; the lowest-tick entry is the LRU eviction victim.
+    tick: u64,
+}
+
+#[derive(Clone, Debug)]
+struct Entry {
+    backend: String,
+    last_tick: u64,
+}
+
+impl SessionAffinity {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Record that `session_id`'s most recent turn was served by `backend`.
+    ///
+    /// Called on the **post-request hook** — off the scoring path. No-op for an
+    /// empty session id. Evicts the LRU session when the ceiling is reached.
+    pub async fn record(&self, session_id: &str, backend: &str) {
+        if session_id.is_empty() {
+            return;
+        }
+        let mut guard = self.inner.write().await;
+        let tick = guard.tick + 1;
+        guard.tick = tick;
+
+        // Evict the LRU session when a NEW session would exceed the ceiling
+        // (re-recording an existing session is free).
+        if !guard.map.contains_key(session_id) && guard.map.len() >= MAX_SESSIONS_TRACKED {
+            let lru = guard
+                .map
+                .iter()
+                .min_by_key(|(_, e)| e.last_tick)
+                .map(|(k, _)| k.clone());
+            if let Some(k) = lru {
+                guard.map.remove(&k);
+            }
+        }
+
+        guard.map.insert(
+            session_id.to_string(),
+            Entry {
+                backend: backend.to_string(),
+                last_tick: tick,
+            },
+        );
+    }
+
+    /// The backend that served this session's last turn, if known.
+    ///
+    /// Called once per request on the scoring path when a session id is present.
+    /// `None` for an empty/unknown session id → dim 18 is absent (neutral).
+    pub async fn get(&self, session_id: &str) -> Option<String> {
+        if session_id.is_empty() {
+            return None;
+        }
+        self.inner
+            .read()
+            .await
+            .map
+            .get(session_id)
+            .map(|e| e.backend.clone())
+    }
+
+    /// Number of tracked sessions. Primarily for tests.
+    pub async fn len(&self) -> usize {
+        self.inner.read().await.map.len()
+    }
+
+    /// True if no sessions are tracked yet.
+    pub async fn is_empty(&self) -> bool {
+        self.inner.read().await.map.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn record_then_get_returns_backend() {
+        let aff = SessionAffinity::new();
+        assert!(aff.is_empty().await);
+
+        aff.record("sess-1", "gpu1").await;
+        assert_eq!(aff.get("sess-1").await.as_deref(), Some("gpu1"));
+        assert_eq!(aff.len().await, 1);
+
+        // Re-recording updates the backend (latest turn wins).
+        aff.record("sess-1", "gpu2").await;
+        assert_eq!(aff.get("sess-1").await.as_deref(), Some("gpu2"));
+        assert_eq!(aff.len().await, 1, "re-record updates in place");
+    }
+
+    #[tokio::test]
+    async fn unknown_and_empty_session_return_none() {
+        let aff = SessionAffinity::new();
+        assert_eq!(aff.get("never-seen").await, None);
+
+        // Empty session id is a no-op on both write and read.
+        aff.record("", "gpu1").await;
+        assert!(aff.is_empty().await);
+        assert_eq!(aff.get("").await, None);
+    }
+
+    #[tokio::test]
+    async fn lru_eviction_at_ceiling() {
+        let aff = SessionAffinity::new();
+
+        // The first session recorded is the LRU victim once we exceed the cap.
+        aff.record("oldest", "gpu1").await;
+        for i in 0..MAX_SESSIONS_TRACKED {
+            aff.record(&format!("s{i}"), "gpu1").await;
+        }
+
+        assert_eq!(aff.len().await, MAX_SESSIONS_TRACKED, "capped at ceiling");
+        assert_eq!(
+            aff.get("oldest").await,
+            None,
+            "least-recently-used session evicted"
+        );
+
+        // Re-recording an existing session must not grow the map.
+        aff.record("s0", "gpu2").await;
+        assert_eq!(aff.len().await, MAX_SESSIONS_TRACKED, "re-record no growth");
+    }
+}

--- a/src/server.rs
+++ b/src/server.rs
@@ -5,6 +5,7 @@ use crate::api::{admin, agent, openai};
 use crate::backend::{BackendPool, HealthChecker, ModelDiscovery, ModelWarmer};
 use crate::config::{parse_duration, Config};
 use crate::router::routing_stats::RoutingStats;
+use crate::router::session_affinity::SessionAffinity;
 use crate::router::{create_router, Router};
 use anyhow::Result;
 use chrono::Timelike;
@@ -155,6 +156,9 @@ pub struct AppState {
     /// Phase-3 per-(backend,model) EWMA history store.
     /// Updated on the post-request hook; read by `ScoredRouter` on the scoring path.
     pub routing_stats: Arc<RoutingStats>,
+    /// Phase-4 session→backend affinity store (dim 18).
+    /// Updated on the post-request hook; read by `ScoredRouter` on the scoring path.
+    pub session_affinity: Arc<SessionAffinity>,
 }
 
 impl AppState {
@@ -256,12 +260,14 @@ impl AppState {
             }
         }
 
-        // Swap router (new router shares the same pool data and routing_stats store)
+        // Swap router (new router shares the same pool data, routing_stats, and
+        // session_affinity stores)
         let new_router = create_router(
             new_config.routing.strategy.clone(),
             (*self.pool).clone(),
             &new_config.routing,
             Arc::clone(&self.routing_stats),
+            Arc::clone(&self.session_affinity),
         );
         *self.router.write().await = new_router;
 
@@ -414,9 +420,11 @@ impl Server {
             }
         });
 
-        // Create the Phase-3 EWMA history store — shared by the router and the
-        // post-request hooks in openai.rs and server.rs.
+        // Create the Phase-3 EWMA history store and Phase-4 session-affinity store
+        // — both shared by the router and the post-request hooks in openai.rs and
+        // server.rs.
         let routing_stats = Arc::new(RoutingStats::new());
+        let session_affinity = Arc::new(SessionAffinity::new());
 
         // Create router
         let router = create_router(
@@ -424,6 +432,7 @@ impl Server {
             pool.clone(),
             &self.config.routing,
             Arc::clone(&routing_stats),
+            Arc::clone(&session_affinity),
         );
 
         // Wrap in Arc
@@ -522,6 +531,7 @@ impl Server {
             routing_retry_count: Arc::new(AtomicU32::new(self.config.routing.retry_count)),
             config_path: self.config_path.clone(),
             routing_stats,
+            session_affinity,
         };
 
         // Start session reaper and audit log cleanup (every 5 minutes)
@@ -1448,11 +1458,19 @@ async fn proxy_handler(
         }
     }
 
+    // Session id (X-Herd-Session) for the scored router's dim 18 stickiness.
+    let session_id: Option<String> = headers
+        .get("x-herd-session")
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.to_string())
+        .filter(|s| !s.is_empty());
+
     // Estimate prompt size once (pre-routing) for the scored router's dim 3.
     // No-op for the other routing strategies (their route_scored is ctx-blind).
     let route_ctx = crate::router::RouteContext {
         prompt_tokens: crate::api::openai::estimate_prompt_tokens(&body_bytes),
         requested_ctx_len: None,
+        session_id: session_id.clone(),
     };
 
     for _ in 0..=state.retry_count() {
@@ -1577,6 +1595,7 @@ async fn proxy_handler(
         auto_tier: Option<String>,
         auto_capability: Option<String>,
         auto_model: Option<String>,
+        session_id: Option<String>,
         start: std::time::Instant,
     }
 
@@ -1630,6 +1649,10 @@ async fn proxy_handler(
             if log.status != "error" {
                 if let Some(m) = self.model_name.as_deref() {
                     self.state.pool.record_served(&log.backend, m).await;
+                }
+                // Phase-4 dim 18: record this session's backend for next-turn stickiness.
+                if let Some(sid) = self.session_id.as_deref() {
+                    self.state.session_affinity.record(sid, &log.backend).await;
                 }
             }
 
@@ -1796,6 +1819,7 @@ async fn proxy_handler(
                     auto_tier: auto_tier.clone(),
                     auto_capability: auto_capability.clone(),
                     auto_model: auto_model.clone(),
+                    session_id: session_id.clone(),
                     start,
                 };
                 tokio::spawn(async move {
@@ -1829,6 +1853,7 @@ async fn proxy_handler(
                     auto_tier,
                     auto_capability,
                     auto_model,
+                    session_id: session_id.clone(),
                     start,
                 };
                 ctx.log_and_record(status, usage).await;
@@ -1853,6 +1878,7 @@ async fn proxy_handler(
                 auto_tier,
                 auto_capability,
                 auto_model,
+                session_id: session_id.clone(),
                 start,
             };
             ctx.log_and_record(status, TokenUsage::default()).await;
@@ -2262,6 +2288,7 @@ async fn skills_handler(
         },
         "headers": {
             "X-Herd-Tags": "Comma-separated tags to target specific backends (e.g. 'gpu,fast')",
+            "X-Herd-Session": "Opaque session id; the scored router prefers the backend that served this session's last turn (prompt-cache warmth)",
             "X-Request-Id": "Correlation ID — send your own or Herd generates a UUID v4",
             "X-API-Key": "Required for admin endpoints only",
             "Authorization: Bearer <HERD_AGENT_TOKEN>": "Required for /api/internal/nodes/* endpoints"
@@ -2365,11 +2392,13 @@ mod tests {
             parse_duration(&initial.circuit_breaker.recovery_time).unwrap(),
         ));
         let routing_stats = Arc::new(RoutingStats::new());
+        let session_affinity = Arc::new(SessionAffinity::new());
         let router = create_router(
             initial.routing.strategy.clone(),
             (*pool).clone(),
             &initial.routing,
             Arc::clone(&routing_stats),
+            Arc::clone(&session_affinity),
         );
 
         let state = AppState {
@@ -2416,6 +2445,7 @@ mod tests {
             routing_retry_count: Arc::new(AtomicU32::new(1)),
             config_path: Some(temp_path.clone()),
             routing_stats,
+            session_affinity,
         };
 
         let message = state.reload_config().await.unwrap();

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -119,8 +119,19 @@ Still open (resolve at each slice's architect pass, not blocking Slice A):
       formula/absence direct, e2e recent-backend-wins, pool `record_served`). Build ✓, clippy
       `-D warnings` ✓, fmt ✓, **lib 544→547**, no lib unwrap. Docs: herd.yaml.example weight +
       spec Slice-B note. **Awaiting: commit (user said local-only for the branch).**
-- [ ] SLICE C (dim 18) — session stickiness, resolve Q-C1 first.
-- [ ] SLICE D (dim 22) — gpu-class affinity, blocked on Q-D1.
+- [x] SLICE B follow-up — `last_served` LRU cap (`MAX_LAST_SERVED=256`), commit `56c1544`.
+- [x] SLICE C (dim 18 `session_stickiness`) — Q-C1 = **all proxy traffic**. New
+      `router/session_affinity.rs` (`SessionAffinity`: session_id→backend, LRU 50k, mirrors
+      `RoutingStats`), injected into `ScoredRouter` + `create_router` (all call sites incl. 2
+      integration tests). `RouteContext.session_id` ← `X-Herd-Session` header in both proxy
+      paths; write-back on all 3 post-request hooks. `compute_raw` gains `sticky_backend:
+      Option<&str>` (resolved once/call); dim 18 = 1.0 match / 0.5 else, absent when no prior
+      backend. Opt-in. 5 tests (3 store, 2 scored). Build ✓, clippy `-D warnings` ✓, fmt ✓,
+      **lib 548→553**, integration green. Docs: skills.md X-Herd-Session, header JSON,
+      herd.yaml.example weight, spec Slice-C note.
+- [ ] SLICE D (dim 22 `gpu_class_affinity`) — Q-D1 = **infer from model size**. Parse param
+      count from model name → class tier; thread candidate gpu_model to BackendState; norm
+      1.0 exact / 0.7 same-vendor / 0.5 unknown. **NEXT.**
 
 ---
 

--- a/tests/fleet_routing.rs
+++ b/tests/fleet_routing.rs
@@ -44,7 +44,7 @@ use herd::{
     metrics::Metrics,
     providers::{cost_db::CostDb, rate_limit::ProviderRateLimiter},
     rate_limit::RateLimiter,
-    router::{create_router, routing_stats::RoutingStats},
+    router::{create_router, routing_stats::RoutingStats, session_affinity::SessionAffinity},
 };
 use rusqlite::Connection;
 use serde_json::{json, Value};
@@ -170,11 +170,13 @@ struct Gateway {
 
 fn build_state(registry: Arc<NodeRegistry>, pool: Arc<BackendPool>, config: Config) -> AppState {
     let routing_stats = Arc::new(RoutingStats::new());
+    let session_affinity = Arc::new(SessionAffinity::new());
     let router = create_router(
         config.routing.strategy.clone(),
         (*pool).clone(),
         &config.routing,
         Arc::clone(&routing_stats),
+        Arc::clone(&session_affinity),
     );
     AppState {
         pool,
@@ -216,6 +218,7 @@ fn build_state(registry: Arc<NodeRegistry>, pool: Arc<BackendPool>, config: Conf
         routing_retry_count: Arc::new(AtomicU32::new(0)),
         config_path: None,
         routing_stats,
+        session_affinity,
     }
 }
 

--- a/tests/frontier_escalation.rs
+++ b/tests/frontier_escalation.rs
@@ -22,7 +22,7 @@ use herd::{
     metrics::Metrics,
     nodes::{NodeDb, NodeRegistry},
     rate_limit::RateLimiter,
-    router::{create_router, routing_stats::RoutingStats},
+    router::{create_router, routing_stats::RoutingStats, session_affinity::SessionAffinity},
 };
 use rusqlite::Connection;
 use std::sync::Arc;
@@ -102,11 +102,13 @@ fn test_state(config: Config) -> AppState {
         std::time::Duration::from_secs(30),
     );
     let routing_stats = Arc::new(RoutingStats::new());
+    let session_affinity = Arc::new(SessionAffinity::new());
     let router = create_router(
         config.routing.strategy.clone(),
         pool.clone(),
         &config.routing,
         Arc::clone(&routing_stats),
+        Arc::clone(&session_affinity),
     );
 
     AppState {
@@ -145,6 +147,7 @@ fn test_state(config: Config) -> AppState {
         routing_retry_count: Arc::new(std::sync::atomic::AtomicU32::new(1)),
         config_path: None,
         routing_stats,
+        session_affinity,
     }
 }
 


### PR DESCRIPTION
Prefer the backend that served a conversation's last turn. **All-proxy scope**: driven by the `X-Herd-Session` request header, not limited to agent sessions.

- New `src/router/session_affinity.rs`: `SessionAffinity` store (session_id→backend, BTreeMap, LRU-bounded 50k).
- `RouteContext.session_id` ← `X-Herd-Session` in both proxy paths; write-back on all 3 post-request hooks.
- `ScoredRouter` + `create_router` thread `Arc<SessionAffinity>` (incl. 2 integration tests). `compute_raw` gains `sticky_backend`; dim 18 = 1.0 match / 0.5 else, absent for unknown/new session. Opt-in.
- 5 tests (3 store, 2 scored). lib → **553**. Docs: skills.md X-Herd-Session + header reference.

**Base:** Slice B branch (stacked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)