### PR TITLE
chore(ci): ignore quick-xml RUSTSEC-2026-0194/-0195 (transitive, not on our path)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,4 +58,11 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: cargo install cargo-audit --locked
-      - run: cargo audit
+      # RUSTSEC-2026-0194 / -0195: DoS advisories in quick-xml, pulled in
+      # transitively by self_update. Ignored deliberately: (1) herd uses
+      # self_update's GitHub backend, which parses JSON — not quick-xml's XML
+      # path — so the vulnerable code is not on our runtime path; (2) the fix
+      # requires self_update 1.0.0-rc.1, a PRE-RELEASE major bump of the
+      # binary-self-replace mechanism (too risky to ship). Revisit and drop
+      # these ignores when self_update ships a stable 1.0 on patched quick-xml.
+      - run: cargo audit --ignore RUSTSEC-2026-0194 --ignore RUSTSEC-2026-0195


### PR DESCRIPTION
Two new **DoS advisories** landed against `quick-xml` (RUSTSEC-2026-0194 quadratic parse, -0195 unbounded namespace allocation), pulled in transitively via `self_update`. This turned **Security Audit red on `main`** (and every open PR).

**Decision: documented ignore**, because —
- herd uses `self_update`'s **GitHub backend (JSON)**, not quick-xml's XML path → the vulnerable code isn't on our runtime path.
- The only real fix is `self_update 0.42 → 1.0.0-rc.1`. I verified it *does* pull patched `quick-xml 0.38.4` — but it's a **pre-release major bump of the binary self-replace mechanism** and requires code migration (`self_replace` moved out, `set_header`→`header`). Too risky to ship for a low-exposure transitive advisory.

Adds `--ignore` flags to the `cargo audit` CI step with an inline justification + a revisit trigger (drop when `self_update` ships stable 1.0 on patched quick-xml). No dependency or code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)