### PR TITLE
feat(dashboard): unify Backends + Fleet into one Nodes view + self-enroll

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@
 *.swo
 *~
 .env
+
+# Playwright MCP verification artifacts
+.playwright-mcp/
+dashboard-nodes*.png

--- a/dashboard.html
+++ b/dashboard.html
@@ -699,8 +699,8 @@
 
         <!-- Tab Navigation -->
         <div class="tab-bar">
-            <div class="tab active" data-tab="backends" onclick="switchTab('backends')">
-                Backends <span class="tab-badge" id="backends-count">0</span>
+            <div class="tab active" data-tab="fleet" onclick="switchTab('fleet')">
+                Nodes <span class="tab-badge" id="fleet-tab-badge">0</span>
             </div>
             <div class="tab" data-tab="analytics" onclick="switchTab('analytics')">
                 Analytics
@@ -711,20 +711,12 @@
             <div class="tab" data-tab="agent-guide" onclick="switchTab('agent-guide')">
                 Agent Guide
             </div>
-            <div class="tab" data-tab="fleet" onclick="switchTab('fleet')">
-                Fleet <span class="tab-badge" id="fleet-tab-badge">0</span>
-            </div>
             <div class="tab" data-tab="models" onclick="switchTab('models')">
                 Models
             </div>
             <div class="tab" data-tab="settings" onclick="switchTab('settings')">
                 Settings
             </div>
-        </div>
-
-        <!-- Backends Tab -->
-        <div class="tab-content active" id="tab-backends">
-            <div class="grid" id="backends"></div>
         </div>
 
         <!-- Analytics Tab -->
@@ -972,14 +964,25 @@ Content-Type: application/json
             </div>
         </div>
 
-        <!-- Fleet Tab -->
-        <div class="tab-content" id="tab-fleet">
+        <!-- Fleet / Nodes Tab -->
+        <div class="tab-content active" id="tab-fleet">
             <div class="fleet-add-node">
-                <h3>Add Node to Fleet</h3>
+                <h3>Add a Node</h3>
                 <p>Run the herd-tune script on any machine to auto-detect hardware and register with this Herd instance.</p>
 
+                <!-- Self-enroll one-liner -->
+                <div id="self-enroll-block" style="margin: 16px 0; padding: 14px 16px; background: rgba(99,102,241,0.08); border: 1px solid rgba(99,102,241,0.25); border-radius: 10px;">
+                    <div style="font-size:13px; font-weight:600; color:#a5b4fc; margin-bottom:8px;">Add THIS machine as a node</div>
+                    <pre id="self-enroll-cmd" style="margin:0 0 8px 0; padding:10px 12px; background:#0f0f1a; border:1px solid rgba(255,255,255,0.08); border-radius:6px; font-size:12px; color:#e2e8f0; white-space:pre-wrap; word-break:break-all; overflow-x:auto;"><code id="self-enroll-cmd-text"></code></pre>
+                    <div style="display:flex; align-items:center; gap:10px; flex-wrap:wrap;">
+                        <button class="btn btn-primary btn-sm" onclick="copyEnrollCmd()">Copy</button>
+                        <span id="self-enroll-os-label" style="font-size:11px; color:#64748b;"></span>
+                    </div>
+                    <p style="margin:8px 0 0 0; font-size:11px; color:#64748b; line-height:1.5;">Browsers can&rsquo;t run local programs &mdash; paste this into a terminal on the machine you want to add.</p>
+                </div>
+
                 <div style="margin: 12px 0;">
-                    <label style="font-size:12px; color:#94a3b8; display:block; margin-bottom:6px;">Backend Type</label>
+                    <label style="font-size:12px; color:#94a3b8; display:block; margin-bottom:6px;">Backend Type (for download buttons below)</label>
                     <select id="fleet-backend-select" onchange="updateFleetScriptLinks()" style="padding:6px 12px; border-radius:8px; border:1px solid rgba(255,255,255,0.1); background:#1e293b; color:#e2e8f0; font-size:13px;">
                         <option value="auto">Auto-detect</option>
                         <option value="ollama">Ollama</option>
@@ -1006,7 +1009,7 @@ Content-Type: application/json
                                     <li>Download herd-tune.ps1 (button above)</li>
                                     <li>Open PowerShell as Administrator on your machine</li>
                                     <li>Run: <code>.\herd-tune.ps1 -Apply</code></li>
-                                    <li>Done &mdash; your node will appear in the fleet below</li>
+                                    <li>Done &mdash; your node will appear below</li>
                                 </ol>
                             </div>
                             <div>
@@ -1016,7 +1019,7 @@ Content-Type: application/json
                                     <li>On your machine:<br>
                                         <code>chmod +x herd-tune.sh</code><br>
                                         <code>sudo ./herd-tune.sh --apply</code></li>
