### PR TITLE
chore(release): v1.4.0 + bundle herd-tray.exe

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,12 @@ jobs:
       - name: Build
         run: cargo build --release --target ${{ matrix.target }}
 
+      # herd-tray is a separate workspace member (not built by the default
+      # `cargo build` above); build it so the Windows zip can bundle it.
+      - name: Build tray (Windows)
+        if: matrix.target == 'x86_64-pc-windows-msvc'
+        run: cargo build --release -p herd-tray --target ${{ matrix.target }}
+
       - name: Package (tar.gz)
         if: matrix.archive == 'tar.gz'
         run: |
@@ -56,7 +62,7 @@ jobs:
         if: matrix.archive == 'zip'
         shell: pwsh
         run: |
-          Compress-Archive -Path "target/${{ matrix.target }}/release/herd.exe" -DestinationPath "herd-${{ github.ref_name }}-${{ matrix.target }}.zip"
+          Compress-Archive -Path "target/${{ matrix.target }}/release/herd.exe", "target/${{ matrix.target }}/release/herd-tray.exe" -DestinationPath "herd-${{ github.ref_name }}-${{ matrix.target }}.zip"
 
       - name: Upload artifact
         uses: actions/upload-artifact@v7

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1453,7 +1453,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "herd"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "herd"
-version = "1.3.0"
+version = "1.4.0"
 edition = "2021"
 authors = ["Swift Innovative Technologies"]
 description = "Intelligent LLM router with multi-backend GPU-aware routing"


### PR DESCRIPTION
Release prep for **v1.4.0**.

- **Version:** herd `1.3.0` → `1.4.0` (Cargo.toml + lock). herd-tray stays `0.1.0` (independent).
- **release.yml:** builds `herd-tray` for `x86_64-pc-windows-msvc` and bundles **`herd-tray.exe`** alongside `herd.exe` in the Windows zip. Linux/macOS tarballs unchanged (tray is Windows-first).

Covers the GUI/config-overlay work since 1.3.0: `models_enabled` allowlist + SQLite overlay (#G1), admin config API (#G2), Settings model-routing tab (#G3), herd-tray (#G5). #G4 (onboarding/detect/pull) is not in this release.

After merge: tag `v1.4.0` → the Release workflow builds all four targets and publishes the GH release with auto-generated notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)