### PR TITLE
fix(ci): clear pre-existing clippy and rustfmt failures on main

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -48,8 +48,13 @@ fn main() {
         if !full_path.exists() {
             continue;
         }
-        let contents = fs::read_to_string(&full_path)
-            .unwrap_or_else(|e| panic!("dashboard2 build: failed to read {}: {}", full_path.display(), e));
+        let contents = fs::read_to_string(&full_path).unwrap_or_else(|e| {
+            panic!(
+                "dashboard2 build: failed to read {}: {}",
+                full_path.display(),
+                e
+            )
+        });
 
         match wrapper {
             Wrapper::Raw => assembled.push_str(&contents),

--- a/src/api/openai.rs
+++ b/src/api/openai.rs
@@ -76,10 +76,9 @@ pub(crate) fn estimate_prompt_tokens(body: &[u8]) -> Option<u32> {
                 _ => {}
             }
         }
-    } else if let Some(prompt) = json.get("prompt").and_then(Value::as_str) {
-        chars += prompt.chars().count();
     } else {
-        return None;
+        let prompt = json.get("prompt").and_then(Value::as_str)?;
+        chars += prompt.chars().count();
     }
 
     if chars == 0 {


### PR DESCRIPTION
`main` is red on Clippy and Format, independently of any in-flight work. Confirmed by CI run 30218361290 on `main` @ `248c025`, which contains none of the placement-doctrine sprint changes and fails both jobs identically.

CI had not run on `main` since **2026-07-03** — `4f605e7` (dashboard2 Settings) was committed locally and never pushed, so three weeks of drift went unchecked.

## Two unrelated failures

**`src/api/openai.rs:79` — `clippy::question_mark`**

The lint's pattern detection expanded in **clippy 1.97.0**. The local toolchain here is **1.96.0**, which does not flag it — so this was invisible to a local `cargo clippy` gate and only CI's `stable` could catch it. Rewritten per the lint's own suggestion:

```rust
} else {
    let prompt = json.get("prompt").and_then(Value::as_str)?;
    chars += prompt.chars().count();
}
```

`?` on an `Option` in a function returning `Option` is semantically identical to the previous `else { return None }` — no behavior change.

**`build.rs:48` — rustfmt**

rustfmt wraps the long `unwrap_or_else`/`panic!` that came in with the dashboard2 build script. Pure formatting.

## Verification

- `cargo build`: clean
- `cargo clippy --all-targets --all-features -- -D warnings`: clean locally (1.96 — CI's 1.97 is the authority for the openai.rs fix)
- `cargo test`: 618 lib + 32 integration passing, 0 failed
- `cargo fmt --check`: clean on all committed files

## Note for whoever lands `herd fit`

`cargo fmt --check` currently reports ~23 diffs in the uncommitted `herd fit` work (`src/fit/*`, `src/api/models.rs`, `src/daemon/capabilities.rs`). Those are not in this PR and not in any commit, so they do not affect CI today — but that branch will fail Format the moment it lands. Run `cargo fmt` before committing it.

## Process gap worth closing

Local `cargo clippy` is a version behind CI's `stable`, so "clippy clean locally" is not a reliable gate. Either pin CI to a `rust-toolchain.toml` the repo controls, or treat clippy as CI-only and stop claiming it locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)