### PR TITLE
refactor(router): dim 22 GPU tier by total VRAM, not card-name list

### DIFF
--- a/docs/specs/smart-routing-scorer-spec.md
+++ b/docs/specs/smart-routing-scorer-spec.md
@@ -702,11 +702,14 @@ Landing incrementally by data-source cost (Slice A → D):
 >
 > **Slice D — dim 22 `gpu_class_affinity` (capability).** Preferred GPU tier inferred from
 > the model's parameter count (Q-D1): `>=30B` → HighEnd, `8–30B` → Mid, `<8B` → Entry. The
-> candidate's GPU tier comes from `gpu_model` (threaded from `AgentCapabilities` to
-> `BackendState` via `pool_sync`, dim-12 pattern), classified by a substring card list. Norm
-> is tier *distance*: exact `1.0`, one off `0.7`, two off `0.5`; either side unknown → absent.
-> Distinct from VRAM dims (4/13) — those check FIT, this checks appropriate placement. Opt-in.
-> The size thresholds and GPU card list are deployment-tunable.
+> candidate's GPU tier comes from **total VRAM** (`BackendState.vram_total_mb`, falling back to
+> gpu-hot's `memory_total`): `>=24GB` → HighEnd, `12–24GB` → Mid, `<12GB` → Entry. VRAM chosen
+> over a GPU-name list (post-merge tuning): self-maintaining, and correctly tiers cut-down SKUs
+> a name match would miss (a "4070 Laptop" @ 8GB is Entry, not Mid). Norm is tier *distance*:
+> exact `1.0`, one off `0.7`, two off `0.5`; either side unknown → absent. Uses TOTAL VRAM
+> (capability), distinct from the FREE-VRAM dims (4/13 check FIT). Opt-in; only discriminates on
+> a heterogeneous fleet (uniform GPU tiers self-cancel via the Q6 pre-pass). Both the model-size
+> and VRAM thresholds are deployment-tunable.
 >
 > **Remaining:** dim 21 (`rpc_shard_capability`) is **deferred to v1.3** — inert until a
 > "request needs sharding" signal exists (Q6 drops a uniform-0.5 dim every call), which

--- a/herd.yaml.example
+++ b/herd.yaml.example
@@ -82,8 +82,9 @@ routing:
   #                                  # (prompt/KV-cache warmth; tracked automatically)
   #     session_stickiness: 3.0      # keep a conversation on its last backend
   #                                  # (needs the X-Herd-Session request header)
-  #     gpu_class_affinity: 1.0      # match model size to GPU class (small models
-  #                                  # to small GPUs; needs agent gpu_model telemetry)
+  #     gpu_class_affinity: 1.0      # match model size to GPU class by total VRAM
+  #                                  # (small models to small GPUs; heterogeneous
+  #                                  # fleets only — uniform fleets self-cancel)
 
   # === AUTO MODE ===
   # LLM-based request classification. When model is "auto" or omitted, Herd calls

--- a/src/backend/pool.rs
+++ b/src/backend/pool.rs
@@ -33,10 +33,6 @@ pub struct BackendState {
     pub vram_free_mb: Option<u64>,
     /// Max concurrent requests the backend will accept. None — no source field yet (future phase).
     pub max_concurrent: Option<u32>,
-    /// GPU model string from agent telemetry (e.g. "NVIDIA GeForce RTX 5090").
-    /// Feeds the scored router's `gpu_class_affinity` dimension (dim 22). None for
-    /// static/enrolled backends or agents that don't report a GPU → dim absent.
-    pub gpu_model: Option<String>,
     /// Per-model last-served wall-clock instant (model name → when this backend
     /// last successfully served or warmed it). Feeds the scored router's
     /// `warm_model_recency` dimension (dim 23). Empty until the warmer or a
@@ -103,7 +99,6 @@ impl BackendPool {
                 ttft_p50_ms: None,
                 vram_free_mb: None,
                 max_concurrent: None,
-                gpu_model: None,
                 last_served: BTreeMap::new(),
             })
             .collect();
