### PR TITLE
feat(router): Phase 4 Slice D — dim 22 (gpu_class_affinity)

### DIFF
--- a/docs/specs/smart-routing-scorer-spec.md
+++ b/docs/specs/smart-routing-scorer-spec.md
@@ -700,10 +700,18 @@ Landing incrementally by data-source cost (Slice A → D):
 > once per call); dim 18 present iff a prior backend is known for the session → the matching
 > candidate scores `1.0`, others `0.5`; unknown/new session → absent. Opt-in (`w_zero`).
 >
-> **Remaining:** dim 22 (`gpu_class_affinity`, Slice D — preferred class inferred from model
-> size, Q-D1). dim 21 (`rpc_shard_capability`) is **deferred to v1.3** — inert until a
+> **Slice D — dim 22 `gpu_class_affinity` (capability).** Preferred GPU tier inferred from
+> the model's parameter count (Q-D1): `>=30B` → HighEnd, `8–30B` → Mid, `<8B` → Entry. The
+> candidate's GPU tier comes from `gpu_model` (threaded from `AgentCapabilities` to
+> `BackendState` via `pool_sync`, dim-12 pattern), classified by a substring card list. Norm
+> is tier *distance*: exact `1.0`, one off `0.7`, two off `0.5`; either side unknown → absent.
+> Distinct from VRAM dims (4/13) — those check FIT, this checks appropriate placement. Opt-in.
+> The size thresholds and GPU card list are deployment-tunable.
+>
+> **Remaining:** dim 21 (`rpc_shard_capability`) is **deferred to v1.3** — inert until a
 > "request needs sharding" signal exists (Q6 drops a uniform-0.5 dim every call), which
-> depends on the llama.cpp RPC tensor-sharding integration.
+> depends on the llama.cpp RPC tensor-sharding integration. **Phase 4 is otherwise complete:
+> 22 of 23 dims live.**
 
 ---
 

--- a/herd.yaml.example
+++ b/herd.yaml.example
@@ -82,6 +82,8 @@ routing:
   #                                  # (prompt/KV-cache warmth; tracked automatically)
   #     session_stickiness: 3.0      # keep a conversation on its last backend
   #                                  # (needs the X-Herd-Session request header)
+  #     gpu_class_affinity: 1.0      # match model size to GPU class (small models
+  #                                  # to small GPUs; needs agent gpu_model telemetry)
 
   # === AUTO MODE ===
   # LLM-based request classification. When model is "auto" or omitted, Herd calls

--- a/src/backend/pool.rs
+++ b/src/backend/pool.rs
@@ -33,6 +33,10 @@ pub struct BackendState {
     pub vram_free_mb: Option<u64>,
     /// Max concurrent requests the backend will accept. None — no source field yet (future phase).
     pub max_concurrent: Option<u32>,
+    /// GPU model string from agent telemetry (e.g. "NVIDIA GeForce RTX 5090").
+    /// Feeds the scored router's `gpu_class_affinity` dimension (dim 22). None for
+    /// static/enrolled backends or agents that don't report a GPU → dim absent.
+    pub gpu_model: Option<String>,
     /// Per-model last-served wall-clock instant (model name → when this backend
     /// last successfully served or warmed it). Feeds the scored router's
     /// `warm_model_recency` dimension (dim 23). Empty until the warmer or a
@@ -99,6 +103,7 @@ impl BackendPool {
                 ttft_p50_ms: None,
                 vram_free_mb: None,
                 max_concurrent: None,
+                gpu_model: None,
                 last_served: BTreeMap::new(),
             })
             .collect();
@@ -348,6 +353,7 @@ impl BackendPool {
         ttft_p50_ms: Option<u32>,
         vram_free_mb: u64,
         max_concurrent: Option<u32>,
+        gpu_model: Option<String>,
     ) {
         let mut backends = self.backends.write().await;
         if let Some(backend) = backends.iter_mut().find(|b| b.config.name == name) {
@@ -355,6 +361,7 @@ impl BackendPool {
             backend.ttft_p50_ms = ttft_p50_ms;
             backend.vram_free_mb = Some(vram_free_mb);
             backend.max_concurrent = max_concurrent;
+            backend.gpu_model = gpu_model;
         }
     }
 
@@ -375,6 +382,7 @@ impl BackendPool {
             ttft_p50_ms: None,
             vram_free_mb: None,
             max_concurrent: None,
+            gpu_model: None,
             last_served: BTreeMap::new(),
         });
     }