-                                    <li>Done &mdash; your node will appear in the fleet below</li>
+                                    <li>Done &mdash; your node will appear below</li>
                                 </ol>
                             </div>
                         </div>
@@ -2063,26 +2066,33 @@ Content-Type: application/json
                         }
                     }
                 }
+                // Tag each backend with whether it came from the healthy list, then merge GPU data
+                for (const b of healthy) { b._healthy = true; }
+                for (const b of unhealthy) { b._healthy = false; }
                 for (const b of all) { if (!b.gpu && gpuMap[b.name]) b.gpu = gpuMap[b.name]; }
+
+                // Store static backends globally so renderFleetTable can include them
+                window.staticBackends = all;
 
                 if (nodesRes && nodesRes.ok) {
                     const nodesData = await nodesRes.json();
                     fleetNodes = nodesData.nodes || [];
-                    // Keep fleetNodes fresh every cycle (the infrastructure summary
-                    // below reads it), but only re-render the table when its tab is
-                    // visible — skip the wasted DOM work while the Fleet tab is hidden.
-                    if (document.getElementById('tab-fleet')?.classList.contains('active')) {
-                        renderFleetTable();
-                    }
                 }
+                // Always re-render the nodes table so badge/count stay current
+                renderFleetTable();
 
                 // Update UI
                 document.getElementById('strategy').textContent = data.routing_strategy || '--';
                 document.getElementById('idle-timeout').textContent = timeout;
-                document.getElementById('backends').innerHTML = all.length > 0
-                    ? all.map(b => renderCard(b, timeout)).join('')
-                    : '<div class="empty-state" style="grid-column:1/-1;"><div class="empty-state-title">No backends configured</div><div class="empty-state-text">Click "+ Add Node" to add an Ollama backend</div></div>';
-                document.getElementById('backends-count').textContent = all.length;
+                // #backends grid is removed; guard in case of cached HTML
+                const bEl = document.getElementById('backends');
+                if (bEl) {
+                    bEl.innerHTML = all.length > 0
+                        ? all.map(b => renderCard(b, timeout)).join('')
+                        : '<div class="empty-state" style="grid-column:1/-1;"><div class="empty-state-title">No backends configured</div></div>';
+                }
+                const bcEl = document.getElementById('backends-count');
+                if (bcEl) bcEl.textContent = all.length;
                 updateInfrastructureSummary();
 
                 conn.classList.remove('error');
@@ -2237,6 +2247,38 @@ Content-Type: application/json
             currentSessionId = null;
         }
 