@@ -353,7 +348,6 @@ impl BackendPool {
         ttft_p50_ms: Option<u32>,
         vram_free_mb: u64,
         max_concurrent: Option<u32>,
-        gpu_model: Option<String>,
     ) {
         let mut backends = self.backends.write().await;
         if let Some(backend) = backends.iter_mut().find(|b| b.config.name == name) {
@@ -361,7 +355,6 @@ impl BackendPool {
             backend.ttft_p50_ms = ttft_p50_ms;
             backend.vram_free_mb = Some(vram_free_mb);
             backend.max_concurrent = max_concurrent;
-            backend.gpu_model = gpu_model;
         }
     }
 
@@ -382,7 +375,6 @@ impl BackendPool {
             ttft_p50_ms: None,
             vram_free_mb: None,
             max_concurrent: None,
-            gpu_model: None,
             last_served: BTreeMap::new(),
         });
     }

--- a/src/nodes/pool_sync.rs
+++ b/src/nodes/pool_sync.rs
@@ -89,7 +89,6 @@ impl AgentPoolSync {
                 st.ttft_p50_ms = caps.ttft_p50_ms;
                 st.vram_free_mb = Some(caps.vram_free_mb);
                 st.max_concurrent = caps.max_concurrent;
-                st.gpu_model = caps.gpu_model.clone();
                 pool.update(st).await;
             } else {
                 // New entry: add, then set models, VRAM, and live telemetry.
@@ -104,7 +103,6 @@ impl AgentPoolSync {
                     caps.ttft_p50_ms,
                     caps.vram_free_mb,
                     caps.max_concurrent,
-                    caps.gpu_model.clone(),
                 )
                 .await;
                 tracing::info!("Added agent backend {} to pool ({})", name, caps.address);

--- a/src/router/scored.rs
+++ b/src/router/scored.rs
@@ -108,30 +108,18 @@ fn parse_param_billions(model: &str) -> Option<f64> {
     best
 }
 
-/// Classify a backend GPU into a tier from its model string (substring match on
-/// common cards). `None` when unrecognized → dim 22 absent (never a penalty for
-/// an unknown GPU). NOTE: this card list is fleet-specific — extend it for the
-/// hardware you actually run.
-fn backend_gpu_class(gpu_model: &str) -> Option<GpuClass> {
-    let g = gpu_model.to_ascii_lowercase();
-    const HIGH_END: &[&str] = &[
-        "5090", "4090", "3090", "a100", "h100", "h200", "a6000", "6000 ada", "l40", "mi300",
-        "mi250",
-    ];
-    const MID: &[&str] = &[
-        "5080", "5070", "4080", "4070", "3080", "3070", "7900", "a5000", "a4000",
-    ];
-    const ENTRY: &[&str] = &[
-        "5060", "4060", "4050", "3060", "3050", "2060", "1660", "1650",
-    ];
-    if HIGH_END.iter().any(|k| g.contains(k)) {
-        Some(GpuClass::HighEnd)
-    } else if MID.iter().any(|k| g.contains(k)) {
-        Some(GpuClass::Mid)
-    } else if ENTRY.iter().any(|k| g.contains(k)) {
-        Some(GpuClass::Entry)
+/// Classify a backend GPU tier from its **total VRAM** (MB): `>= 24GB` → HighEnd,
+/// `12–24GB` → Mid, `< 12GB` → Entry. Total VRAM is the objective capability
+/// signal — self-maintaining (no per-card upkeep) and immune to SKU-name
+/// ambiguity (a "4070 Laptop" @ 8GB correctly tiers Entry, not Mid). Thresholds
+/// are deployment-tunable; defaults assume a consumer/prosumer NVIDIA fleet.
+fn vram_gpu_class(vram_mb: u64) -> GpuClass {
+    if vram_mb >= 24_000 {
+        GpuClass::HighEnd
+    } else if vram_mb >= 12_000 {
+        GpuClass::Mid
     } else {
-        None
+        GpuClass::Entry
     }
 }
 
@@ -597,15 +585,18 @@ fn compute_raw(
 
     // ── Dim 22: gpu_class_affinity — Phase 4 ─────────────────────────────────
     // Match the model's demanded GPU tier (inferred from its parameter count)
-    // against this candidate's GPU tier. Present iff BOTH are known: exact tier →
-    // 1.0, one tier off → 0.7, two off → 0.5. Either unknown → absent (neutral).
-    // Distinct from VRAM dims (4/13): those measure whether a model FITS; this
-    // measures whether the placement is APPROPRIATE (don't tie up a 5090 with a
-    // 1B model when an entry GPU would do).
-    if let (Some(have), Some(want)) = (
-        b.gpu_model.as_deref().and_then(backend_gpu_class),
-        model.and_then(model_gpu_class),
-    ) {
+    // against this candidate's GPU tier (from total VRAM). Present iff BOTH are
+    // known: exact tier → 1.0, one tier off → 0.7, two off → 0.5. Either unknown →
+    // absent (neutral). Backend tier reads `vram_total_mb` (agent telemetry),
+    // falling back to gpu-hot's `memory_total` for static backends. Uses TOTAL
+    // VRAM (capability), distinct from the FREE-VRAM dims (4/13 measure whether a
+    // model FITS now); dim 22 measures whether the placement is APPROPRIATE (don't
+    // tie up a 32GB card with a 1B model when an entry GPU would do).
+    let total_vram_mb = b
+        .vram_total_mb
+        .or_else(|| b.gpu_metrics.as_ref().map(|g| g.memory_total));
+    if let (Some(vram), Some(want)) = (total_vram_mb, model.and_then(model_gpu_class)) {
+        let have = vram_gpu_class(vram);
         let dim = Dimension::GpuClassAffinity.idx();
         present0[dim] = true;
         let dist = (have as i32 - want as i32).unsigned_abs();
@@ -993,7 +984,6 @@ mod tests {
             ttft_p50_ms: None,
             vram_free_mb: None,
             max_concurrent: None,
-            gpu_model: None,
             last_served: std::collections::BTreeMap::new(),
         }
     }
@@ -2399,16 +2389,13 @@ mod tests {
         assert!(matches!(model_gpu_class("x:7b"), Some(GpuClass::Entry)));
         assert!(model_gpu_class("gpt-4").is_none());
 
-        assert!(matches!(
-            backend_gpu_class("NVIDIA GeForce RTX 5090"),
-            Some(GpuClass::HighEnd)
-        ));
-        assert!(matches!(backend_gpu_class("RTX 4070"), Some(GpuClass::Mid)));
-        assert!(matches!(
-            backend_gpu_class("RTX 4060"),
-            Some(GpuClass::Entry)
-        ));
-        assert!(backend_gpu_class("Some Mystery GPU").is_none());
+        // Backend tier from total VRAM (MB). The 4070-Laptop @ 8GB case is the
+        // whole point: a name list would call it "Mid" (4070), VRAM tiers it Entry.
+        assert!(matches!(vram_gpu_class(32_768), GpuClass::HighEnd)); // 5090 32GB
+        assert!(matches!(vram_gpu_class(24_564), GpuClass::HighEnd)); // 4090 24GB
+        assert!(matches!(vram_gpu_class(16_376), GpuClass::Mid)); // 4080 16GB
+        assert!(matches!(vram_gpu_class(12_288), GpuClass::Mid)); // 4070 12GB
+        assert!(matches!(vram_gpu_class(8_188), GpuClass::Entry)); // 4070 Laptop 8GB
     }
 
     /// dim 22 — tier-distance norm: exact 1.0, one off 0.7, two off 0.5; absent
@@ -2417,9 +2404,9 @@ mod tests {
     fn gpu_class_affinity_norm_and_absence_in_compute_raw() {
         let dim = Dimension::GpuClassAffinity.idx();
         let now = Instant::now();
-        let with_gpu = |g: &str| {
+        let with_vram = |mb: u64| {
             let mut s = make_state("b", 50, true);
-            s.gpu_model = Some(g.to_string());
+            s.vram_total_mb = Some(mb);
             s
         };
         let raw_for = |s: &BackendState, model: &str| {
@@ -2438,22 +2425,21 @@ mod tests {
             )
         };
 
-        // 70B (HighEnd) on a 5090 (HighEnd) → exact → 1.0.
-        let raw = raw_for(&with_gpu("RTX 5090"), "llama:70b");
+        // 70B (HighEnd) on a 32GB card (HighEnd) → exact → 1.0.
+        let raw = raw_for(&with_vram(32_768), "llama:70b");
         assert!(raw.present0[dim]);
         assert!((raw.norms[dim] - 1.0).abs() < 1e-9, "exact tier → 1.0");
 
-        // 70B (HighEnd) on a 4070 (Mid) → one tier off → 0.7.
-        let raw = raw_for(&with_gpu("RTX 4070"), "llama:70b");
+        // 70B (HighEnd) on a 12GB card (Mid) → one tier off → 0.7.
+        let raw = raw_for(&with_vram(12_288), "llama:70b");
         assert!((raw.norms[dim] - 0.7).abs() < 1e-9, "one tier off → 0.7");
 
-        // 70B (HighEnd) on a 4060 (Entry) → two tiers off → 0.5.
-        let raw = raw_for(&with_gpu("RTX 4060"), "llama:70b");
+        // 70B (HighEnd) on an 8GB card (Entry) → two tiers off → 0.5.
+        let raw = raw_for(&with_vram(8_188), "llama:70b");
         assert!((raw.norms[dim] - 0.5).abs() < 1e-9, "two tiers off → 0.5");
 
-        // Unknown GPU / unparseable size / no gpu_model → absent.
-        assert!(!raw_for(&with_gpu("Mystery GPU"), "llama:70b").present0[dim]);
-        assert!(!raw_for(&with_gpu("RTX 5090"), "gpt-4").present0[dim]);
+        // No VRAM known / unparseable model size → absent.
+        assert!(!raw_for(&with_vram(32_768), "gpt-4").present0[dim]);
         assert!(!raw_for(&make_state("b", 50, true), "llama:70b").present0[dim]);
     }
 
@@ -2467,8 +2453,8 @@ mod tests {
         let mut small = make_state("zeta", 50, true);
         big.models = vec!["m:7b".to_string()];
         small.models = vec!["m:7b".to_string()];
-        big.gpu_model = Some("RTX 5090".to_string()); // HighEnd
-        small.gpu_model = Some("RTX 4060".to_string()); // Entry
+        big.vram_total_mb = Some(32_768); // 32GB → HighEnd
+        small.vram_total_mb = Some(8_188); // 8GB → Entry
 
         let mut cfg = ScoredConfig::default();
         cfg.weights.gpu_class_affinity = 100.0;


### PR DESCRIPTION
Post-merge tuning of `gpu_class_affinity` (dim 22), driven by real fleet telemetry. The node registry's only GPU is a **`NVIDIA GeForce RTX 4070 Laptop GPU` @ 8188 MB** — which the substring card list mis-tiered as **Mid** (matches `"4070"`) when its 8GB VRAM makes it **Entry**-class.

**Change:** replace the GPU-name substring list with a **total-VRAM** classifier — `≥24GB → HighEnd`, `12–24GB → Mid`, `<12GB → Entry`. Reads `BackendState.vram_total_mb`, falling back to gpu-hot's `memory_total` for static backends. Self-maintaining (no per-card upkeep), immune to SKU-name ambiguity. Model-size thresholds (30B/8B) unchanged.

**Cleanup:** removes the now-unused `BackendState.gpu_model` plumbing (field, `set_agent_telemetry` param, `pool_sync` threading) — dim 22 was its only consumer. `AgentCapabilities.gpu_model` (node telemetry / node-id source) is untouched.

- Tests updated to VRAM, incl. the 4070-Laptop-8GB → Entry case. **lib 557 green**, clippy `-D warnings` + fmt clean, no lib unwrap.
- Docs: spec Slice-D note + herd.yaml.example updated.

Note: dim 22 only discriminates on a **heterogeneous** fleet (uniform GPU tiers self-cancel via the Q6 call-uniform pre-pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)