### PR TITLE
feat: GUI config overlay — models_enabled allowlist + admin API (#G1 + #G2)

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -893,6 +893,12 @@ Content-Type: application/json
                             <tr class="admin-row"><td>List backends</td><td>GET</td><td><code>/admin/backends</code></td><td>Yes</td></tr>
                             <tr class="admin-row"><td>Add backend</td><td>POST</td><td><code>/admin/backends</code></td><td>Yes</td></tr>
                             <tr class="admin-row"><td>Reload config</td><td>POST</td><td><code>/admin/reload</code></td><td>Yes</td></tr>
+                            <tr class="admin-row"><td>Effective backend configs (+ models)</td><td>GET</td><td><code>/admin/config/backends</code></td><td>Yes</td></tr>
+                            <tr class="admin-row"><td>Create overlay backend</td><td>POST</td><td><code>/admin/config/backends</code></td><td>Yes</td></tr>
+                            <tr class="admin-row"><td>Patch backend (priority/enabled/hot_models)</td><td>PUT</td><td><code>/admin/config/backends/{name}</code></td><td>Yes</td></tr>
+                            <tr class="admin-row"><td>Set models allowlist (null clears)</td><td>PUT</td><td><code>/admin/config/backends/{name}/models</code></td><td>Yes</td></tr>
+                            <tr class="admin-row"><td>List config overrides</td><td>GET</td><td><code>/admin/config/overrides</code></td><td>Yes</td></tr>
+                            <tr class="admin-row"><td>Delete one override</td><td>DELETE</td><td><code>/admin/config/overrides/{scope}/{key}</code></td><td>Yes</td></tr>
                             <tr class="admin-row"><td>Self-update</td><td>POST</td><td><code>/admin/update</code></td><td>Yes</td></tr>
                             <tr class="admin-row"><td>Agent heartbeat (herd agent daemons only)</td><td>POST</td><td><code>/api/internal/nodes/heartbeat</code></td><td>Yes</td></tr>
                             <tr class="admin-row"><td>Agent binary download (herd agent self-update)</td><td>GET</td><td><code>/api/internal/nodes/binary/{version}/{os}-{arch}</code></td><td>Yes</td></tr>

--- a/docs/specs/gui-tray-spec.md
+++ b/docs/specs/gui-tray-spec.md
@@ -1,0 +1,214 @@
+# Herd GUI & Tray — v1.4 Spec
+
+**Milestone:** v1.4 "Approachable Herd" (v1.3 remains distributed-inference: RPC sharding, agent/enrolled dedup)
+**Status:** Draft — locked decisions below, PR breakdown at bottom
+**Author:** Tom Swift / Gage
+**Date:** 2026-07-03
+
+---
+
+## Problem
+
+Herd's adoption ceiling is "people who enjoy editing YAML." Three concrete pains:
+
+1. **No GUI config surface.** Every routing decision — which models a backend exposes,
+   hot_models, priorities — requires hand-editing `herd.yaml` and knowing the schema.
+2. **Model sprawl poisons routing.** A long-lived Ollama install (e.g. CITADEL: 84 models
+   accumulated over years of experiments) exposes *everything* via `/api/tags`, so the
+   residency gate treats stale experiments as routing candidates. `model_filter` (regex)
+   exists but is hostile as a user-facing control.
+3. **Zero onboarding.** A new user with no `herd.yaml` and no backend gets a config error,
+   not a path forward. No Ollama detection, no starter guidance.
+
+## Goals
+
+- Tray icon: at-a-glance gateway health + one-click access to dashboard/config.
+- GUI model selection: per-backend checkbox allowlist of which installed models Herd routes to.
+- Ollama auto-detection with zero config.
+- First-run onboarding: detect → (optionally) link installs → suggest starter model families by VRAM tier.
+- Surface future config options through the same GUI channel without another config-file schema.
+
+## Non-Goals (v1.4)
+
+- No new GUI framework. **No Tauri app, no egui, no webview bundling.** The existing web
+  dashboard (`dashboard.html`) is the single config surface; the tray is a native
+  status/launcher only.
+- No macOS/Linux tray in the first cut (code stays portable; Windows ships first).
+- No YAML rewriting. GUI never serializes `herd.yaml` (comments are documentation).
+- No model *deletion* (`ollama rm`) from the GUI — allowlist only. Deleting user data
+  from a router GUI is a footgun; revisit post-v1.4.
+- No auth/user system beyond the existing `server.api_key`.
+
+---
+
+## Locked Decisions
+
+### D1 — Tray is a launcher, dashboard is the GUI
+`herd-tray` is a new small workspace binary using `tray-icon` + `muda` + `tao` (no webview).
+All configuration UI lives in the existing dashboard as a new **Settings** tab. The tray's
+"Models…" item opens `http://{host}:{port}/#settings` in the default browser (`open` crate).
+One UI, one truth; remote users get the identical config surface.
+
+### D2 — `models_enabled` allowlist (GUI-managed), `model_filter` (hand-managed) both survive
+New optional field on `Backend`:
+
+```rust
+/// GUI-managed allowlist. When Some, discovery retains ONLY these models
+/// (exact-name match on the backend's reported model list).
+/// Some(vec![]) is valid and means "expose nothing" (explicit off-switch).
+/// Takes precedence over model_filter when both are set.
+#[serde(default)]
+pub models_enabled: Option<Vec<String>>,
+```
+
+Filter application order in `ModelDiscovery::discover_models`:
+`raw list → models_enabled (if Some) → model_filter regex (only if models_enabled is None)`.
+`None` = current behavior, zero change for existing configs (code-quality rule: defaults off).
+
+### D3 — SQLite settings overlay; YAML stays the hand-edited base
+GUI-managed values persist to a new `config_overrides` table in the existing `herd.db`
+(NodeDb connection), NOT to `herd.yaml`.
+
+```sql
+CREATE TABLE IF NOT EXISTS config_overrides (
+  scope      TEXT NOT NULL,   -- e.g. 'backend:local-5090'
+  key        TEXT NOT NULL,   -- e.g. 'models_enabled'
+  value_json TEXT NOT NULL,   -- JSON-encoded value
+  updated_at TEXT NOT NULL,
+  PRIMARY KEY (scope, key)
+);
+```
+
+Merge semantics: config is loaded from YAML, then overrides are applied on top
+(**DB wins on conflict**). Applied at: (a) startup after YAML parse, (b) config
+hot-reload, (c) immediately on PUT (write DB → patch in-memory `AppState.config`
+→ nudge discovery). A `GET /admin/config/overrides` + `DELETE /admin/config/overrides/:scope/:key`
+pair makes the overlay inspectable and reversible — no invisible state.
+
+v1.4 supports overrides for: `backend:{name}` scope, keys `models_enabled`,
+`hot_models`, `priority`, `enabled`. The table is generic so future GUI settings
+need no migration.
+
+**Backends created by the GUI** (e.g. auto-detected Ollama) use scope `backend:{name}`,
+key `definition` (full Backend JSON). Overlay-defined backends are appended to the pool
+after YAML backends; name collision → YAML wins + warn (never bail — code-quality rule).
+
+### D4 — Admin API endpoints (all guarded by existing `server.api_key` middleware)
+
+| Method | Path | Purpose |
+|---|---|---|
+| GET | `/admin/config/backends` | Effective (merged) backend configs + per-backend `models_available` (live from pool) + `models_enabled` |
+| PUT | `/admin/config/backends/:name/models` | Body `{"models_enabled": ["a","b"] \| null}` — null clears the override |
+| PUT | `/admin/config/backends/:name` | Patch `priority` / `enabled` / `hot_models` |
+| POST | `/admin/config/backends` | Create overlay-defined backend (used by detect flow) |
+| GET | `/admin/config/overrides` | Dump the overlay |
+| DELETE | `/admin/config/overrides/:scope/:key` | Remove one override |
+| GET | `/admin/detect/ollama` | Probe `OLLAMA_HOST` env, then `http://127.0.0.1:11434/api/version`; returns `{found, url, version, model_count}` |
+| POST | `/admin/models/pull` | Proxy Ollama `/api/pull` for a named backend; streams NDJSON progress through |
+
+New endpoints go into `skills.md` and the dashboard Agent Guide tab (repo rule).
+
+### D5 — Settings tab (dashboard.html)
+- **Backends section:** card per backend. Shows name, URL, type, health. Model list
+  rendered as checkboxes: checked = enabled. Source of truth for the list is
+  `models_available` from the pool (i.e. `/api/tags` for Ollama, `/v1/models` for
+  llama-server). "Select all / none", filter-as-you-type box (84 models needs search).
+  Save → PUT. A model that is checked but no longer installed renders greyed with a
+  "missing" badge (kept in the allowlist — it may be mid-`ollama pull`).
+- **Hot models:** per-backend multi-select drawn from the enabled set → writes
+  `hot_models` override (warmer picks it up next tick).
+- **Overrides panel:** raw view of the overlay with per-row delete (D3 inspectability).
+
+### D6 — First-run onboarding wizard (dashboard)
+Shown when the effective config has **zero backends** (also reachable manually via
+Settings → "Add backend"). Steps:
+
+1. **Detect.** Call `/admin/detect/ollama`. Found → offer "Use this Ollama" →
+   POST creates the overlay backend, jump to step 3.
+2. **Install links.** Not found → two cards:
+   - **Ollama** (recommended for new users): `https://ollama.com/download`
+   - **llama.cpp / llama-server** (max performance, advanced):
+     `https://github.com/ggml-org/llama.cpp/releases` + pointer to `docs/LLAMA_CPP_BACKEND.md`
+   "Detect again" button re-probes.
+3. **Starter models.** Read VRAM (pool `gpu_metrics`/`vram_total_mb` if present, else ask
+   the user to pick a tier). Render the starter catalog (D7) for that tier with one-click
+   pull buttons (`/admin/models/pull`, NDJSON progress bar). Pulled models are
+   auto-added to `models_enabled`.
+4. **Auto mode prefill.** Offer to write the `auto.model_map` tiers from the pulled set
+   (stored as overlay scope `routing`, key `model_map` — read-only in v1.4 UI beyond
+   this prefill; full model_map editor is post-v1.4).
+
+### D7 — Starter model catalog (static JSON, versioned in-repo)
+`src/onboarding/catalog.json`, compiled in via `include_str!`. Three-to-four entries per
+tier; tiers keyed by usable VRAM. Initial content (update as families evolve — this file
+is the single place to touch):
+
+| VRAM tier | General | Code | Reasoning | Always |
+|---|---|---|---|---|
+| `<=8gb` | `qwen3:4b` | `qwen2.5-coder:7b` | `deepseek-r1:7b` | `qwen3:1.7b` (auto-classifier), `nomic-embed-text` |
+| `16gb` | `gemma4:e4b` | `qwen2.5-coder:14b` | `deepseek-r1:14b` | same |
+| `24gb+` | `gemma4:26b` | `qwen3-coder:30b` | `deepseek-r1:32b` | same |
+
+Catalog schema: `{tier, role, model, approx_gb, note}`. Keep it small — a wall of
+options is the CITADEL failure mode this spec exists to prevent.
+
+### D8 — `herd-tray` binary (Windows-first)
+New workspace member `herd-tray/` (convert repo root to a cargo workspace:
+`[workspace] members = [".", "herd-tray"]` — the main crate's build output is unchanged).
+
+- **Crates:** `tray-icon`, `muda`, `tao` (event loop), `open`, `reqwest` (blocking or
+  minimal tokio), `serde_json`. Windows autostart via `HKCU\...\Run` registry key
+  (`winreg` crate), behind `#[cfg(windows)]`.
+- **Behavior:**
+  - On launch: probe `GET {gateway}/api/status`. Reachable → attach (status mode).
+    Unreachable → spawn `herd serve` as child process (looks for `herd.exe` beside
+    itself, then PATH), supervise: child exit → icon red + "Start gateway" menu item.
+  - Poll `/api/status` every 5s → icon tint: green (healthy backends > 0),
+    amber (gateway up, zero healthy backends), red (gateway unreachable).
+  - Menu: **Open Dashboard** · **Models…** (→ `/#settings`) · **Start/Stop gateway**
+    (only when supervising) · **Start at login** (checkbox, registry) · **Quit**
+    (stops supervised child, leaves attached gateways alone).
+  - Single instance: named mutex (`Global\herd-tray`); second launch focuses nothing,
+    just exits 0.
+- **Config:** `--gateway <url>` (default `http://127.0.0.1:40114`), `HERD_TRAY_GATEWAY` env.
+- Tray never writes config; it is a viewer/launcher (D1).
+
+### D9 — Routing interaction note (context from 2026-07-03 analysis)
+`models_enabled` filters the **pool model list**, which is what the scored router's
+residency GATE reads. For static Ollama backends that list is `/api/tags` (installed);
+for enrolled/agent nodes it is currently `/api/ps` (warm-only). The installed-vs-warm
+gate split is a **separate v1.3/v1.4 work item** (see tasks/todo: "split installed from
+warm for Ollama backends") — this spec neither depends on nor blocks it. The Settings
+tab reads whatever the pool reports; when the gate fix lands, enrolled/agent nodes get
+checkbox lists for free.
+
+---
+
+## PR Breakdown
+
+| PR | Title | Scope | Depends on |
+|----|-------|-------|-----------|
+| #G1 | `models_enabled` + config overlay store | `Backend.models_enabled`; discovery filter order (D2); `config_overrides` migration + `NodeDb` CRUD; overlay merge at load/reload; unit tests (filter precedence, `Some(vec![])`, merge determinism, YAML-wins-on-name-collision) | — |
+| #G2 | Admin config API | D4 endpoints minus detect/pull; api_key guard; patch-in-memory + discovery nudge on PUT; `skills.md` + Agent Guide entries; endpoint tests (auth, null-clears, unknown backend 404) | #G1 |
+| #G3 | Settings tab | Dashboard Settings tab per D5 (checkbox list w/ search, hot_models select, overrides panel); no new build tooling — stays vanilla JS in `dashboard.html` like existing tabs | #G2 |
+| #G4 | Ollama detect + onboarding + catalog + pull proxy | `/admin/detect/ollama`, `/admin/models/pull` (NDJSON stream-through), `catalog.json`, wizard UI (D6), model_map prefill override | #G2 (#G3 for UI shell) |
+| #G5 | `herd-tray` | Workspace conversion; tray bin per D8; icon assets (green/amber/red .ico); autostart; single-instance; supervised-child lifecycle tests where feasible (status-poll + menu-state logic unit-tested behind traits) | gateway API only |
+
+#G1 and #G2 are the value core and independently shippable — they fix CITADEL's 84-model
+problem via `curl` even before the Settings tab exists.
+
+## Acceptance (v1.4)
+
+- [ ] Existing `herd.yaml` files load byte-for-byte identically with no overrides present
+- [ ] Checking/unchecking models in Settings changes the routable set within one discovery tick, no restart
+- [ ] `Some(vec![])` allowlist yields an empty pool model list (backend healthy, gates everything)
+- [ ] Override survives gateway restart; `DELETE` restores YAML behavior
+- [ ] Fresh machine, no `herd.yaml`, Ollama running → wizard detects, creates backend, user pulls a starter model, first chat completion routes — zero file edits
+- [ ] Tray icon reflects gateway state transitions (green/amber/red) and survives gateway restart
+- [ ] `cargo test` green; new endpoints in `skills.md`
+
+## References
+
+- Routing/gate analysis motivating D9: conversation 2026-07-03 (installed-vs-warm split)
+- `docs/LLAMA_CPP_BACKEND.md` — backend strategy, linked from onboarding
+- `CLAUDE.md` — code-quality rules (defaults-off, never-bail, endpoint registry)

--- a/skills.md
+++ b/skills.md
@@ -277,6 +277,30 @@ or
 Authorization: Bearer your-secret-key
 ```
 
+## Config Overlay (Admin)
+
+GUI-managed config lives in a SQLite overlay on top of `herd.yaml` (YAML stays the
+hand-edited base; the overlay wins on conflict and survives restarts). All require the
+admin API key. A per-backend `models_enabled` allowlist fixes model sprawl — Herd routes
+only to the listed models (`[]` = expose none, absent = all installed).
+
+| Method | Endpoint | Purpose |
+|--------|----------|---------|
+| GET | `/admin/config/backends` | Effective (merged) backend configs + live `models_available` + `models_enabled` |
+| PUT | `/admin/config/backends/{name}/models` | Body `{"models_enabled": ["a","b"]}` sets the allowlist; `{"models_enabled": null}` clears it |
+| PUT | `/admin/config/backends/{name}` | Patch `priority` / `enabled` / `hot_models` |
+| POST | `/admin/config/backends` | Create an overlay-defined backend (`{"name","url","backend","priority"}`) |
+| GET | `/admin/config/overrides` | Inspect the raw overlay |
+| DELETE | `/admin/config/overrides/{scope}/{key}` | Remove one override (restores YAML behavior) |
+
+Changes take effect within one discovery tick — no restart. Example (limit CITADEL to two models):
+
+```
+curl -X PUT http://gateway:40114/admin/config/backends/citadel/models \
+  -H "X-API-Key: your-secret-key" -H "Content-Type: application/json" \
+  -d '{"models_enabled": ["qwen3-coder:30b", "llama3.1:8b"]}'
+```
+
 ## Routing Strategies
 
 Herd supports four strategies. You don't choose the strategy per-request — it's configured

--- a/src/api/admin.rs
+++ b/src/api/admin.rs
@@ -135,6 +135,8 @@ pub async fn add_backend(
         max_context_len: None,
         locality: None,
         power_cost: None,
+        models_enabled: None,
+        enabled: true,
     };
 
     state.pool.add(backend).await;

--- a/src/api/admin.rs
+++ b/src/api/admin.rs
@@ -445,3 +445,267 @@ pub async fn update_config(
     tracing::info!("Config updated via dashboard: {}", msg);
     Ok(Json(serde_json::json!({"status": "ok", "message": msg})))
 }
+
+// ── GUI config overlay endpoints (gui-tray-spec #G2) ─────────────────────────
+
+/// Effective (merged) view of a backend plus its live pool state.
+#[derive(Debug, Serialize)]
+pub struct EffectiveBackend {
+    pub name: String,
+    pub url: String,
+    pub backend: String,
+    pub priority: u32,
+    pub enabled: bool,
+    pub hot_models: Vec<String>,
+    pub model_filter: Option<String>,
+    pub tags: Vec<String>,
+    /// GUI allowlist: `None` = all installed, `Some([])` = none.
+    pub models_enabled: Option<Vec<String>>,
+    /// Models the pool currently reports for this backend (post-filter).
+    pub models_available: Vec<String>,
+    pub healthy: bool,
+}
+
+/// True iff the effective config currently contains a backend named `name`.
+async fn backend_exists(state: &AppState, name: &str) -> bool {
+    state
+        .config
+        .read()
+        .await
+        .backends
+        .iter()
+        .any(|b| b.name == name)
+}
+
+/// Persist one override, JSON-encoding `value`. Never bails — encode/DB errors warn.
+fn persist_override<T: Serialize>(state: &AppState, scope: &str, key: &str, value: &T) {
+    match serde_json::to_string(value) {
+        Ok(json) => {
+            if let Err(e) = state.node_db.set_override(scope, key, &json) {
+                tracing::warn!("config overlay: failed to persist {}/{}: {}", scope, key, e);
+            }
+        }
+        Err(e) => tracing::warn!("config overlay: failed to encode {}/{}: {}", scope, key, e),
+    }
+}
+
+/// Recompute the effective config from the YAML base + current overrides, push it
+/// to the in-memory config and the live pool, and nudge discovery so the routable
+/// model list updates within a tick — no restart. Correctly restores YAML values
+/// when an override is cleared. No config file (CLI-args start) → the override is
+/// still persisted; it takes effect on next start. Never bails.
+async fn remerge_and_apply(state: &AppState) {
+    let Some(path) = state.config_path.clone() else {
+        tracing::warn!(
+            "config overlay: override saved but no config file to re-merge live — restart to apply"
+        );
+        return;
+    };
+    let mut cfg = match crate::config::Config::from_file(&path) {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::warn!("config overlay: re-merge failed to read config: {}", e);
+            return;
+        }
+    };
+    let rows: Vec<(String, String, String)> = match state.node_db.list_overrides() {
+        Ok(l) => l
+            .into_iter()
+            .map(|o| (o.scope, o.key, o.value_json))
+            .collect(),
+        Err(e) => {
+            tracing::warn!("config overlay: re-merge failed to list overrides: {}", e);
+            return;
+        }
+    };
+    cfg.apply_overrides(&rows);
+
+    // Reconcile the pool: update existing backends' live config, add new ones.
+    for b in &cfg.backends {
+        if state.pool.get(&b.name).await.is_some() {
+            state.pool.update_backend_config(&b.name, b.clone()).await;
+        } else {
+            state.pool.add(b.clone()).await;
+        }
+    }
+
+    // Best-effort immediate re-discovery so model lists reflect new filters now
+    // (the scheduled discovery tick would also catch up).
+    let pool = (*state.pool).clone();
+    let backends = cfg.backends.clone();
+    tokio::spawn(async move {
+        let disc = crate::backend::ModelDiscovery::new(0);
+        for b in &backends {
+            if let Err(e) = disc.discover_models(&pool, b).await {
+                tracing::debug!(
+                    "config overlay: discovery nudge for {} failed: {}",
+                    b.name,
+                    e
+                );
+            }
+        }
+    });
+
+    *state.config.write().await = cfg;
+}
+
+/// GET /admin/config/backends — effective merged configs + live `models_available`.
+pub async fn get_effective_backends(State(state): State<AppState>) -> Json<serde_json::Value> {
+    let config = state.config.read().await;
+    let mut backends = Vec::with_capacity(config.backends.len());
+    for b in &config.backends {
+        let (models_available, healthy) = match state.pool.get(&b.name).await {
+            Some(st) => (st.models, st.healthy),
+            None => (Vec::new(), false),
+        };
+        backends.push(EffectiveBackend {
+            name: b.name.clone(),
+            url: b.url.clone(),
+            backend: b.backend.to_string(),
+            priority: b.priority,
+            enabled: b.enabled,
+            hot_models: b.hot_models.clone(),
+            model_filter: b.model_filter.clone(),
+            tags: b.tags.clone(),
+            models_enabled: b.models_enabled.clone(),
+            models_available,
+            healthy,
+        });
+    }
+    Json(serde_json::json!({ "backends": backends }))
+}
+
+#[derive(Debug, Deserialize)]
+pub struct SetModelsRequest {
+    /// An array sets the allowlist; JSON `null` (or absent) clears the override.
+    #[serde(default)]
+    pub models_enabled: Option<Vec<String>>,
+}
+
+/// PUT /admin/config/backends/:name/models — set or clear the models_enabled allowlist.
+pub async fn put_backend_models(
+    State(state): State<AppState>,
+    Path(name): Path<String>,
+    Json(req): Json<SetModelsRequest>,
+) -> Result<Json<serde_json::Value>, StatusCode> {
+    if !backend_exists(&state, &name).await {
+        return Err(StatusCode::NOT_FOUND);
+    }
+    let scope = format!("backend:{name}");
+    match &req.models_enabled {
+        Some(list) => persist_override(&state, &scope, "models_enabled", list),
+        None => {
+            // JSON null / absent → delete the override (restore YAML behavior).
+            if let Err(e) = state.node_db.delete_override(&scope, "models_enabled") {
+                tracing::warn!(
+                    "config overlay: failed to clear models_enabled for {}: {}",
+                    name,
+                    e
+                );
+            }
+        }
+    }
+    remerge_and_apply(&state).await;
+    Ok(Json(serde_json::json!({ "ok": true, "backend": name })))
+}
+
+#[derive(Debug, Deserialize)]
+pub struct PatchBackendRequest {
+    #[serde(default)]
+    pub priority: Option<u32>,
+    #[serde(default)]
+    pub enabled: Option<bool>,
+    #[serde(default)]
+    pub hot_models: Option<Vec<String>>,
+}
+
+/// PUT /admin/config/backends/:name — patch priority / enabled / hot_models.
+pub async fn patch_backend(
+    State(state): State<AppState>,
+    Path(name): Path<String>,
+    Json(req): Json<PatchBackendRequest>,
+) -> Result<Json<serde_json::Value>, StatusCode> {
+    if !backend_exists(&state, &name).await {
+        return Err(StatusCode::NOT_FOUND);
+    }
+    let scope = format!("backend:{name}");
+    if let Some(p) = req.priority {
+        persist_override(&state, &scope, "priority", &p);
+    }
+    if let Some(e) = req.enabled {
+        persist_override(&state, &scope, "enabled", &e);
+    }
+    if let Some(ref h) = req.hot_models {
+        persist_override(&state, &scope, "hot_models", h);
+    }
+    remerge_and_apply(&state).await;
+    Ok(Json(serde_json::json!({ "ok": true, "backend": name })))
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CreateOverlayBackendRequest {
+    pub name: String,
+    pub url: String,
+    #[serde(default)]
+    pub backend: BackendType,
+    #[serde(default = "default_priority")]
+    pub priority: u32,
+}
+
+/// POST /admin/config/backends — create an overlay-defined backend (detect flow).
+pub async fn create_overlay_backend(
+    State(state): State<AppState>,
+    Json(req): Json<CreateOverlayBackendRequest>,
+) -> Result<Json<serde_json::Value>, StatusCode> {
+    if backend_exists(&state, &req.name).await {
+        return Err(StatusCode::CONFLICT);
+    }
+    let backend = Backend {
+        name: req.name.clone(),
+        url: req.url,
+        backend: req.backend,
+        priority: req.priority,
+        ..Default::default()
+    };
+    persist_override(
+        &state,
+        &format!("backend:{}", req.name),
+        "definition",
+        &backend,
+    );
+    remerge_and_apply(&state).await;
+    Ok(Json(serde_json::json!({ "ok": true, "backend": req.name })))
+}
+
+/// GET /admin/config/overrides — dump the raw overlay (D3 inspectability).
+pub async fn get_overrides(
+    State(state): State<AppState>,
+) -> Result<Json<serde_json::Value>, StatusCode> {
+    match state.node_db.list_overrides() {
+        Ok(list) => Ok(Json(serde_json::json!({ "overrides": list }))),
+        Err(e) => {
+            tracing::warn!("config overlay: failed to list overrides: {}", e);
+            Err(StatusCode::INTERNAL_SERVER_ERROR)
+        }
+    }
+}
+
+/// DELETE /admin/config/overrides/:scope/:key — remove one override, restoring YAML.
+pub async fn delete_override_handler(
+    State(state): State<AppState>,
+    Path((scope, key)): Path<(String, String)>,
+) -> Result<Json<serde_json::Value>, StatusCode> {
+    match state.node_db.delete_override(&scope, &key) {
+        Ok(true) => {
+            remerge_and_apply(&state).await;
+            Ok(Json(
+                serde_json::json!({ "ok": true, "removed": format!("{scope}/{key}") }),
+            ))
+        }
+        Ok(false) => Err(StatusCode::NOT_FOUND),
+        Err(e) => {
+            tracing::warn!("config overlay: failed to delete {}/{}: {}", scope, key, e);
+            Err(StatusCode::INTERNAL_SERVER_ERROR)
+        }
+    }
+}

--- a/src/backend/discovery.rs
+++ b/src/backend/discovery.rs
@@ -193,7 +193,9 @@ impl ModelDiscovery {
         info!("Model discovery complete");
     }
 
-    async fn discover_models(&self, pool: &BackendPool, backend: &Backend) -> Result<()> {
+    /// Re-probe a single backend and update the pool's model list (applies the
+    /// D2 filter). Public so the config API can nudge a refresh after a PUT.
+    pub async fn discover_models(&self, pool: &BackendPool, backend: &Backend) -> Result<()> {
         let model_names: Vec<String> = match backend.backend {
             crate::config::BackendType::LlamaServer | crate::config::BackendType::OpenAICompat => {
                 let url = format!("{}/v1/models", backend.url);

--- a/src/backend/discovery.rs
+++ b/src/backend/discovery.rs
@@ -57,6 +57,62 @@ struct GpuInfo {
     temperature: f32,
 }
 
+/// Apply the D2 model-filter order to a backend's raw model list:
+/// `raw → models_enabled (exact-name retain, when Some) → model_filter regex
+/// (only when models_enabled is None)`.
+///
+/// - `models_enabled = Some(list)` → keep only exact-name matches; `Some(&[])`
+///   yields an empty list ("expose nothing").
+/// - `models_enabled = None` → current behavior: apply the `model_filter` regex
+///   if set (an invalid regex warns and is skipped — never a hard error).
+pub(crate) fn filter_models(
+    mut names: Vec<String>,
+    models_enabled: Option<&[String]>,
+    model_filter: Option<&str>,
+    backend_name: &str,
+) -> Vec<String> {
+    if let Some(allow) = models_enabled {
+        let before = names.len();
+        let set: std::collections::HashSet<&str> = allow.iter().map(|s| s.as_str()).collect();
+        names.retain(|n| set.contains(n.as_str()));
+        tracing::debug!(
+            "models_enabled on {}: kept {}/{} models",
+            backend_name,
+            names.len(),
+            before
+        );
+        return names;
+    }
+
+    if let Some(filter) = model_filter {
+        match regex::Regex::new(filter) {
+            Ok(re) => {
+                let before = names.len();
+                names.retain(|name| re.is_match(name));
+                if names.len() < before {
+                    tracing::debug!(
+                        "model_filter '{}' on {}: kept {}/{} models",
+                        filter,
+                        backend_name,
+                        names.len(),
+                        before
+                    );
+                }
+            }
+            Err(e) => {
+                tracing::warn!(
+                    "Invalid model_filter '{}' on {}: {}",
+                    filter,
+                    backend_name,
+                    e
+                );
+            }
+        }
+    }
+
+    names
+}
+
 pub struct ModelDiscovery {
     client: reqwest::Client,
     interval: Duration,
@@ -138,7 +194,7 @@ impl ModelDiscovery {
     }
 
     async fn discover_models(&self, pool: &BackendPool, backend: &Backend) -> Result<()> {
-        let mut model_names: Vec<String> = match backend.backend {
+        let model_names: Vec<String> = match backend.backend {
             crate::config::BackendType::LlamaServer | crate::config::BackendType::OpenAICompat => {
                 let url = format!("{}/v1/models", backend.url);
                 let resp = self.client.get(&url).send().await?;
@@ -153,32 +209,13 @@ impl ModelDiscovery {
             }
         };
 
-        // Apply model_filter regex if configured
-        if let Some(ref filter) = backend.model_filter {
-            match regex::Regex::new(filter) {
-                Ok(re) => {
-                    let before = model_names.len();
-                    model_names.retain(|name| re.is_match(name));
-                    if model_names.len() < before {
-                        tracing::debug!(
-                            "model_filter '{}' on {}: kept {}/{} models",
-                            filter,
-                            backend.name,
-                            model_names.len(),
-                            before
-                        );
-                    }
-                }
-                Err(e) => {
-                    tracing::warn!(
-                        "Invalid model_filter '{}' on {}: {}",
-                        filter,
-                        backend.name,
-                        e
-                    );
-                }
-            }
-        }
+        // Apply the D2 filter order: models_enabled allowlist wins over model_filter.
+        let model_names = filter_models(
+            model_names,
+            backend.models_enabled.as_deref(),
+            backend.model_filter.as_deref(),
+            &backend.name,
+        );
 
         pool.update_models(&backend.name, model_names).await;
 
@@ -235,6 +272,68 @@ impl ModelDiscovery {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn v(items: &[&str]) -> Vec<String> {
+        items.iter().map(|s| s.to_string()).collect()
+    }
+
+    // ── D2 filter_models: models_enabled allowlist vs model_filter regex ─────
+
+    #[test]
+    fn models_enabled_takes_precedence_over_filter() {
+        // Allowlist wins; the regex (which would keep only b:2) is ignored.
+        let out = filter_models(
+            v(&["a:1", "b:2", "c:3"]),
+            Some(&v(&["a:1", "c:3"])),
+            Some("^b"),
+            "be",
+        );
+        assert_eq!(out, v(&["a:1", "c:3"]));
+    }
+
+    #[test]
+    fn some_empty_enabled_exposes_nothing() {
+        let out = filter_models(v(&["a", "b"]), Some(&[]), None, "be");
+        assert!(out.is_empty(), "Some(vec![]) => expose nothing");
+    }
+
+    #[test]
+    fn none_enabled_applies_filter_current_behavior() {
+        let out = filter_models(
+            v(&["keep-1", "drop-2", "keep-3"]),
+            None,
+            Some("^keep"),
+            "be",
+        );
+        assert_eq!(out, v(&["keep-1", "keep-3"]));
+    }
+
+    #[test]
+    fn none_enabled_no_filter_is_identity() {
+        let raw = v(&["x", "y", "z"]);
+        assert_eq!(filter_models(raw.clone(), None, None, "be"), raw);
+    }
+
+    #[test]
+    fn enabled_is_exact_name_not_substring() {
+        let out = filter_models(
+            v(&["llama3:8b", "llama3:70b"]),
+            Some(&v(&["llama3:8b"])),
+            None,
+            "be",
+        );
+        assert_eq!(out, v(&["llama3:8b"]));
+    }
+
+    #[test]
+    fn invalid_filter_regex_is_passthrough_not_error() {
+        let raw = v(&["a", "b"]);
+        // Invalid regex warns and keeps everything — never a hard error.
+        assert_eq!(
+            filter_models(raw.clone(), None, Some("(unclosed"), "be"),
+            raw
+        );
+    }
 
     #[test]
     fn parse_openai_models_response() {

--- a/src/backend/pool.rs
+++ b/src/backend/pool.rs
@@ -65,6 +65,7 @@ pub(crate) fn filter_healthy<'a>(
         .iter()
         .filter(|b| {
             b.healthy
+                && b.config.enabled
                 && !excluded.contains(&b.config.name)
                 && tags.iter().all(|t| b.config.tags.contains(t))
         })

--- a/src/backend/pool.rs
+++ b/src/backend/pool.rs
@@ -211,6 +211,17 @@ impl BackendPool {
         }
     }
 
+    /// Replace a backend's live config in place (GUI config overlay, #G2). The
+    /// routing gate (`enabled`), scorer (`priority`), warmer (`hot_models`) and
+    /// the next discovery tick (`models_enabled`/`model_filter`) all read this
+    /// config, so a PUT takes effect without a restart. No-op for an unknown name.
+    pub async fn update_backend_config(&self, name: &str, config: Backend) {
+        let mut backends = self.backends.write().await;
+        if let Some(backend) = backends.iter_mut().find(|b| b.config.name == name) {
+            backend.config = config;
+        }
+    }
+
     pub async fn update_gpu_metrics(&self, name: &str, metrics: GpuMetrics) {
         let mut backends = self.backends.write().await;
         if let Some(backend) = backends.iter_mut().find(|b| b.config.name == name) {

--- a/src/config.rs
+++ b/src/config.rs
@@ -551,6 +551,20 @@ pub struct Backend {
     /// backend (neutral, weight-dropped).
     #[serde(default)]
     pub power_cost: Option<f64>,
+
+    /// GUI-managed allowlist. When `Some`, discovery retains ONLY these models
+    /// (exact-name match on the backend's reported model list). `Some(vec![])` is
+    /// valid and means "expose nothing" (explicit off-switch). Takes precedence
+    /// over `model_filter` when both are set. `None` (the default) = current
+    /// behavior, zero change for existing configs.
+    #[serde(default)]
+    pub models_enabled: Option<Vec<String>>,
+
+    /// Whether this backend participates in routing. `true` (the default) = current
+    /// behavior. Set `false` (via the GUI config overlay) to keep the backend
+    /// visible/toggleable while excluding it from the routing gate.
+    #[serde(default = "default_true")]
+    pub enabled: bool,
 }
 
 impl Backend {
@@ -580,6 +594,8 @@ impl Default for Backend {
             max_context_len: None,
             locality: None,
             power_cost: None,
+            models_enabled: None,
+            enabled: true,
         }
     }
 }
@@ -1243,6 +1259,98 @@ impl Config {
         Ok(config)
     }
 
+    /// Apply GUI config-overlay rows onto the parsed config (D3). Each row is
+    /// `(scope, key, value_json)`; the overlay (DB) wins over YAML for field
+    /// overrides. Scope `backend:{name}` with key `models_enabled`/`hot_models`/
+    /// `priority`/`enabled` patches that backend's field; key `definition` (full
+    /// Backend JSON) appends a GUI-created backend AFTER the YAML backends — a
+    /// name collision keeps the YAML backend and warns. Never bails: a malformed
+    /// row or unknown target is warned and skipped (config-error rule).
+    ///
+    /// Pure over the override slice (no DB dependency) so the merge is unit-
+    /// testable and deterministic given a stable row order.
+    pub fn apply_overrides(&mut self, overrides: &[(String, String, String)]) {
+        for (scope, key, value_json) in overrides {
+            let Some(name) = scope.strip_prefix("backend:") else {
+                // Non-backend scopes (e.g. future "routing") are not part of the
+                // v1.4 field merge — ignore silently.
+                continue;
+            };
+
+            if key == "definition" {
+                match serde_json::from_str::<Backend>(value_json) {
+                    Ok(b) => {
+                        if self.backends.iter().any(|e| e.name == b.name) {
+                            tracing::warn!(
+                                "config overlay defines backend '{}' but a YAML backend with that name exists — keeping YAML, ignoring overlay",
+                                b.name
+                            );
+                        } else {
+                            self.backends.push(b);
+                        }
+                    }
+                    Err(e) => tracing::warn!(
+                        "config overlay: invalid backend definition for '{}' — ignored: {}",
+                        name,
+                        e
+                    ),
+                }
+                continue;
+            }
+
+            let Some(backend) = self.backends.iter_mut().find(|b| b.name == name) else {
+                tracing::warn!(
+                    "config overlay: override for unknown backend '{}' (key '{}') — ignored",
+                    name,
+                    key
+                );
+                continue;
+            };
+
+            match key.as_str() {
+                // JSON `null` clears the allowlist (back to YAML/None behavior);
+                // an array sets it. `[]` is a valid "expose nothing".
+                "models_enabled" => match serde_json::from_str::<Option<Vec<String>>>(value_json) {
+                    Ok(v) => backend.models_enabled = v,
+                    Err(e) => tracing::warn!(
+                        "config overlay: invalid models_enabled for '{}' — ignored: {}",
+                        name,
+                        e
+                    ),
+                },
+                "hot_models" => match serde_json::from_str::<Vec<String>>(value_json) {
+                    Ok(v) => backend.hot_models = v,
+                    Err(e) => tracing::warn!(
+                        "config overlay: invalid hot_models for '{}' — ignored: {}",
+                        name,
+                        e
+                    ),
+                },
+                "priority" => match serde_json::from_str::<u32>(value_json) {
+                    Ok(v) => backend.priority = v,
+                    Err(e) => tracing::warn!(
+                        "config overlay: invalid priority for '{}' — ignored: {}",
+                        name,
+                        e
+                    ),
+                },
+                "enabled" => match serde_json::from_str::<bool>(value_json) {
+                    Ok(v) => backend.enabled = v,
+                    Err(e) => tracing::warn!(
+                        "config overlay: invalid enabled for '{}' — ignored: {}",
+                        name,
+                        e
+                    ),
+                },
+                other => tracing::warn!(
+                    "config overlay: unknown key '{}' for backend '{}' — ignored",
+                    other,
+                    name
+                ),
+            }
+        }
+    }
+
     fn warn_deprecated_keys(value: &serde_yaml::Value, path: &[String]) {
         if let serde_yaml::Value::Mapping(map) = value {
             for (k, v) in map {
@@ -1421,6 +1529,119 @@ mod tests {
     use super::BackendType;
     use super::Config;
     use std::time::Duration;
+
+    // ── D3 config overlay: Config::apply_overrides ───────────────────────────
+
+    fn one_backend(name: &str) -> Config {
+        serde_yaml::from_str(&format!(
+            "backends:\n  - name: {name}\n    url: http://{name}\n    priority: 50\n"
+        ))
+        .unwrap()
+    }
+
+    #[test]
+    fn apply_overrides_empty_is_no_change() {
+        let mut cfg = one_backend("a");
+        cfg.apply_overrides(&[]);
+        assert_eq!(cfg.backends.len(), 1);
+        assert_eq!(cfg.backends[0].models_enabled, None);
+        assert!(cfg.backends[0].enabled);
+        assert_eq!(cfg.backends[0].priority, 50);
+    }
+
+    #[test]
+    fn apply_overrides_patches_all_field_keys() {
+        let mut cfg = one_backend("local");
+        cfg.apply_overrides(&[
+            (
+                "backend:local".into(),
+                "models_enabled".into(),
+                r#"["a","b"]"#.into(),
+            ),
+            ("backend:local".into(), "priority".into(), "99".into()),
+            ("backend:local".into(), "enabled".into(), "false".into()),
+            (
+                "backend:local".into(),
+                "hot_models".into(),
+                r#"["a"]"#.into(),
+            ),
+        ]);
+        let b = &cfg.backends[0];
+        assert_eq!(
+            b.models_enabled.as_deref(),
+            Some(&["a".to_string(), "b".to_string()][..])
+        );
+        assert_eq!(b.priority, 99);
+        assert!(!b.enabled);
+        assert_eq!(b.hot_models, vec!["a".to_string()]);
+    }
+
+    #[test]
+    fn apply_overrides_models_enabled_null_clears() {
+        let mut cfg: Config = serde_yaml::from_str(
+            "backends:\n  - name: local\n    url: http://x\n    priority: 50\n    models_enabled: [\"x\"]\n",
+        )
+        .unwrap();
+        assert!(cfg.backends[0].models_enabled.is_some());
+        cfg.apply_overrides(&[(
+            "backend:local".into(),
+            "models_enabled".into(),
+            "null".into(),
+        )]);
+        assert_eq!(cfg.backends[0].models_enabled, None);
+    }
+
+    #[test]
+    fn apply_overrides_definition_appends_and_collision_keeps_yaml() {
+        let mut cfg = one_backend("yaml-be");
+        let new_def = r#"{"name":"gui-be","url":"http://gui","priority":10}"#;
+        let collision = r#"{"name":"yaml-be","url":"http://EVIL","priority":1}"#;
+        cfg.apply_overrides(&[
+            ("backend:gui-be".into(), "definition".into(), new_def.into()),
+            (
+                "backend:yaml-be".into(),
+                "definition".into(),
+                collision.into(),
+            ),
+        ]);
+        // gui-be appended; collision on yaml-be ignored (YAML wins).
+        assert_eq!(cfg.backends.len(), 2);
+        let yaml_be = cfg.backends.iter().find(|b| b.name == "yaml-be").unwrap();
+        assert_eq!(
+            yaml_be.url, "http://yaml-be",
+            "YAML backend must win the name collision"
+        );
+        assert!(cfg.backends.iter().any(|b| b.name == "gui-be"));
+    }
+
+    #[test]
+    fn apply_overrides_unknown_backend_and_bad_json_are_skipped_not_panic() {
+        let mut cfg = one_backend("a");
+        cfg.apply_overrides(&[
+            ("backend:ghost".into(), "priority".into(), "5".into()), // unknown backend
+            ("backend:a".into(), "priority".into(), "not-a-number".into()), // bad JSON
+            ("routing".into(), "model_map".into(), "{}".into()),     // non-backend scope
+        ]);
+        assert_eq!(cfg.backends.len(), 1);
+        assert_eq!(
+            cfg.backends[0].priority, 50,
+            "bad priority JSON left the field untouched"
+        );
+    }
+
+    #[test]
+    fn apply_overrides_is_deterministic() {
+        let ov = vec![
+            ("backend:a".into(), "priority".into(), "10".into()),
+            ("backend:a".into(), "enabled".into(), "false".into()),
+        ];
+        let mut c1 = one_backend("a");
+        let mut c2 = c1.clone();
+        c1.apply_overrides(&ov);
+        c2.apply_overrides(&ov);
+        assert_eq!(c1.backends[0].priority, c2.backends[0].priority);
+        assert_eq!(c1.backends[0].enabled, c2.backends[0].enabled);
+    }
 
     #[test]
     fn parse_duration_seconds() {

--- a/src/nodes/db.rs
+++ b/src/nodes/db.rs
@@ -1,9 +1,19 @@
 use super::registry::AgentCapabilities;
 use super::types::*;
 use anyhow::Result;
-use rusqlite::Connection;
+use rusqlite::{Connection, OptionalExtension};
 use serde::{Deserialize, Serialize};
 use std::sync::Mutex;
+
+/// A single row of the GUI config overlay (gui-tray-spec D3): a scoped,
+/// JSON-encoded value that overrides YAML config at load/reload time.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ConfigOverride {
+    pub scope: String,
+    pub key: String,
+    pub value_json: String,
+    pub updated_at: String,
+}
 
 /// Status of a model file download.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -85,6 +95,78 @@ impl NodeDb {
         };
         db.migrate()?;
         Ok(db)
+    }
+
+    // ── config_overrides CRUD (GUI config overlay, D3) ───────────────────────
+
+    /// Upsert a config override `(scope, key) -> value_json`.
+    pub fn set_override(&self, scope: &str, key: &str, value_json: &str) -> Result<()> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| anyhow::anyhow!("DB lock: {}", e))?;
+        let now = chrono::Utc::now().to_rfc3339();
+        conn.execute(
+            "INSERT INTO config_overrides (scope, key, value_json, updated_at)
+             VALUES (?1, ?2, ?3, ?4)
+             ON CONFLICT(scope, key) DO UPDATE SET value_json = ?3, updated_at = ?4;",
+            rusqlite::params![scope, key, value_json, now],
+        )?;
+        Ok(())
+    }
+
+    /// Fetch a single override's `value_json`, or `None` if absent.
+    pub fn get_override(&self, scope: &str, key: &str) -> Result<Option<String>> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| anyhow::anyhow!("DB lock: {}", e))?;
+        let value = conn
+            .query_row(
+                "SELECT value_json FROM config_overrides WHERE scope = ?1 AND key = ?2;",
+                rusqlite::params![scope, key],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()?;
+        Ok(value)
+    }
+
+    /// Delete a single override. Returns `true` if a row was removed.
+    pub fn delete_override(&self, scope: &str, key: &str) -> Result<bool> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| anyhow::anyhow!("DB lock: {}", e))?;
+        let removed = conn.execute(
+            "DELETE FROM config_overrides WHERE scope = ?1 AND key = ?2;",
+            rusqlite::params![scope, key],
+        )?;
+        Ok(removed > 0)
+    }
+
+    /// List all overrides in a deterministic `(scope, key)` order so the overlay
+    /// merge is reproducible.
+    pub fn list_overrides(&self) -> Result<Vec<ConfigOverride>> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| anyhow::anyhow!("DB lock: {}", e))?;
+        let mut stmt = conn.prepare(
+            "SELECT scope, key, value_json, updated_at FROM config_overrides ORDER BY scope, key;",
+        )?;
+        let rows = stmt.query_map([], |row| {
+            Ok(ConfigOverride {
+                scope: row.get(0)?,
+                key: row.get(1)?,
+                value_json: row.get(2)?,
+                updated_at: row.get(3)?,
+            })
+        })?;
+        let mut out = Vec::new();
+        for r in rows {
+            out.push(r?);
+        }
+        Ok(out)
     }
 
     fn migrate(&self) -> Result<()> {
@@ -179,6 +261,18 @@ impl NodeDb {
             .ok();
         conn.execute_batch("ALTER TABLE nodes ADD COLUMN agent_version TEXT;")
             .ok();
+
+        // Migration v6: GUI config-overlay store (gui-tray-spec D3). Generic
+        // (scope, key) -> JSON value so future GUI settings need no migration.
+        conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS config_overrides (
+                scope      TEXT NOT NULL,
+                key        TEXT NOT NULL,
+                value_json TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                PRIMARY KEY (scope, key)
+            );",
+        )?;
 
         Ok(())
     }
@@ -803,6 +897,66 @@ mod tests {
 
     fn test_db() -> NodeDb {
         NodeDb::open_in_memory().unwrap()
+    }
+
+    // ── config_overrides CRUD (D3) ───────────────────────────────────────────
+
+    #[test]
+    fn config_override_round_trip() {
+        let db = test_db();
+        assert!(db.list_overrides().unwrap().is_empty());
+
+        db.set_override("backend:local", "models_enabled", r#"["a"]"#)
+            .unwrap();
+        assert_eq!(
+            db.get_override("backend:local", "models_enabled")
+                .unwrap()
+                .as_deref(),
+            Some(r#"["a"]"#)
+        );
+
+        // Upsert overwrites value, does not duplicate the row.
+        db.set_override("backend:local", "models_enabled", r#"["a","b"]"#)
+            .unwrap();
+        assert_eq!(
+            db.get_override("backend:local", "models_enabled")
+                .unwrap()
+                .as_deref(),
+            Some(r#"["a","b"]"#)
+        );
+        assert_eq!(db.list_overrides().unwrap().len(), 1);
+
+        // Delete: first removes, second is a no-op (false).
+        assert!(db
+            .delete_override("backend:local", "models_enabled")
+            .unwrap());
+        assert!(db
+            .get_override("backend:local", "models_enabled")
+            .unwrap()
+            .is_none());
+        assert!(!db
+            .delete_override("backend:local", "models_enabled")
+            .unwrap());
+    }
+
+    #[test]
+    fn config_overrides_listed_in_deterministic_order() {
+        let db = test_db();
+        db.set_override("backend:z", "priority", "1").unwrap();
+        db.set_override("backend:a", "enabled", "true").unwrap();
+        db.set_override("backend:a", "priority", "10").unwrap();
+        let l = db.list_overrides().unwrap();
+        // ORDER BY scope, key → (a,enabled), (a,priority), (z,priority)
+        let keys: Vec<(String, String)> =
+            l.iter().map(|o| (o.scope.clone(), o.key.clone())).collect();
+        assert_eq!(
+            keys,
+            vec![
+                ("backend:a".into(), "enabled".into()),
+                ("backend:a".into(), "priority".into()),
+                ("backend:z".into(), "priority".into()),
+            ]
+        );
     }
 
     #[test]

--- a/src/server.rs
+++ b/src/server.rs
@@ -857,6 +857,28 @@ impl Server {
                 "/admin/config",
                 axum::routing::get(admin::get_config).put(admin::update_config),
             )
+            // GUI config overlay (gui-tray-spec #G2)
+            .route(
+                "/admin/config/backends",
+                axum::routing::get(admin::get_effective_backends)
+                    .post(admin::create_overlay_backend),
+            )
+            .route(
+                "/admin/config/backends/:name",
+                axum::routing::put(admin::patch_backend),
+            )
+            .route(
+                "/admin/config/backends/:name/models",
+                axum::routing::put(admin::put_backend_models),
+            )
+            .route(
+                "/admin/config/overrides",
+                axum::routing::get(admin::get_overrides),
+            )
+            .route(
+                "/admin/config/overrides/:scope/:key",
+                axum::routing::delete(admin::delete_override_handler),
+            )
             .layer(axum::middleware::from_fn_with_state(
                 state.clone(),
                 require_api_key,
@@ -2493,6 +2515,244 @@ mod tests {
         assert_eq!(state.pool.all().await, vec![String::from("new")]);
 
         let _ = std::fs::remove_file(temp_path);
+    }
+
+    // ── #G2 GUI config API ────────────────────────────────────────────────
+
+    fn uniq_suffix() -> String {
+        // Atomic counter guarantees uniqueness across parallel tests (a bare
+        // nanosecond timestamp can collide, sharing a temp path → flaky reload).
+        static COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+        format!(
+            "{}-{}",
+            std::process::id(),
+            COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+        )
+    }
+
+    fn write_temp_yaml(cfg: &Config) -> std::path::PathBuf {
+        let path = std::env::temp_dir().join(format!("herd-g2-{}.yaml", uniq_suffix()));
+        std::fs::write(&path, cfg.to_yaml().unwrap()).unwrap();
+        path
+    }
+
+    fn cfg_with_backend(b: Backend) -> Config {
+        Config {
+            server: crate::config::ServerConfig {
+                api_key: Some("k".into()),
+                ..Default::default()
+            },
+            backends: vec![b],
+            ..Default::default()
+        }
+    }
+
+    fn build_test_state(initial: Config, config_path: std::path::PathBuf) -> AppState {
+        let u = uniq_suffix();
+        let pool = Arc::new(BackendPool::new(
+            initial.backends.clone(),
+            initial.circuit_breaker.failure_threshold,
+            parse_duration(&initial.circuit_breaker.recovery_time).unwrap(),
+        ));
+        let routing_stats = Arc::new(RoutingStats::new());
+        let session_affinity = Arc::new(SessionAffinity::new());
+        let router = create_router(
+            initial.routing.strategy.clone(),
+            (*pool).clone(),
+            &initial.routing,
+            Arc::clone(&routing_stats),
+            Arc::clone(&session_affinity),
+        );
+        AppState {
+            pool,
+            router: Arc::new(tokio::sync::RwLock::new(router)),
+            client: Arc::new(reqwest::Client::new()),
+            mgmt_client: Arc::new(reqwest::Client::new()),
+            config: Arc::new(tokio::sync::RwLock::new(initial.clone())),
+            analytics: Arc::new(
+                Analytics::new(&std::env::temp_dir().join(format!("herd-g2-an-{u}"))).unwrap(),
+            ),
+            session_store: Arc::new(SessionStore::new(100)),
+            agent_audit: Arc::new(
+                AgentAudit::new(&std::env::temp_dir().join(format!("herd-g2-au-{u}"))).unwrap(),
+            ),
+            metrics: Arc::new(crate::metrics::Metrics::new()),
+            node_db: Arc::new(
+                crate::nodes::NodeDb::open(&std::env::temp_dir().join(format!("herd-g2-db-{u}")))
+                    .unwrap(),
+            ),
+            node_registry: Arc::new(crate::nodes::NodeRegistry::new(Duration::from_secs(30))),
+            binary_store: Arc::new(crate::nodes::BinaryStore::new()),
+            budget: crate::budget::BudgetTracker::new(initial.budget.clone()),
+            rate_limiter: Arc::new(tokio::sync::RwLock::new(
+                crate::rate_limit::RateLimiter::new(&initial.rate_limiting),
+            )),
+            frontier_rate_limiter: Arc::new(tokio::sync::RwLock::new(
+                crate::providers::rate_limit::ProviderRateLimiter::new(&initial.providers),
+            )),
+            auto_cache: Arc::new(crate::classifier_auto::ClassificationCache::new(1000)),
+            cost_db: Arc::new(crate::providers::cost_db::CostDb::new(
+                rusqlite::Connection::open_in_memory().unwrap(),
+            )),
+            routing_timeout_ms: Arc::new(AtomicU64::new(1_000)),
+            routing_retry_count: Arc::new(AtomicU32::new(1)),
+            config_path: Some(config_path),
+            routing_stats,
+            session_affinity,
+        }
+    }
+
+    #[tokio::test]
+    async fn config_api_put_get_models_round_trip() {
+        let cfg = cfg_with_backend(make_backend("local", "http://x:11434", 50));
+        let path = write_temp_yaml(&cfg);
+        let state = build_test_state(cfg, path.clone());
+
+        let before = crate::api::admin::get_effective_backends(axum::extract::State(state.clone()))
+            .await
+            .0;
+        assert!(before["backends"][0]["models_enabled"].is_null());
+
+        let _ = crate::api::admin::put_backend_models(
+            axum::extract::State(state.clone()),
+            axum::extract::Path("local".to_string()),
+            axum::Json(crate::api::admin::SetModelsRequest {
+                models_enabled: Some(vec!["a".into(), "b".into()]),
+            }),
+        )
+        .await
+        .unwrap();
+
+        let after = crate::api::admin::get_effective_backends(axum::extract::State(state.clone()))
+            .await
+            .0;
+        assert_eq!(
+            after["backends"][0]["models_enabled"],
+            serde_json::json!(["a", "b"])
+        );
+        assert!(state
+            .node_db
+            .get_override("backend:local", "models_enabled")
+            .unwrap()
+            .is_some());
+
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[tokio::test]
+    async fn config_api_null_clears_override_restoring_yaml() {
+        let cfg = cfg_with_backend(make_backend("local", "http://x:11434", 50));
+        let path = write_temp_yaml(&cfg);
+        let state = build_test_state(cfg, path.clone());
+
+        let _ = crate::api::admin::put_backend_models(
+            axum::extract::State(state.clone()),
+            axum::extract::Path("local".to_string()),
+            axum::Json(crate::api::admin::SetModelsRequest {
+                models_enabled: Some(vec!["a".into()]),
+            }),
+        )
+        .await
+        .unwrap();
+        // null clears
+        let _ = crate::api::admin::put_backend_models(
+            axum::extract::State(state.clone()),
+            axum::extract::Path("local".to_string()),
+            axum::Json(crate::api::admin::SetModelsRequest {
+                models_enabled: None,
+            }),
+        )
+        .await
+        .unwrap();
+
+        assert!(state
+            .node_db
+            .get_override("backend:local", "models_enabled")
+            .unwrap()
+            .is_none());
+        let eff = crate::api::admin::get_effective_backends(axum::extract::State(state.clone()))
+            .await
+            .0;
+        assert!(
+            eff["backends"][0]["models_enabled"].is_null(),
+            "cleared override restores YAML behavior (None)"
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[tokio::test]
+    async fn config_api_unknown_backend_404() {
+        let cfg = cfg_with_backend(make_backend("local", "http://x:11434", 50));
+        let path = write_temp_yaml(&cfg);
+        let state = build_test_state(cfg, path.clone());
+        let r = crate::api::admin::put_backend_models(
+            axum::extract::State(state.clone()),
+            axum::extract::Path("ghost".to_string()),
+            axum::Json(crate::api::admin::SetModelsRequest {
+                models_enabled: Some(vec![]),
+            }),
+        )
+        .await;
+        assert_eq!(r.unwrap_err(), axum::http::StatusCode::NOT_FOUND);
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[tokio::test]
+    async fn config_api_override_survives_reload() {
+        let cfg = cfg_with_backend(make_backend("local", "http://x:11434", 50));
+        let path = write_temp_yaml(&cfg);
+        let state = build_test_state(cfg, path.clone());
+
+        let _ = crate::api::admin::patch_backend(
+            axum::extract::State(state.clone()),
+            axum::extract::Path("local".to_string()),
+            axum::Json(crate::api::admin::PatchBackendRequest {
+                priority: Some(7),
+                enabled: Some(false),
+                hot_models: None,
+            }),
+        )
+        .await
+        .unwrap();
+
+        // A full reload re-reads YAML then re-applies the overlay.
+        state.reload_config().await.unwrap();
+        let eff = crate::api::admin::get_effective_backends(axum::extract::State(state.clone()))
+            .await
+            .0;
+        assert_eq!(eff["backends"][0]["priority"], 7);
+        assert_eq!(eff["backends"][0]["enabled"], false);
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[tokio::test]
+    async fn config_api_requires_api_key() {
+        use tower::ServiceExt; // for oneshot
+        let cfg = cfg_with_backend(make_backend("local", "http://x:11434", 50));
+        let path = write_temp_yaml(&cfg);
+        let state = build_test_state(cfg, path.clone());
+        // Mount the endpoint behind the same guard used in production.
+        let app = axum::Router::new()
+            .route(
+                "/admin/config/backends",
+                axum::routing::get(crate::api::admin::get_effective_backends),
+            )
+            .layer(axum::middleware::from_fn_with_state(
+                state.clone(),
+                require_api_key,
+            ))
+            .with_state(state);
+        let resp = app
+            .oneshot(
+                axum::http::Request::builder()
+                    .uri("/admin/config/backends")
+                    .body(axum::body::Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), axum::http::StatusCode::UNAUTHORIZED);
+        let _ = std::fs::remove_file(path);
     }
 
     #[test]

--- a/src/server.rs
+++ b/src/server.rs
@@ -202,6 +202,22 @@ impl AppState {
         let mut new_config = Config::from_file(path)?;
         new_config.validate()?;
 
+        // Re-apply the GUI config overlay (D3) on top of the freshly parsed YAML,
+        // so a hot-reload preserves GUI-managed overrides. Never bails.
+        match self.node_db.list_overrides() {
+            Ok(overrides) => {
+                let rows: Vec<(String, String, String)> = overrides
+                    .into_iter()
+                    .map(|o| (o.scope, o.key, o.value_json))
+                    .collect();
+                new_config.apply_overrides(&rows);
+            }
+            Err(e) => tracing::warn!(
+                "config overlay: failed to load overrides on reload — using YAML config as-is: {}",
+                e
+            ),
+        }
+
         // Detect settings that changed but require a restart to take effect
         let mut restart_warnings: Vec<String> = Vec::new();
         {
@@ -357,6 +373,25 @@ impl Server {
         let data_dir = self.config.resolved_data_dir();
         std::fs::create_dir_all(&data_dir)?;
 
+        // Open the node DB early: it holds the GUI config overlay (gui-tray-spec
+        // D3), which we merge onto the parsed YAML config BEFORE building the pool
+        // so the routable set reflects overrides from the first tick. Never bails
+        // — if listing fails we warn and proceed with the YAML config unchanged.
+        let node_db = Arc::new(crate::nodes::NodeDb::open(&data_dir)?);
+        match node_db.list_overrides() {
+            Ok(overrides) => {
+                let rows: Vec<(String, String, String)> = overrides
+                    .into_iter()
+                    .map(|o| (o.scope, o.key, o.value_json))
+                    .collect();
+                self.config.apply_overrides(&rows);
+            }
+            Err(e) => tracing::warn!(
+                "config overlay: failed to load overrides — using YAML config as-is: {}",
+                e
+            ),
+        }
+
         // Create backend pool with circuit breaker config
         let pool = BackendPool::new(
             self.config.backends.clone(),
@@ -467,7 +502,7 @@ impl Server {
             self.config.server.enrollment_key = Some(key);
         }
 
-        let node_db = Arc::new(crate::nodes::NodeDb::open(&data_dir)?);
+        // `node_db` was opened earlier (before the pool) to apply the config overlay.
         let cost_db = Arc::new(crate::providers::cost_db::CostDb::new(
             rusqlite::Connection::open(data_dir.join("frontier_costs.db"))?,
         ));

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,56 +1,35 @@
 # Herd — Working TODO
 
-> Scratchpad for in-flight work. Milestone tracking lives in `ROADMAP.md`.
+> Scratchpad for in-flight work. Milestone tracking in `ROADMAP.md`.
 
-**Last updated:** 2026-07-02
-
----
-
-## ACTIVE — Dashboard: unify Backends+Fleet + self-enroll
-
-**Goal (user):** Backends and Fleet aren't really different — unify them. Any node
-appears on the main dashboard. Easy "add node" + a surfaced install link. Opening the
-dashboard on a computer → easily make that computer a node.
-
-**Findings:**
-- 3 node types today, split across 2 tabs: static backends (`herd.yaml` → `/admin/backends`,
-  "Backends" card grid) + enrolled nodes (`herd-tune` → `POST /api/nodes/register`) + agent
-  nodes (`herd agent` heartbeat) — the latter two in the "Fleet" table (`/api/nodes`).
-- Install infra EXISTS: `GET /api/nodes/script?os=windows|linux` bakes the gateway endpoint
-  (Host header / `HERD_PUBLIC_URL`) + enrollment key into `herd-tune.ps1/sh`. herd-tune does
-  full GPU/VRAM detect + backend setup + register.
-- dashboard.html is a single 2829-line file, `include_str!`-compiled into the binary
-  (`/dashboard`). Tabs: backends(default)/analytics/sessions/agent-guide/fleet/models/settings.
-
-**Design (locked with user):**
-- ONE unified **"Nodes"** view replaces the separate Backends + Fleet tabs. Merge
-  `/admin/backends` (+`/status`) and `/api/nodes` client-side into one table. **No source
-  column** — treat every node identically (columns: name, GPU, VRAM, status, models, load/latency).
-- Prominent **"Add Node"** affordance → panel with an OS-auto-detected **herd-tune one-liner**
-  pre-pointed at THIS gateway (`window.location.origin`): e.g. Windows
-  `iwr <origin>/api/nodes/script?os=windows -OutFile herd-tune.ps1; ./herd-tune.ps1`.
-  Copy button. Both windows + linux shown.
-
-### Plan
-- [ ] Read dashboard render paths (backends grid render, fleet table render, switchTab,
-      /api/nodes + /admin/backends + /status fetch/merge points).
-- [ ] Build unified `renderNodes()` — normalize static-backend and node schemas to one row
-      shape; merge + best-effort dedup by name/url (full enrolled+agent dedup deferred to v1.4).
-- [ ] Replace Backends + Fleet tabs with one "Nodes" tab (keep analytics/sessions/guide/models/settings).
-- [ ] Add "Add Node" panel: herd-tune one-liner (origin-baked, OS-detected), copy button, link.
-- [ ] Rebuild + verify live against the running BASTION gateway (local-5090 + citadel + warden
-      should all appear in one list; install one-liner shows correct origin).
-- [ ] Update CLAUDE.md dashboard-tab rules + skills.md if endpoints/tabs change.
-
-### Notes / open
-- Known limitation: enrolled+agent on one host = two entries (dedup deferred v1.4). Dashboard
-  merges but won't fully de-dup those; surface both, don't crash.
-- dashboard.html is compiled in → changes need `cargo build` + gateway restart to test live.
+**Last updated:** 2026-07-03
 
 ---
 
-## DONE — recent (collapsed; full detail in git history)
-- **Fleet two-box smoke test PASSED** (2026-07-02) — gateway BASTION + agent CITADEL over
-  Tailscale; cross-machine routing validated. See memory `herd-fleet-two-box-smoke-test`.
-- **v1.3.0 released** — scorer feature-complete (22/23 dims); tag `v1.3.0`, GH release, 4 artifacts.
-- **Scorer Phase 4 + dim-22 VRAM tuning** — PRs #29–33; dim 21 deferred to v1.4.
+## ACTIVE — GUI/tray spec: PR #G1 + #G2 (two feat: commits)
+
+Spec: `docs/specs/gui-tray-spec.md`. Fixes CITADEL's 84-model sprawl via a
+GUI-managed `models_enabled` allowlist + a SQLite config overlay (YAML stays the
+hand-edited base). #G1 = data model + overlay; #G2 = admin API. Do NOT start #G3–#G5.
+
+Non-negotiables (CLAUDE.md): defaults-off / zero change for existing `herd.yaml`;
+never `bail!` on config; no `unwrap()` in lib; backend-agnostic routing; `cargo test` +
+`cargo clippy` green before EACH commit; existing tests stay green.
+
+### #G1 — models_enabled + config overlay store  (commit 1: feat:)
+- [ ] config.rs: `models_enabled: Option<Vec<String>>` (default None) + `enabled: bool`
+      (default true) on Backend; Default impl + exhaustive `Backend {}` literals.
+- [ ] config.rs: `Config::apply_overrides(&mut self, &[(scope,key,value_json)])` per D3
+      (backend:{name} keys models_enabled/hot_models/priority/enabled; `definition` append,
+      YAML-wins-on-collision + warn; parse errors warn+skip; pure/testable).
+- [ ] discovery.rs: pure `filter_models(...)` per D2 order; discover_models calls it.
+- [ ] pool.rs: filter_healthy also requires `b.config.enabled`.
+- [ ] db.rs: migration v6 `config_overrides` + CRUD (set/get/delete/list).
+- [ ] server.rs: startup opens node_db before pool + apply_overrides; reload_config merges.
+- [ ] Tests: filter precedence, Some(vec![]) empties, None byte-identical, merge determinism,
+      collision warn, override round-trip.
+
+### #G2 — Admin config API  (commit 2: feat:)
+- [ ] D4 endpoints minus detect/pull; api_key guard; PUT writes override + patches AppState +
+      nudges discovery; null clears; skills.md + Agent Guide; tests (401, round-trip, null,
+      404, reload survives).


### PR DESCRIPTION
Implements **#G1 + #G2** from `docs/specs/gui-tray-spec.md` — the value core that fixes model sprawl (e.g. CITADEL's 84 accumulated models poisoning the residency gate) via a GUI-managed allowlist + a SQLite config overlay. Two commits.

**Defaults-off** — existing `herd.yaml` files load byte-for-byte identically; every new field defaults to current behavior.

### #G1 — `models_enabled` + config overlay store (`3e79d68`)
- `Backend.models_enabled: Option<Vec<String>>` (default None; `Some([])` = expose nothing) + `enabled: bool` (default true).
- `Config::apply_overrides` — D3 merge: backend field patches + `definition` append (YAML wins on name collision + warn); malformed rows warn + skip, never bails. Pure/unit-testable.
- Pure `filter_models` with the D2 order (allowlist exact-retain wins over `model_filter` regex; `None` = unchanged).
- `filter_healthy` honors `enabled` (backend-agnostic); migration v6 `config_overrides` + `NodeDb` CRUD; startup + hot-reload apply the overlay onto the YAML config.

### #G2 — admin config API (`4a0153b`)
- Six D4 endpoints (minus detect/pull → #G4) behind the existing `require_api_key` guard: effective-config GET, models allowlist PUT (`null` clears), backend patch PUT, overlay-backend POST, overrides GET, override DELETE.
- Each mutation persists to the overlay then `remerge_and_apply` (re-read YAML base + re-apply overrides → patch in-memory config → update live pool + nudge discovery) → routable set changes **within a discovery tick, no restart**; clearing an override restores the YAML value.
- Registered in `skills.md` + dashboard Agent Guide (repo rule).

### Verification
- `cargo test`: **576 lib + all integration suites pass, 0 failed** (+19 new tests).
- `cargo clippy --all-targets -D warnings` clean · `cargo fmt` clean · no lib `unwrap` · never `bail!`.
- Tests: filter precedence, `Some([])` empties, `None` byte-identical, merge determinism, collision-keeps-YAML, NodeDb round-trip, 401-without-key, PUT→GET round-trip, null-clears, unknown-backend 404, override-survives-reload.

Does **not** start #G3–#G5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)