+        // -- Self-Enroll One-Liner --
+        function initSelfEnrollCmd() {
+            const origin = window.location.origin;
+            const ua = (navigator.userAgent || '') + '|' + (navigator.platform || '');
+            const isWindows = /Win/i.test(navigator.platform) || /Windows/i.test(navigator.userAgent);
+            let cmd, osLabel;
+            if (isWindows) {
+                cmd = `iwr "${origin}/api/nodes/script?os=windows" -OutFile herd-tune.ps1; ./herd-tune.ps1 -Apply`;
+                osLabel = 'Detected: Windows (PowerShell)';
+            } else {
+                cmd = `curl -fsSL "${origin}/api/nodes/script?os=linux" -o herd-tune.sh && chmod +x herd-tune.sh && sudo ./herd-tune.sh --apply`;
+                osLabel = /Mac/i.test(ua) ? 'Detected: macOS (Bash)' : 'Detected: Linux (Bash)';
+            }
+            const cmdEl = document.getElementById('self-enroll-cmd-text');
+            const labelEl = document.getElementById('self-enroll-os-label');
+            if (cmdEl) cmdEl.textContent = cmd;
+            if (labelEl) labelEl.textContent = osLabel;
+        }
+
+        function copyEnrollCmd() {
+            const cmdEl = document.getElementById('self-enroll-cmd-text');
+            if (!cmdEl) return;
+            const text = cmdEl.textContent || '';
+            if (navigator.clipboard && navigator.clipboard.writeText) {
+                navigator.clipboard.writeText(text).then(() => showToast('Copied to clipboard')).catch(() => {
+                    showToast('Copy failed — select and copy manually', 'error');
+                });
+            } else {
+                showToast('Copy not supported — select and copy manually', 'error');
+            }
+        }
+
         // -- Fleet Management --
 
         async function fetchFleetNodes() {
@@ -2258,15 +2300,62 @@ Content-Type: application/json
             const badgeEl = document.getElementById('fleet-tab-badge');
             if (!tbody) return;
 
-            countEl.textContent = `(${fleetNodes.length})`;
-            badgeEl.textContent = fleetNodes.length;
+            // Normalize a static config backend into a display row object.
+            // Exclude `agent:`/`node:`-prefixed pool entries — those are the router
+            // pool's MIRRORS of registered fleet nodes (AgentPoolSync), already
+            // shown below from /api/nodes. Only genuine config backends remain.
+            const staticRows = (window.staticBackends || [])
+                .filter(b => !/^(agent|node):/.test(b.name || ''))
+                .map(b => ({
+                _isStatic: true,
+                hostname: b.name,
+                url: b.url,
+                backend: b.backend || 'ollama',
+                backend_version: b.backend_version || null,
+                gpuName: b.gpu ? (b.gpu.name || '\u2014') : '\u2014',
+                // memory_total is in MB (same units renderCard uses: /1024 => GB)
+                vramGB: b.gpu && b.gpu.memory_total ? (b.gpu.memory_total / 1024).toFixed(1) + ' GB' : '\u2014',
+                ramGB: '\u2014',
+                status: b._healthy ? 'healthy' : 'unreachable',
+                models: b.models || [],
+            }));
 
-            if (fleetNodes.length === 0) {
+            const combined = staticRows.length + fleetNodes.length;
+            countEl.textContent = `(${combined})`;
+            badgeEl.textContent = combined;
+
+            if (combined === 0) {
                 tbody.innerHTML = '<tr><td colspan="10" class="empty-state">No nodes registered yet. Download and run herd-tune to add nodes.</td></tr>';
                 return;
             }
 
-            tbody.innerHTML = fleetNodes.map(node => {
+            // Render static config backends first, then registered fleet nodes
+            const staticHtml = staticRows.map(row => {
+                const statusClass = row.status === 'healthy' ? 'status-healthy' : 'status-unreachable';
+                const statusDot = `<span class="status-dot ${statusClass}"></span>`;
+                const bt = row.backend;
+                const btClass = bt === 'llama-server' ? 'llama-server' : bt === 'ollama' ? 'ollama' : 'unknown';
+                const btLabel = bt === 'llama-server' ? 'llama-server' : 'Ollama';
+                const backendBadge = `<span class="badge-backend ${btClass}">${escapeHtml(btLabel)}</span>`;
+                const backendVer = row.backend_version ? `<br><small style="color:#64748b;">${escapeHtml(row.backend_version)}</small>` : '';
+                const modelsHtml = row.models.length > 0
+                    ? '<small>' + row.models.map(m => escapeHtml(m)).join(', ') + '</small>'
+                    : '<small style="color:#64748b;">\u2014</small>';
+                return `<tr>
+                    <td><strong>${escapeHtml(row.hostname)}</strong><br><small style="color:#64748b;">${escapeHtml(row.url || '')}</small></td>
+                    <td>${backendBadge}${backendVer}</td>
+                    <td>${escapeHtml(row.gpuName)}</td>
+                    <td>${escapeHtml(row.vramGB)}</td>
+                    <td>\u2014</td>
+                    <td>${statusDot} ${escapeHtml(row.status)}</td>
+                    <td>${modelsHtml}</td>
+                    <td>\u2014</td>
+                    <td>\u2014</td>
+                    <td><small style="color:#475569;">—</small></td>
+                </tr>`;
+            }).join('');
+
+            const nodeHtml = fleetNodes.map(node => {
                 const statusClass = (node.status === 'healthy' || node.status === 'online') ? 'status-healthy' :
                                    node.status === 'degraded' ? 'status-degraded' :
                                    (node.status === 'disabled' || node.status === 'offline') ? 'status-disabled' : 'status-unreachable';
@@ -2283,13 +2372,6 @@ Content-Type: application/json
                 const btClass = bt === 'llama-server' ? 'llama-server' : bt === 'ollama' ? 'ollama' : 'unknown';
                 const btLabel = bt === 'llama-server' ? 'llama-server' : 'Ollama';
                 const backendBadge = `<span class="badge-backend ${btClass}">${btLabel}</span>`;
-
-                // Source badge: 'agent' rows come from herd agent heartbeats
-                // (live state in the gateway registry); enrolled rows from herd-tune.
-                const agentVer = node.agent_version ? ' v' + node.agent_version : '';
-                const sourceBadge = node.source === 'agent'
-                    ? ` <span class="badge-backend agent" title="Registered via herd agent heartbeat${escapeHtml(agentVer)}">agent</span>`
-                    : '';
                 const backendVer = node.backend_version ? `<br><small style="color:#64748b;">${escapeHtml(node.backend_version)}</small>` : '';
 
                 // GPU info
@@ -2330,7 +2412,7 @@ Content-Type: application/json
                 }
 
                 return `<tr class="${!node.enabled ? 'row-disabled' : ''}">
-                    <td><strong>${escapeHtml(node.hostname || '')}</strong>${sourceBadge}<br><small style="color:#64748b;">${escapeHtml(node.ollama_url || node.backend_url || '')}</small></td>
+                    <td><strong>${escapeHtml(node.hostname || '')}</strong><br><small style="color:#64748b;">${escapeHtml(node.ollama_url || node.backend_url || '')}</small></td>
                     <td>${backendBadge}${backendVer}</td>
                     <td>${gpuInfoHtml}</td>
                     <td>${vramGB}</td>
@@ -2350,6 +2432,8 @@ Content-Type: application/json
                     </td>
                 </tr>`;
             }).join('');
+
+            tbody.innerHTML = staticHtml + nodeHtml;
         }
 
         async function toggleNodeEnabled(id, enabled) {
@@ -2811,15 +2895,20 @@ Content-Type: application/json
         // Restore API key
         const savedKey = getApiKey();
         if (savedKey) document.getElementById('api-key-input').value = savedKey;
+        initSelfEnrollCmd();
         refresh();
         updateAnalytics();
         checkUpdate();
         refreshSessions();
-        fetchFleetNodes(); // initial badge count
         startCountdown();
 
-        // If fleet tab was last active, start its auto-refresh
-        if (savedTab === 'fleet') startFleetRefresh();
+        // Nodes (fleet) is the default tab — start its auto-refresh unless the user
+        // had a different tab saved from a previous session.
+        if (!savedTab || savedTab === 'fleet') {
+            startFleetRefresh();
+        } else {
+            fetchFleetNodes(); // populate badge count even when another tab is active
+        }
 
         setInterval(refresh, 5000);
         setInterval(updateAnalytics, 30000);

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,206 +1,56 @@
 # Herd — Working TODO
 
-> Scratchpad for in-flight work. Milestone tracking lives in `ROADMAP.md`;
-> the v1.2 PR breakdown + acceptance checklist live in `tasks/HERD-V1.2-SPRINT.md`.
-> Full scorer design: `docs/specs/smart-routing-scorer-spec.md`.
+> Scratchpad for in-flight work. Milestone tracking lives in `ROADMAP.md`.
 
-**Last updated:** 2026-06-25
+**Last updated:** 2026-07-02
 
 ---
 
-## ACTIVE — Scorer Phase 4: Locality, cost & capability (dims 18–23)
+## ACTIVE — Dashboard: unify Backends+Fleet + self-enroll
 
-Phase 4 is the **final 6 dims** (spec dims 18–23 = `Dimension` enum slots 17–22, all already
-declared, weight-zeroed via `w_zero()`, and `present0=false`). The scorer engine does NOT
-change — each dim needs a **data source + a `compute_raw` branch + a weight default**. Plan
-only; no code yet (Director decision 2026-06-25).
+**Goal (user):** Backends and Fleet aren't really different — unify them. Any node
+appears on the main dashboard. Easy "add node" + a surfaced install link. Opening the
+dashboard on a computer → easily make that computer a node.
 
-### Seam audit (verified against current `main`, post-PR #28)
+**Findings:**
+- 3 node types today, split across 2 tabs: static backends (`herd.yaml` → `/admin/backends`,
+  "Backends" card grid) + enrolled nodes (`herd-tune` → `POST /api/nodes/register`) + agent
+  nodes (`herd agent` heartbeat) — the latter two in the "Fleet" table (`/api/nodes`).
+- Install infra EXISTS: `GET /api/nodes/script?os=windows|linux` bakes the gateway endpoint
+  (Host header / `HERD_PUBLIC_URL`) + enrollment key into `herd-tune.ps1/sh`. herd-tune does
+  full GPU/VRAM detect + backend setup + register.
+- dashboard.html is a single 2829-line file, `include_str!`-compiled into the binary
+  (`/dashboard`). Tabs: backends(default)/analytics/sessions/agent-guide/fleet/models/settings.
 
-The plumbing is locked in and proven by Phases 1–3:
-- `Dimension` enum + `ALL_DIMS` + `weights_array` carry all 23 dims (`scored.rs:46–195`).
-- `compute_raw(b, model, tags, relaxed, prefer_type, pmin, pmax, prompt_tokens, stats)`
-  sets `present0[i]` per candidate; dims 18–23 currently force `false` (`scored.rs:~434`).
-- Injected state pattern: `ScoredRouter` holds an `Arc`, snapshots **once per call** off the
-  scoring path (`routing_stats.snapshot_all()` at `scored.rs:519`; pool snapshot at `:466`).
-  This is the template for any new stateful source.
-- `ScoredWeights` already has all 6 Phase-4 fields, each `#[serde(default = "w_zero")]`
-  (`config.rs:283–293`). `RouteContext` (`router/mod.rs:21–26`) carries `prompt_tokens` +
-  `requested_ctx_len` and is the seam for any new request-side signal.
+**Design (locked with user):**
+- ONE unified **"Nodes"** view replaces the separate Backends + Fleet tabs. Merge
+  `/admin/backends` (+`/status`) and `/api/nodes` client-side into one table. **No source
+  column** — treat every node identically (columns: name, GPU, VRAM, status, models, load/latency).
+- Prominent **"Add Node"** affordance → panel with an OS-auto-detected **herd-tune one-liner**
+  pre-pointed at THIS gateway (`window.location.origin`): e.g. Windows
+  `iwr <origin>/api/nodes/script?os=windows -OutFile herd-tune.ps1; ./herd-tune.ps1`.
+  Copy button. Both windows + linux shown.
 
-Per-dim source reality (the part the spec assumed but didn't verify):
+### Plan
+- [ ] Read dashboard render paths (backends grid render, fleet table render, switchTab,
+      /api/nodes + /admin/backends + /status fetch/merge points).
+- [ ] Build unified `renderNodes()` — normalize static-backend and node schemas to one row
+      shape; merge + best-effort dedup by name/url (full enrolled+agent dedup deferred to v1.4).
+- [ ] Replace Backends + Fleet tabs with one "Nodes" tab (keep analytics/sessions/guide/models/settings).
+- [ ] Add "Add Node" panel: herd-tune one-liner (origin-baked, OS-detected), copy button, link.
+- [ ] Rebuild + verify live against the running BASTION gateway (local-5090 + citadel + warden
+      should all appear in one list; install one-liner shows correct origin).
+- [ ] Update CLAUDE.md dashboard-tab rules + skills.md if endpoints/tabs change.
 
-| dim | name | source today | verdict |
-|----|------|--------------|---------|
-| 18 | `session_stickiness` | **none on scoring path** — proxy never reads a session id; agent `executor.rs:160` uses legacy `route()` not `route_scored()` and never writes the chosen backend back to `Session` (no `last_backend` field) | **architectural** |
-| 19 | `network_locality` | net-new `Backend` config field (tier) | **config-only ✅** |
-| 20 | `power_cost` | net-new `Backend` config field (cost weight) | **config-only ✅** |
-| 21 | `rpc_shard_capability` | `AgentCapabilities.rpc_capable` exists, but "**request needs sharding**" signal does NOT — dim is always `0.5` → Q6-dropped every call | **policy-blocked → defer** |
-| 22 | `gpu_class_affinity` | hardware side exists (`gpu_model`/`gpu_vendor` in `NodeRegistration`/SQLite; `gpu_model` in `AgentCapabilities`) but **no model→preferred-class mapping** and `BackendState` carries no class string on the scoring path | **needs design** |
-| 23 | `warm_model_recency` | `ModelWarmer` records **no timestamps** (just logs); `BackendState` has `last_check`/`last_request` `Instant`s but no per-model warm time | **stateful, self-contained ✅** |
-
-### Recommended slice order (cheapest/lowest-risk first)
-
-**Slice A (PR #29) — dims 19 + 20, config-only.** The clean dim-3-shaped slice: no protocol
-field, no stateful plumbing, no agent change.
-- `Backend` gains `locality: Option<LocalityTier>` (enum: `local`/`lan`/`tailnet`/`wan`,
-  `#[serde(default)]`) and `power_cost: Option<f64>` (e.g. watts or $/1k-tok).
-- `compute_raw` dim 19: tier map `local 1.0 / lan 0.8 / tailnet 0.6 / wan 0.4`, present iff
-  `locality.is_some()`. dim 20: `clamp(1 - cost/COST_REF, 0, 1)`, present iff
-  `power_cost.is_some() && COST_REF > 0`.
-- **Weight default decision (open):** keep `w_zero()` (opt-in policy) — locality/cost are
-  deployment value-judgments, not universally-good defaults. Document, don't flip.
-- Tests: presence gating, tier map exactness, cost clamp, Q6-drop when all candidates same tier.
-
-**Slice B (PR #30) — dim 23 `warm_model_recency`, one stateful source.**
-- Add per-(backend, model) last-served time. Two options (Q-B1): (a) `BTreeMap<String,Instant>`
-  on `BackendState` — reuses the pool snapshot already taken at `:466`, no new lock; (b) a
-  separate `ModelWarmStore` `Arc` like `RoutingStats`. **Recommend (a)** — no extra snapshot,
-  warm-state is backend-local.
-- Writers: `ModelWarmer` on successful warm **and** the serve path (a model loaded by serving
-  is warm too, not just `hot_models`) — record `Instant::now()` keyed by served model.
-- Norm: `clamp(1 - age_secs/WARM_REF, 0, 1)`; `0.5` when model never seen (spec: neutral).
-  Open (Q-B2): spec says `turns_since/WARM_REF` (turn count) — recommend **time-based**
-  (`age_secs`) since there's no global turn counter; `WARM_REF` ~ a few minutes.
-
-**Slice C (PR #31) — dim 18 `session_stickiness`, architectural.** Largest blast radius; do
-after A/B prove the Phase-4 wiring.
-- Needs three things that don't exist: (1) a session→backend ledger (extend `Session` with
-  `last_backend: Option<String>`, or a side map), (2) a session key on the scoring path
-  (`RouteContext.session_id` + proxy/agent extraction), (3) route agent turns through
-  `route_scored()` and write the chosen backend back post-request (piggyback the existing
-  post-request hooks at `openai.rs:601/670`, `server.rs:1618`).
-- Open (Q-C1): does this apply to plain `/v1/chat/completions` (no session) at all, or only
-  agent sessions? If agent-only, the proxy path stays untouched and scope shrinks a lot.
-
-**Defer — dim 21 `rpc_shard_capability` → backlog / v1.3.** Inert until a "request needs
-sharding" signal exists, which itself depends on the roadmap llama.cpp RPC tensor-sharding
-integration. Building it now adds a field that Q6 drops on every call. Park with rationale.
-
-**Needs-design — dim 22 `gpu_class_affinity` (PR #32, after a decision).** Blocked on Q-D1:
-where does "model M's preferred GPU class" come from? Options: a config `model_gpu_class` map,
-a request tag, or inferred from model size. Also needs the candidate's GPU class on the scoring
-path (`BackendState` doesn't carry `gpu_model` today — would thread it from `AgentCapabilities`
-via pool_sync, the dim-12 pattern). Decide source before building.
-
-### Director decisions (locked 2026-06-25)
-
-- **Reach:** *all dims except the blocked 21.* Build order **A (19+20) → B (23) → C (18) →
-  D (22)**. dim 21 deferred to v1.3 (RPC integration). Target: **22/23 dims live.**
-- **Q-A1 (weights):** *all Phase-4 dims stay opt-in `w_zero()`* — incl. dim 23. Operators
-  turn on what fits their fleet; no non-zero defaults this milestone.
-
-Still open (resolve at each slice's architect pass, not blocking Slice A):
-- **Q-B1:** warm-time on `BackendState` (recommended) vs separate store. *(Slice B)*
-- **Q-B2:** time-based recency (recommended) vs spec's turn-count. *(Slice B)*
-- **Q-C1:** dim 18 agent-sessions-only (smaller) vs all proxy traffic. *(Slice C)*
-- **Q-D1:** source of "model→preferred GPU class" for dim 22. *(blocks Slice D)*
-
-### Status
-- [x] SEAM AUDIT — 3 parallel explores (scorer plumbing / session model / warmer+capability),
-      cross-checked against spec dims 18–23 formulas. Findings above.
-- [x] DIRECTOR — reach + weights locked (above). Build order A→B→C→D, 21 deferred.
-- [x] SLICE A (dims 19+20) — branch `feat/v1.2-scorer-phase4-slice-a-dims-19-20`.
-      `LocalityTier` enum + `Backend.locality`/`Backend.power_cost` (both serde-default,
-      wire-compat); `COST_REF=100`; dim 19 tier map + dim 20 `clamp(1-cost/COST_REF)` in
-      `compute_raw`; both opt-in (`w_zero`). 4 tests (2 direct `compute_raw` formula/absence,
-      2 anti-trivial e2e). Build ✓, clippy `-D warnings` ✓, fmt ✓, **lib 540→544**. Docs:
-      herd.yaml example (weights + per-backend fields), spec Slice-A note. No lib unwrap.
-      **Awaiting: commit + push + PR (user confirm).**
-- [x] SLICE B (dim 23 `warm_model_recency`) — built on the locked decisions:
-      Q-B1 = `last_served: BTreeMap<String, Instant>` on `BackendState` (read from existing
-      pool snapshot, no new lock); Q-B2 = time-based `n = clamp(1 - age_secs/WARM_REF, 0, 1)`,
-      `WARM_REF=300`, `0.5` when requested model never served here, absent when no model
-      requested; Q-B3 = stamp on BOTH `ModelWarmer` success AND every successful served
-      request via new `BackendPool::record_served` (3 hooks: openai.rs streaming+non-streaming,
-      server.rs proxy; serve-path writer also covers llama-server nodes the warmer skips).
-      `compute_raw` gained a `now: Instant` arg (captured once per call → fair + deterministic;
-      dim 23 stays weight-0 opt-in so default determinism tests unaffected). 3 tests (dim-23
-      formula/absence direct, e2e recent-backend-wins, pool `record_served`). Build ✓, clippy
-      `-D warnings` ✓, fmt ✓, **lib 544→547**, no lib unwrap. Docs: herd.yaml.example weight +
-      spec Slice-B note. **Awaiting: commit (user said local-only for the branch).**
-- [x] SLICE B follow-up — `last_served` LRU cap (`MAX_LAST_SERVED=256`), commit `56c1544`.
-- [x] SLICE C (dim 18 `session_stickiness`) — Q-C1 = **all proxy traffic**. New
-      `router/session_affinity.rs` (`SessionAffinity`: session_id→backend, LRU 50k, mirrors
-      `RoutingStats`), injected into `ScoredRouter` + `create_router` (all call sites incl. 2
-      integration tests). `RouteContext.session_id` ← `X-Herd-Session` header in both proxy
-      paths; write-back on all 3 post-request hooks. `compute_raw` gains `sticky_backend:
-      Option<&str>` (resolved once/call); dim 18 = 1.0 match / 0.5 else, absent when no prior
-      backend. Opt-in. 5 tests (3 store, 2 scored). Build ✓, clippy `-D warnings` ✓, fmt ✓,
-      **lib 548→553**, integration green. Docs: skills.md X-Herd-Session, header JSON,
-      herd.yaml.example weight, spec Slice-C note.
-- [x] SLICE D (dim 22 `gpu_class_affinity`) — Q-D1 = **infer from model size**. `GpuClass`
-      tiers (Entry/Mid/HighEnd); `model_gpu_class` (param count: ≥30B HighEnd / 8–30B Mid /
-      <8B Entry) + `backend_gpu_class` (substring card list); `parse_param_billions` (last
-      `<num>b` token). `BackendState.gpu_model` threaded from `AgentCapabilities` via
-      `set_agent_telemetry` + `pool_sync` both branches. dim 22 norm = tier distance (0→1.0,
-      1→0.7, 2→0.5), absent when either side unknown. Opt-in. 4 tests. Build ✓, clippy
-      `-D warnings` ✓, fmt ✓, **lib 553→557**, integration green. Docs: herd.yaml.example
-      weight, spec Slice-D note. **Tunable:** size thresholds + GPU card list are fleet-specific.
-
-### PHASE 4 COMPLETE — 22/23 dims live. Only dim 21 (`rpc_shard_capability`) deferred to v1.3.
+### Notes / open
+- Known limitation: enrolled+agent on one host = two entries (dedup deferred v1.4). Dashboard
+  merges but won't fully de-dup those; surface both, don't crash.
+- dashboard.html is compiled in → changes need `cargo build` + gateway restart to test live.
 
 ---
 
-## DONE — audit log (collapsed; full detail in git history + ROADMAP)
-
-- **Scorer Phase 3 — history/EWMA dims 14–17** (PR #28, `2026-06-24`, merged `95123a6`) —
-  new `src/router/routing_stats.rs`: per-(backend,model) request-count EWMA (`alpha=0.2`),
-  32-bit rolling error ring, LRU eviction at 20k entries. `ScoredRouter` holds
-  `Arc<RoutingStats>`, `snapshot_all()` once per call; dims 14–17 absent for cold/
-  under-sampled backends (`< MIN_SAMPLES=5`). Phase-3 weights flipped off 0:
-  `error_rate=3`/`latency=3`/`throughput=2`/`flap_stability=1`. Post-request hooks in
-  `server.rs`/`openai.rs` call `routing_stats.update()`. 14 new tests; lib 526→540.
-
-- **dim-3 agent ctx source** (commit `147bb3f`) — agent reports llama-server `/props` `n_ctx`
-  so dim 3 (`prompt_size_vs_capacity`) covers agent nodes, not just static `max_context_len`.
-
-- **Scorer Phase 2 — prompt_size_vs_capacity (dim 3)** (PR #25, `2026-06-19`) — `Backend.
-  max_context_len: Option<u32>` (static backends); `estimate_prompt_tokens` ~4 chars/token over
-  chat messages; both proxy sites switched `route_excluding` → `route_scored(RouteContext)`;
-  dim 3 `n = clamp((1 - prompt/window)/0.5, 0, 1)`, present iff both sides known. lib 512→518.
-
-- **Scorer Phase 2 Slice 2 — measure real load + dim 12** (PR #24, `2026-06-19`, merged
-  `53f86b7`) — `herd agent` probes llama-server `/props` (`total_slots`→`max_concurrent`) +
-  `/slots` (busy→`queue_depth`), best-effort. `AgentCapabilities.queue_depth` → `Option<u32>`
-  (honest unmeasured) + new `max_concurrent` (both serde-default). dim 12
-  `concurrency_saturation = 1-queue_depth/max_concurrent`, guard `max>0`, coexists with dim 10,
-  weight 1.0. lib 504→512. **Deferred:** agent ttft (dim 11) — `/metrics` has no quantiles.
-
-- **Scorer Phase 2 Slice 1 — live-load dims 10/11/13** (PR #23, `2026-06-19`, merged
-  `90b5251`) — read agent telemetry at the pool boundary. `is_some()` presence (`Some(0)`
-  scored, not absent); dim 13 supersedes dim 5 per-candidate (no VRAM double-count); weights
-  `ttft_p50=3`/`queue_depth=2`/`precise_vram_free=2`. `QUEUE_REF=8`/`TTFT_REF=2000`. lib
-  499→504. **Test gotcha:** the Q6 call-uniform pre-pass drops any dim present on only ONE
-  candidate — live-dim tests need ≥2 reporters; supersession tested directly on `compute_raw`.
-
-- **Scorer Phase 1 hardening** (PR #21, `2026-06-15`) — dim-6 temp sentinel guard,
-  per-candidate alloc drop, VRAM-comment fix. lib 499.
-- **Scorer Phase 1 — `ScoredRouter`** (PR #19) — GATE→SCORE→SELECT over dims 1–9,
-  per-backend active-weight renorm, Q6 call-uniform-drop, i64-quantized total
-  tie-break, `routing.scored` config + weight sanitize. Dims 10–23 recognized/inert.
-- **Scorer Phase 0 — telemetry to pool boundary** (PR #17) — `BackendState` gains
-  `queue_depth`/`ttft_p50_ms`/`vram_free_mb`/`max_concurrent` `Option`s; `pool_sync`
-  populates them for `agent:` entries.
-- **Containerized-gateway persistence** (PR #18, `2026-06-14`) — all 6 stores root
-  under `HERD_DATA_DIR`; default byte-identical when unset; Dockerfile volume.
-- **v1.2 fleet foundation** (PRs #1–#8) — `herd agent` daemon, `NodeRegistry` (TTL
-  evict), heartbeat endpoint, agent persistence, gateway version authority +
-  sha256 self-update (#6a/#6b), `herd publish` (#6c), BackendPool routing (#7),
-  in-process integration test (#8). Two-box cross-machine remains manual acceptance.
-
----
-
-## Backlog
-- **dim 21 `rpc_shard_capability`** — deferred from Phase 4: inert until a "request needs
-  sharding" signal exists, which depends on llama.cpp RPC tensor-sharding integration (v1.3
-  roadmap). Building now = a Q6-dropped no-op field. Revisit with the RPC work.
-- **Agent ttft measurement (dim 11)** — agent reports `ttft_p50_ms: None`; a TRUE p50 isn't
-  reachable for an observe-only agent (`/metrics` counters/gauges, no quantiles; per-request
-  `timings.prompt_ms` only on completion responses the agent doesn't see). Realistic option:
-  interval-MEAN TTFT from `/metrics` counter deltas (needs `--metrics` + daemon delta-state),
-  reported as an approximation. Deferred pending a decision on the mean approximation.
-- **Scorer Phase 4 leftovers** — dim 18 (session stickiness) and dim 22 (gpu-class affinity)
-  may land or defer per Director decisions Q-C1/Q-D1 above.
-- v1.3 milestone — speculative decoding, full mDNS discovery, routing-strategy plugins,
-  llama.cpp RPC tensor-parallel sharding.
+## DONE — recent (collapsed; full detail in git history)
+- **Fleet two-box smoke test PASSED** (2026-07-02) — gateway BASTION + agent CITADEL over
+  Tailscale; cross-machine routing validated. See memory `herd-fleet-two-box-smoke-test`.
+- **v1.3.0 released** — scorer feature-complete (22/23 dims); tag `v1.3.0`, GH release, 4 artifacts.
+- **Scorer Phase 4 + dim-22 VRAM tuning** — PRs #29–33; dim 21 deferred to v1.4.


### PR DESCRIPTION
The **Backends** (static config) and **Fleet** (registered nodes) tabs were two representations of the same concept. This merges them into a single **Nodes** tab so every node — static config backend, herd-tune-enrolled, or herd-agent — appears in one uniform table on the main dashboard, and adds a one-paste self-enroll flow.

**Changes (dashboard.html only):**
- Tab bar: remove Backends + Fleet → one **Nodes** tab (default). Latency tables already live in Analytics; model management in the Models tab.
- `renderFleetTable()` merges static backends (`/status`) with registered nodes (`/api/nodes`). **Dedup:** exclude `agent:`/`node:`-prefixed pool entries — those are `AgentPoolSync` mirrors of registry nodes already listed from `/api/nodes`. (Same-host enrolled+agent dedup within `/api/nodes` stays deferred to v1.4.)
- **No source column/badge** — a node is a node. Config backends show no per-node actions (config-managed, not registry-managed).
- **"Add THIS machine as a node"** one-liner — OS auto-detected from the browser, gateway origin pre-baked (`window.location.origin`), Copy button, note that browsers can't run local programs. Existing herd-tune download buttons + Quick Start kept as the manual path.

**Verification:** driven live in a real browser (Playwright) against a 3-node tailnet fleet (`local-5090` config + `citadel` agent + `warden`). Confirmed one table, no dupes, correct origin/OS in the one-liner. `dashboard.html` is `include_str!`'d — `cargo build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)