--- a/src/nodes/pool_sync.rs
+++ b/src/nodes/pool_sync.rs
@@ -89,6 +89,7 @@ impl AgentPoolSync {
                 st.ttft_p50_ms = caps.ttft_p50_ms;
                 st.vram_free_mb = Some(caps.vram_free_mb);
                 st.max_concurrent = caps.max_concurrent;
+                st.gpu_model = caps.gpu_model.clone();
                 pool.update(st).await;
             } else {
                 // New entry: add, then set models, VRAM, and live telemetry.
@@ -103,6 +104,7 @@ impl AgentPoolSync {
                     caps.ttft_p50_ms,
                     caps.vram_free_mb,
                     caps.max_concurrent,
+                    caps.gpu_model.clone(),
                 )
                 .await;
                 tracing::info!("Added agent backend {} to pool ({})", name, caps.address);

--- a/src/router/scored.rs
+++ b/src/router/scored.rs
@@ -4,10 +4,11 @@
 /// plus dims 10–13 (Phase 2 — live load & latency from agent telemetry; dim 11
 /// `ttft_p50` reads agent caps but the agent does not yet measure it). Dims 14–17
 /// (Phase 3) read per-(backend,model) EWMA history from `RoutingStats`.
-/// Phase 4 (policy/affinity) is landing incrementally: dims 18 (`session_stickiness`,
-/// from the `SessionAffinity` store), 19 (`network_locality`), 20 (`power_cost`,
-/// config-only) and 23 (`warm_model_recency`, from per-(backend,model) last-served
-/// time on `BackendState`) are active; dims 21, 22 remain absent until their slices.
+/// Phase 4 (policy/affinity): dims 18 (`session_stickiness`, from the
+/// `SessionAffinity` store), 19 (`network_locality`), 20 (`power_cost`, config),
+/// 22 (`gpu_class_affinity`, model-size→GPU-tier) and 23 (`warm_model_recency`,
+/// last-served time on `BackendState`) are active. Only dim 21
+/// (`rpc_shard_capability`) remains — deferred to v1.3 with the llama.cpp RPC work.
 use crate::backend::{pool::filter_healthy, BackendPool};
 use crate::config::{BackendType, ModelGate, ScoredConfig, ScoredWeights};
 use crate::router::routing_stats::{BackendModelStats, RoutingStats, MIN_SAMPLES};
@@ -50,6 +51,90 @@ const SCORE_SCALE: f64 = 1_000_000.0;
 // Using the canonical values from routing_stats rather than duplicating them.
 use crate::router::routing_stats::{FLAP_REF, LAT_REF, TPS_REF};
 
+// ── GPU-class affinity (dim 22) ──────────────────────────────────────────────
+
+/// Coarse GPU capability tier. Ordered: `Entry` < `Mid` < `HighEnd`. dim 22
+/// scores by the tier *distance* between what a model wants and what a backend
+/// has, so the exact tier values only matter relative to each other.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum GpuClass {
+    Entry = 0,
+    Mid = 1,
+    HighEnd = 2,
+}
+
+/// Infer the GPU tier a model "wants" from the parameter count in its name.
+/// `>= 30B` → HighEnd, `8B..30B` → Mid, `< 8B` → Entry. `None` when no size token
+/// is parseable (→ dim 22 absent for that request, neutral).
+///
+/// NOTE: the size→tier thresholds here are a deployment judgment — tune them to
+/// your fleet's GPUs.
+fn model_gpu_class(model: &str) -> Option<GpuClass> {
+    let b = parse_param_billions(model)?;
+    Some(if b >= 30.0 {
+        GpuClass::HighEnd
+    } else if b >= 8.0 {
+        GpuClass::Mid
+    } else {
+        GpuClass::Entry
+    })
+}
+
+/// Parse a parameter count in billions from a model name: the last `<number>b`
+/// token (e.g. `"qwen2.5-coder:32b"` → `32.0`, `"deepseek-r1:1.5b"` → `1.5`,
+/// `"qwen3-235b-a22b"` → `22.0` active params). `None` when absent (e.g. frontier
+/// names like `"gpt-4"`).
+fn parse_param_billions(model: &str) -> Option<f64> {
+    let s = model.to_ascii_lowercase();
+    let b = s.as_bytes();
+    let mut best = None;
+    let mut i = 0;
+    while i < b.len() {
+        if b[i].is_ascii_digit() {
+            let start = i;
+            while i < b.len() && (b[i].is_ascii_digit() || b[i] == b'.') {
+                i += 1;
+            }
+            // A number immediately followed by 'b' is a parameter-count token.
+            if i < b.len() && b[i] == b'b' {
+                if let Ok(v) = s[start..i].parse::<f64>() {
+                    best = Some(v); // keep the last match
+                }
+            }
+        } else {
+            i += 1;
+        }
+    }
+    best
+}
+
+/// Classify a backend GPU into a tier from its model string (substring match on
+/// common cards). `None` when unrecognized → dim 22 absent (never a penalty for
+/// an unknown GPU). NOTE: this card list is fleet-specific — extend it for the
+/// hardware you actually run.
+fn backend_gpu_class(gpu_model: &str) -> Option<GpuClass> {
+    let g = gpu_model.to_ascii_lowercase();
+    const HIGH_END: &[&str] = &[
+        "5090", "4090", "3090", "a100", "h100", "h200", "a6000", "6000 ada", "l40", "mi300",
+        "mi250",
+    ];
+    const MID: &[&str] = &[
+        "5080", "5070", "4080", "4070", "3080", "3070", "7900", "a5000", "a4000",
+    ];
+    const ENTRY: &[&str] = &[
+        "5060", "4060", "4050", "3060", "3050", "2060", "1660", "1650",
+    ];
+    if HIGH_END.iter().any(|k| g.contains(k)) {
+        Some(GpuClass::HighEnd)
+    } else if MID.iter().any(|k| g.contains(k)) {
+        Some(GpuClass::Mid)
+    } else if ENTRY.iter().any(|k| g.contains(k)) {
+        Some(GpuClass::Entry)
+    } else {
+        None
+    }
+}
+
 // ── Dimension catalog ────────────────────────────────────────────────────────
 
 /// Fixed-order catalog of all 23 dimensions (catalog order = array index).
@@ -76,7 +161,7 @@ pub enum Dimension {
     RecentErrorRate = 14,
     RecentSuccessThroughput = 15,
     FlapStability = 16,
-    // Phase 4 — dims 18/19/20/23 active; 21, 22 absent until their slices
+    // Phase 4 — dims 18/19/20/22/23 active; only dim 21 absent (deferred to v1.3)
     SessionStickiness = 17,
     NetworkLocality = 18,
     PowerCost = 19,
@@ -510,8 +595,29 @@ fn compute_raw(
         norms[dim] = if last == b.config.name { 1.0 } else { 0.5 };
     }
 
-    // ── Dims 21, 22: Phase 4 — absent until their slices ─────────────────────
-    // rpc_shard_capability (21), gpu_class_affinity (22): sources None/absent →
+    // ── Dim 22: gpu_class_affinity — Phase 4 ─────────────────────────────────
+    // Match the model's demanded GPU tier (inferred from its parameter count)
+    // against this candidate's GPU tier. Present iff BOTH are known: exact tier →
+    // 1.0, one tier off → 0.7, two off → 0.5. Either unknown → absent (neutral).
+    // Distinct from VRAM dims (4/13): those measure whether a model FITS; this
+    // measures whether the placement is APPROPRIATE (don't tie up a 5090 with a
+    // 1B model when an entry GPU would do).
+    if let (Some(have), Some(want)) = (
+        b.gpu_model.as_deref().and_then(backend_gpu_class),
+        model.and_then(model_gpu_class),
+    ) {
+        let dim = Dimension::GpuClassAffinity.idx();
+        present0[dim] = true;
+        let dist = (have as i32 - want as i32).unsigned_abs();
+        norms[dim] = match dist {
+            0 => 1.0,
+            1 => 0.7,
+            _ => 0.5,
+        };
+    }
+
+    // ── Dim 21: rpc_shard_capability — Phase 4, deferred to v1.3 ──────────────
+    // Inert until a "request needs sharding" signal exists; source absent →
     // present0 stays false.
 
     CandidateRaw { norms, present0 }
@@ -887,6 +993,7 @@ mod tests {
             ttft_p50_ms: None,
             vram_free_mb: None,
             max_concurrent: None,
+            gpu_model: None,
             last_served: std::collections::BTreeMap::new(),
         }
     }
@@ -2269,6 +2376,117 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(result.name, "zeta", "session's last backend must win");
+    }
+
+    // ── Phase 4 Slice D: gpu_class_affinity (dim 22) ─────────────────────────
+
+    #[test]
+    fn parse_param_billions_extracts_size() {
+        assert_eq!(parse_param_billions("qwen2.5-coder:32b"), Some(32.0));
+        assert_eq!(parse_param_billions("llama-3-8b"), Some(8.0));
+        assert_eq!(parse_param_billions("deepseek-r1:1.5b"), Some(1.5));
+        // MoE name → last <num>b token is the active-param count.
+        assert_eq!(parse_param_billions("qwen3-235b-a22b"), Some(22.0));
+        // No size token (frontier-style names).
+        assert_eq!(parse_param_billions("gpt-4"), None);
+        assert_eq!(parse_param_billions("claude-opus"), None);
+    }
+
+    #[test]
+    fn gpu_class_mappings() {
+        assert!(matches!(model_gpu_class("x:70b"), Some(GpuClass::HighEnd)));
+        assert!(matches!(model_gpu_class("x:13b"), Some(GpuClass::Mid)));
+        assert!(matches!(model_gpu_class("x:7b"), Some(GpuClass::Entry)));
+        assert!(model_gpu_class("gpt-4").is_none());
+
+        assert!(matches!(
+            backend_gpu_class("NVIDIA GeForce RTX 5090"),
+            Some(GpuClass::HighEnd)
+        ));
+        assert!(matches!(backend_gpu_class("RTX 4070"), Some(GpuClass::Mid)));
+        assert!(matches!(
+            backend_gpu_class("RTX 4060"),
+            Some(GpuClass::Entry)
+        ));
+        assert!(backend_gpu_class("Some Mystery GPU").is_none());
+    }
+
+    /// dim 22 — tier-distance norm: exact 1.0, one off 0.7, two off 0.5; absent
+    /// when the GPU or the model size is unknown. Tested directly on `compute_raw`.
+    #[test]
+    fn gpu_class_affinity_norm_and_absence_in_compute_raw() {
+        let dim = Dimension::GpuClassAffinity.idx();
+        let now = Instant::now();
+        let with_gpu = |g: &str| {
+            let mut s = make_state("b", 50, true);
+            s.gpu_model = Some(g.to_string());
+            s
+        };
+        let raw_for = |s: &BackendState, model: &str| {
+            compute_raw(
+                s,
+                Some(model),
+                None,
+                false,
+                None,
+                50,
+                50,
+                None,
+                None,
+                now,
+                None,
+            )
+        };
+
+        // 70B (HighEnd) on a 5090 (HighEnd) → exact → 1.0.
+        let raw = raw_for(&with_gpu("RTX 5090"), "llama:70b");
+        assert!(raw.present0[dim]);
+        assert!((raw.norms[dim] - 1.0).abs() < 1e-9, "exact tier → 1.0");
+
+        // 70B (HighEnd) on a 4070 (Mid) → one tier off → 0.7.
+        let raw = raw_for(&with_gpu("RTX 4070"), "llama:70b");
+        assert!((raw.norms[dim] - 0.7).abs() < 1e-9, "one tier off → 0.7");
+
+        // 70B (HighEnd) on a 4060 (Entry) → two tiers off → 0.5.
+        let raw = raw_for(&with_gpu("RTX 4060"), "llama:70b");
+        assert!((raw.norms[dim] - 0.5).abs() < 1e-9, "two tiers off → 0.5");
+
+        // Unknown GPU / unparseable size / no gpu_model → absent.
+        assert!(!raw_for(&with_gpu("Mystery GPU"), "llama:70b").present0[dim]);
+        assert!(!raw_for(&with_gpu("RTX 5090"), "gpt-4").present0[dim]);
+        assert!(!raw_for(&make_state("b", 50, true), "llama:70b").present0[dim]);
+    }
+
+    /// dim 22 end-to-end — a small model prefers the appropriately-sized GPU.
+    /// Anti-trivial: the entry-class node is "zeta", the high-end node "alpha"; a
+    /// "zeta" win proves dim 22 steered the 7B model to the entry GPU (and kept
+    /// the 5090 free). Weight opt-in.
+    #[tokio::test]
+    async fn gpu_class_affinity_best_match_wins() {
+        let mut big = make_state("alpha", 50, true);
+        let mut small = make_state("zeta", 50, true);
+        big.models = vec!["m:7b".to_string()];
+        small.models = vec!["m:7b".to_string()];
+        big.gpu_model = Some("RTX 5090".to_string()); // HighEnd
+        small.gpu_model = Some("RTX 4060".to_string()); // Entry
+
+        let mut cfg = ScoredConfig::default();
+        cfg.weights.gpu_class_affinity = 100.0;
+        let pool = pool_from_states(vec![big, small]);
+        let router = make_router(pool, &cfg);
+        let result = router
+            .route_scored(
+                Some("m:7b"),
+                None,
+                &HashSet::new(),
+                &RouteContext::default(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            result.name, "zeta",
+            "7B model should prefer the entry-class GPU"
+        );
     }
 
     // ── Phase 2: prompt_size_vs_capacity (dim 3) ─────────────────────────────

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -129,9 +129,16 @@ Still open (resolve at each slice's architect pass, not blocking Slice A):
       backend. Opt-in. 5 tests (3 store, 2 scored). Build ✓, clippy `-D warnings` ✓, fmt ✓,
       **lib 548→553**, integration green. Docs: skills.md X-Herd-Session, header JSON,
       herd.yaml.example weight, spec Slice-C note.
-- [ ] SLICE D (dim 22 `gpu_class_affinity`) — Q-D1 = **infer from model size**. Parse param
-      count from model name → class tier; thread candidate gpu_model to BackendState; norm
-      1.0 exact / 0.7 same-vendor / 0.5 unknown. **NEXT.**
+- [x] SLICE D (dim 22 `gpu_class_affinity`) — Q-D1 = **infer from model size**. `GpuClass`
+      tiers (Entry/Mid/HighEnd); `model_gpu_class` (param count: ≥30B HighEnd / 8–30B Mid /
+      <8B Entry) + `backend_gpu_class` (substring card list); `parse_param_billions` (last
+      `<num>b` token). `BackendState.gpu_model` threaded from `AgentCapabilities` via
+      `set_agent_telemetry` + `pool_sync` both branches. dim 22 norm = tier distance (0→1.0,
+      1→0.7, 2→0.5), absent when either side unknown. Opt-in. 4 tests. Build ✓, clippy
+      `-D warnings` ✓, fmt ✓, **lib 553→557**, integration green. Docs: herd.yaml.example
+      weight, spec Slice-D note. **Tunable:** size thresholds + GPU card list are fleet-specific.
+
+### PHASE 4 COMPLETE — 22/23 dims live. Only dim 21 (`rpc_shard_capability`) deferred to v1.3.
 
 ---
 


### PR DESCRIPTION
Steer a model to an appropriately-sized GPU (small models → small GPUs; keep big GPUs free for big models). **Q-D1: infer demanded tier from model param count.**

- `GpuClass` tiers; `model_gpu_class` (`≥30B` HighEnd / `8-30B` Mid / `<8B` Entry via `parse_param_billions`); `backend_gpu_class` (substring card list).
- `BackendState.gpu_model` threaded from `AgentCapabilities` via `set_agent_telemetry` + `pool_sync`. dim 22 norm = tier distance (exact 1.0 / one off 0.7 / two off 0.5); absent when unknown. Distinct from VRAM dims (fit vs placement). Opt-in.
- 4 tests. lib → **557**. Size thresholds + GPU card list are deployment-tunable.

**Base:** Slice C branch (stacked). **Completes Phase 4 — 22/23 dims live** (dim 21 deferred to v1.3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)